### PR TITLE
More Informative Errors

### DIFF
--- a/runpod/endpoint/runner.py
+++ b/runpod/endpoint/runner.py
@@ -93,4 +93,10 @@ class Job:
 
         output_request = requests.get(output_url, headers=headers, timeout=10)
 
+        if "output" not in output_request.json():
+            if "error" in output_request.json():
+                raise RuntimeError(output_request.json()["error"])
+            else:
+                raise ValueError(f"Unexpected response from server: {output_request.json()}")
+
         return output_request.json()["output"]

--- a/runpod/endpoint/runner.py
+++ b/runpod/endpoint/runner.py
@@ -76,7 +76,7 @@ class Job:
 
         if "error" in status_request.json():
             raise RuntimeError(status_request.json()["error"])
-        else:
+        elif "status" not in status_request.json():
             raise ValueError(f"Unexpected response from server: {status_request.json()}")
 
         return status_request.json()

--- a/runpod/endpoint/runner.py
+++ b/runpod/endpoint/runner.py
@@ -74,6 +74,15 @@ class Job:
 
         status_request = requests.get(status_url, headers=headers, timeout=10)
 
+        try:
+            status_request.json()
+        except requests.exceptions.JSONDecodeError:
+            raise ValueError(
+                "Error decoding response json " +
+                f"Status Code: {status_request.status_code} " +
+                f"Raw Response: '{status_request.text}'"
+            )
+
         if "error" in status_request.json():
             raise RuntimeError(status_request.json()["error"])
         elif "status" not in status_request.json():

--- a/runpod/endpoint/runner.py
+++ b/runpod/endpoint/runner.py
@@ -105,7 +105,7 @@ class Job:
         return self._status_json()["status"]
 
 
-    def output(self):
+    def output(self, max_wait=10):
         '''
         Gets the output of the endpoint run request.
         If blocking is True, the method will block until the endpoint run is complete.
@@ -116,13 +116,13 @@ class Job:
                 status = self.status()
             except TooManyRequestsError as e:
                 sleep_time += 0.3
-                if sleep_time > 10:  # don't sleep more than 10 seconds
+                if sleep_time > max_wait:  # don't sleep more than max_wait
                     raise e
                 time.sleep(sleep_time)
             else:
                 sleep_time = 0.1
 
-            if status not in ["COMPLETED", "FAILED"]:
+            if status in ["COMPLETED", "FAILED"]:
                 break
             time.sleep(.1)
 

--- a/runpod/endpoint/runner.py
+++ b/runpod/endpoint/runner.py
@@ -78,8 +78,8 @@ class Job:
             status_request.json()
         except requests.exceptions.JSONDecodeError:
             raise ValueError(
-                "Error decoding response json " +
-                f"Status Code: {status_request.status_code} " +
+                "Error decoding response json. " +
+                f"Status Code: {status_request.status_code}, " +
                 f"Raw Response: '{status_request.text}'"
             )
 

--- a/runpod/endpoint/runner.py
+++ b/runpod/endpoint/runner.py
@@ -108,7 +108,7 @@ class Job:
     def output(self, max_wait=10):
         '''
         Gets the output of the endpoint run request.
-        If blocking is True, the method will block until the endpoint run is complete.
+        max_wait defines the maximum time to wait for retry if returning 429
         '''
         sleep_time = 0.1
         while True:

--- a/runpod/endpoint/runner.py
+++ b/runpod/endpoint/runner.py
@@ -119,6 +119,7 @@ class Job:
                 if sleep_time > max_wait:  # don't sleep more than max_wait
                     raise e
                 time.sleep(sleep_time)
+                continue
             else:
                 sleep_time = 0.1
 

--- a/runpod/endpoint/runner.py
+++ b/runpod/endpoint/runner.py
@@ -91,7 +91,7 @@ class Job:
                 )
 
         if "error" in status_request.json():
-            raise RuntimeError(status_request.json()["error"])
+            raise RuntimeError(f"Error from RunPod Server: '{status_request.json()['error']}'")
         elif "status" not in status_request.json():
             raise ValueError(f"Unexpected response from server: {status_request.json()}")
 


### PR DESCRIPTION
In short
- show server error in error code
- if 429, wait longer between requests

`/{endpoint_id}/status/{job_id}` is not guaranteed to have an "output" key:

```
curl -X POST https://api.runpod.ai/v1/9<redacted>/status/54<redacted> \
-H 'Content-Type: application/json' \
-H 'Authorization: Bearer T9<redacted>'

{"delayTime":9862,"error":"name 'app' is not defined","executionTime":97,"id":"54a54b10-d43e-43cb-b29e-c4cac8712ea6","input":{"prompts":["a cute magical flying dog, fantasy art drawn by disney concept artists"]},"status":"FAILED"}
```


In `runpod-python` this results in an uniformative `KeyError`, which is fixed by this PR:

```
File "/usr/src/app/myapp/embeddings/text_embeddings.py", line 60, in send_run_request
    return run_request.output()

File "/usr/local/lib/python3.11/site-packages/runpod/endpoint/runner.py", line 96, in output
    return output_request.json()["output"]
           ~~~~~^^^^^^^^^^
KeyError: 'output'
```




Additionally sometimes there is no json returned at all, I was getting 429 in this case:

```
File "/usr/local/lib/python3.11/site-packages/runpod/endpoint/runner.py", line 85, in output
    while self.status() not in ["COMPLETED", "FAILED"]:
          ^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/runpod/endpoint/runner.py", line 76, in status
    return status_request.json()["status"]
           ^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/requests/models.py", line 975, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
```

This PR results in a more informative traceback:

```
File "/usr/local/lib/python3.11/site-packages/runpod/endpoint/runner.py", line 105, in output
    while self.status() not in ["COMPLETED", "FAILED"]:

File "/usr/local/lib/python3.11/site-packages/runpod/endpoint/runner.py", line 97, in status
    return self._status_json()["status"]
           ^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/runpod/endpoint/runner.py", line 80, in _status_json
    raise ValueError(
ValueError: Error decoding response json. Status Code: 429, Raw Response: ''
```

I further improved this by raising `TooManyRequestsError` in the case of 429 and applying backoff. The above traceback will only be shown for invalid json responses which **are not** 429.