### PR TITLE
add ExtraArgs support for upload_file_to_bucket

### DIFF
--- a/runpod/serverless/utils/rp_upload.py
+++ b/runpod/serverless/utils/rp_upload.py
@@ -190,7 +190,8 @@ def upload_file_to_bucket(
         file_name: str, file_location: str,
         bucket_creds: Optional[dict] = None,
         bucket_name: Optional[str] = None,
-        prefix: Optional[str] = None) -> str:
+        prefix: Optional[str] = None,
+        extra_args: Optional[dict] = None) -> str:
     '''
     Uploads a single file to bucket storage and returns a presigned URL.
     '''
@@ -206,7 +207,8 @@ def upload_file_to_bucket(
         boto_client.upload_file(
             file_location, bucket_name, key,
             Config=transfer_config,
-            Callback=progress_bar.update
+            Callback=progress_bar.update,
+            ExtraArgs=extra_args
         )
 
     presigned_url = boto_client.generate_presigned_url(


### PR DESCRIPTION
As all SD templates use this method in rp_handler, would be nice to natively support boto3 ExtraArgs (like 'CacheControl' and 'ContentType' etc.)  param on upload.