### PR TITLE
fix fn check if it is a generator

### DIFF
--- a/runpod/serverless/modules/rp_http.py
+++ b/runpod/serverless/modules/rp_http.py
@@ -12,6 +12,9 @@ from .worker_state import WORKER_ID, IS_LOCAL_TEST
 JOB_DONE_URL_TEMPLATE = str(os.environ.get('RUNPOD_WEBHOOK_POST_OUTPUT'))
 JOB_DONE_URL_TEMPLATE = JOB_DONE_URL_TEMPLATE.replace('$RUNPOD_POD_ID', WORKER_ID)
 
+JOB_STREAM_URL_TEMPLATE = str(os.environ.get('RUNPOD_WEBHOOK_POST_STREAM'))
+JOB_STREAM_URL_TEMPLATE = JOB_STREAM_URL_TEMPLATE.replace('$RUNPOD_POD_ID', WORKER_ID)
+
 log = RunPodLogger()
 
 
@@ -59,7 +62,7 @@ async def stream_result(session, job_data, job):
     try:
         job_data = json.dumps(job_data, ensure_ascii=False)
         if not IS_LOCAL_TEST:
-            job_done_url = JOB_DONE_URL_TEMPLATE.replace('$ID', job['id'])
+            job_done_url = JOB_STREAM_URL_TEMPLATE.replace('$ID', job['id'])
             await transmit(session, job_data, job_done_url)
         else:
             log.warn(f"Local test job results for {job['id']}: {job_data}")

--- a/runpod/serverless/work_loop.py
+++ b/runpod/serverless/work_loop.py
@@ -2,7 +2,7 @@
 runpod | serverless | worker_loop.py
 Called to convert a container into a worker pod for the runpod serverless platform.
 """
-
+import inspect
 import os
 import sys
 import types
@@ -63,7 +63,7 @@ async def start_worker(config: Dict[str, Any]) -> None:
                 error_msg = f"Job {job['id']} has no input parameter. Unable to run."
                 log.error(error_msg)
                 job_result = {"error": error_msg}
-            elif isinstance(config["handler"], types.GeneratorType):
+            elif inspect.isgeneratorfunction(config["handler"]):
                 job_result = run_job_generator(config["handler"], job)
 
                 log.debug("Handler is a generator, streaming results.")


### PR DESCRIPTION
fixes #57 

`isinstance(config["handler"], types.GeneratorType)` doesn't work as expected in this case because it should be run against the job result. using inspect is the proper way to handle this after the previous refactor was applied