### PR TITLE
Add informative error message when API key not provided

### DIFF
--- a/runpod/endpoint/runner.py
+++ b/runpod/endpoint/runner.py
@@ -18,7 +18,13 @@ class RunPodClient:
         Initialize the client.
         '''
         from runpod import api_key, endpoint_url_base  # pylint: disable=import-outside-toplevel, cyclic-import
-
+        if api_key is None:
+            raise RuntimeError(
+                "Expected `run_pod.api_key` to be initialized. "
+                "You can solve this by running `run_pod.api_key = 'your-key'. "
+                "An API key can be generated at "
+                "https://www.runpod.io/console/user/settings"
+            )
         self.rp_session = requests.Session()
         retries = Retry(total=5, backoff_factor=0.1, status_forcelist=[429])
         self.rp_session.mount('http://', HTTPAdapter(max_retries=retries))

--- a/tests/test_endpoint/test_runner.py
+++ b/tests/test_endpoint/test_runner.py
@@ -16,7 +16,8 @@ class TestEndpoint(unittest.TestCase):
         '''
         Tests Endpoint.run without api_key
         '''
-        self.assertRaises(RuntimeError, runpod.Endpoint("ENDPOINT_ID"))
+        with self.assertRaises(RuntimeError):
+            runpod.Endpoint("ENDPOINT_ID")
 
     @patch.object(requests.Session, 'get')
     @patch.object(requests.Session, 'post')

--- a/tests/test_endpoint/test_runner.py
+++ b/tests/test_endpoint/test_runner.py
@@ -12,6 +12,12 @@ import runpod
 class TestEndpoint(unittest.TestCase):
     ''' Tests for Endpoint '''
 
+    def test_missing_api_key(self):
+        '''
+        Tests Endpoint.run without api_key
+        '''
+        self.assertRaises(RuntimeError, runpod.Endpoint("ENDPOINT_ID"))
+
     @patch.object(requests.Session, 'get')
     @patch.object(requests.Session, 'post')
     def test_run(self, mock_post, mock_get):
@@ -26,6 +32,7 @@ class TestEndpoint(unittest.TestCase):
         mock_post.return_value = mock_response
         mock_get.return_value = mock_response
 
+        runpod.api_key = "MOCK_API_KEY"
         endpoint = runpod.Endpoint("ENDPOINT_ID")
 
         request_data = {"YOUR_MODEL_INPUT_JSON": "YOUR_MODEL_INPUT_VALUE"}
@@ -47,6 +54,7 @@ class TestEndpoint(unittest.TestCase):
         }
         mock_post.return_value = mock_response
 
+        runpod.api_key = "MOCK_API_KEY"
         endpoint = runpod.Endpoint("ENDPOINT_ID")
 
         request_data = {"YOUR_MODEL_INPUT_JSON": "YOUR_MODEL_INPUT_VALUE"}


### PR DESCRIPTION
fixes https://github.com/runpod/runpod-python/issues/36#issuecomment-1605511127