### PR TITLE
feat: add country_code to create_pod

### DIFF
--- a/runpod/api_wrapper/ctl_commands.py
+++ b/runpod/api_wrapper/ctl_commands.py
@@ -26,8 +26,8 @@ def get_gpu(gpu_id):
     return cleaned_return
 
 
-def create_pod(name, image_name, gpu_type_id,
-               cloud_type="ALL", data_center_id=None, gpu_count=1, volume_in_gb=0,
+def create_pod(name, image_name, gpu_type_id, cloud_type="ALL",
+               data_center_id=None, country_code=None, gpu_count=1, volume_in_gb=0,
                container_disk_in_gb=5, min_vcpu_count=1, min_memory_in_gb=1, docker_args="",
                ports=None, volume_mount_path="/workspace", env=None):
     '''
@@ -36,8 +36,8 @@ def create_pod(name, image_name, gpu_type_id,
 
     raw_response = run_graphql_query(
         pods.generate_pod_deployment_mutation(
-            name, image_name, gpu_type_id, cloud_type, data_center_id, gpu_count, volume_in_gb,
-            container_disk_in_gb, min_vcpu_count, min_memory_in_gb, docker_args,
+            name, image_name, gpu_type_id, cloud_type, data_center_id, country_code, gpu_count,
+            volume_in_gb, container_disk_in_gb, min_vcpu_count, min_memory_in_gb, docker_args,
             ports, volume_mount_path, env)
     )
 

--- a/runpod/api_wrapper/mutations/pods.py
+++ b/runpod/api_wrapper/mutations/pods.py
@@ -5,8 +5,8 @@ RunPod | API Wrapper | Mutations | Pods
 
 
 def generate_pod_deployment_mutation(
-        name, image_name, gpu_type_id, cloud_type=None, data_center_id=None, gpu_count=None,
-        volume_in_gb=None, container_disk_in_gb=None, min_vcpu_count=None,
+        name, image_name, gpu_type_id, cloud_type=None, data_center_id=None, country_code=None,
+        gpu_count=None, volume_in_gb=None, container_disk_in_gb=None, min_vcpu_count=None,
         min_memory_in_gb=None, docker_args=None, ports=None, volume_mount_path=None,
         env=None, support_public_ip=None):
     '''
@@ -18,6 +18,8 @@ def generate_pod_deployment_mutation(
         input_fields.append(f"cloudType: {cloud_type}")
     if data_center_id is not None:
         input_fields.append(f'dataCenterId: "{data_center_id}"')
+    if country_code is not None:
+        input_fields.append(f'countryCode: "{country_code}"')
     if gpu_count is not None:
         input_fields.append(f"gpuCount: {gpu_count}")
     if volume_in_gb is not None:


### PR DESCRIPTION
country_code can be passed to create_pod
```python
gpu_count = 1

pod = runpod.create_pod(
    name="Test",
    image_name="runpod/pytorch:3.10-2.0.1-117-devel",
    gpu_type_id="NVIDIA RTX A4000",
    cloud_type="COMMUNITY",
    country_code="CA",
    gpu_count=gpu_count,
    volume_in_gb=5,
    container_disk_in_gb=5,
    ports="8888/http,22/tcp",
)
```