### PR TITLE
Enabling multi-job, single-worker in Runpod-Python.

### DIFF
--- a/runpod/serverless/modules/rp_job.py
+++ b/runpod/serverless/modules/rp_job.py
@@ -71,7 +71,7 @@ async def get_job(session: ClientSession, retry=True) -> Optional[Dict[str, Any]
     return next_job
 
 
-def run_job(handler: Callable, job: Dict[str, Any]) -> Dict[str, Any]:
+async def run_job(handler: Callable, job: Dict[str, Any]) -> Dict[str, Any]:
     """
     Run the job using the handler.
     Returns the job output or error.
@@ -79,7 +79,7 @@ def run_job(handler: Callable, job: Dict[str, Any]) -> Dict[str, Any]:
     log.info(f'{job["id"]} | Started')
 
     try:
-        job_output = handler(job)
+        job_output = await handler(job)
         log.debug(f'{job["id"]} | Handler output: {job_output}')
 
         run_result = {"output": job_output}

--- a/runpod/serverless/worker.py
+++ b/runpod/serverless/worker.py
@@ -169,6 +169,7 @@ async def run_worker_multi(config: Dict[str, Any]) -> None:
                 scalar.background_tasks.add(task)
                 task.add_done_callback(scalar.background_tasks.discard)
 
+        log.debug("rp_debugger | The event loop has closed due to {}, #2.")
         asyncio.get_event_loop().stop() # Stops the worker loop if the kill_worker flag is set.
 
 
@@ -241,5 +242,7 @@ def main(config: Dict[str, Any]) -> None:
                 asyncio.ensure_future(run_worker(config), loop=work_loop)
             work_loop.run_forever()
 
+        except Exception as e:  
+            log.debug("rp_debugger | The event loop has closed due to {}, #1.".format(e))
         finally:
             work_loop.close()

--- a/runpod/serverless/worker.py
+++ b/runpod/serverless/worker.py
@@ -94,6 +94,8 @@ class Scaler():
 
         # If our worker is fully utilized or the SLS queue is throttling, reduce the job query rate.
         if self.handler_fully_utilized() is True:
+            log.debug("The handler is fully utilized. Downscaling now.")
+
             # Reduce job query rate.
             self.num_concurrent_requests = int(max(
                 self.num_concurrent_requests // SCALE_FACTOR, MIN_CONCURRENT_REQUESTS))

--- a/runpod/serverless/worker.py
+++ b/runpod/serverless/worker.py
@@ -76,6 +76,8 @@ class Scaler():
 
             self.rescale_request_rate()
 
+            log.info(f"Concurrent Get Jobs | The number of concurrent get_jobs is {self.num_concurrent_requests}.")
+
     # Scale up or down the rate at which we are handling jobs from SLS.
     def rescale_request_rate(self, force_downscale=False):
         if force_downscale:
@@ -83,7 +85,7 @@ class Scaler():
                 self.num_concurrent_requests // SCALE_FACTOR, MIN_CONCURRENT_REQUESTS))
             return
 
-        if len(self.job_history) == 0:
+        if len(self.job_history) < 10:
             return
 
         # Compute the availability ratio of the job queue.

--- a/runpod/serverless/worker.py
+++ b/runpod/serverless/worker.py
@@ -49,7 +49,7 @@ def _is_local(config) -> bool:
 # Constants
 SCALE_FACTOR = 2
 INITIAL_CONCURRENT_REQUESTS = 1
-MAX_CONCURRENT_REQUESTS = 10000 #sys.maxsize
+MAX_CONCURRENT_REQUESTS = 100 #sys.maxsize
 MIN_CONCURRENT_REQUESTS = 1
 AVAILABILITY_RATIO_THRESHOLD = 0.90
 
@@ -62,7 +62,7 @@ class Scaler():
 
     async def get_jobs(self, session):
         while True:
-            tasks = [asyncio.create_task(get_job(session)) for _ in range(self.num_concurrent_requests)]
+            tasks = [asyncio.create_task(get_job(session, retry=False)) for _ in range(self.num_concurrent_requests)]
             for job_future in asyncio.as_completed(tasks):
                 job = await job_future
                 self.job_history.append(job)
@@ -85,7 +85,7 @@ class Scaler():
                 self.num_concurrent_requests // SCALE_FACTOR, MIN_CONCURRENT_REQUESTS))
             return
 
-        if len(self.job_history) < 10:
+        if len(self.job_history) == 0:
             return
 
         # Compute the availability ratio of the job queue.

--- a/runpod/serverless/worker.py
+++ b/runpod/serverless/worker.py
@@ -46,7 +46,128 @@ def _is_local(config) -> bool:
     return False
 
 
+# Constants
+SCALE_FACTOR = 2
+INITIAL_CONCURRENT_REQUESTS = 1
+MAX_CONCURRENT_REQUESTS = 10000 #sys.maxsize
+MIN_CONCURRENT_REQUESTS = 1
+AVAILABILITY_RATIO_THRESHOLD = 0.90
+
+class Scaler():
+    def __init__(self, handler_fully_utilized):
+        self.background_tasks = set()
+        self.num_concurrent_requests = INITIAL_CONCURRENT_REQUESTS
+        self.job_history = []  # Keeps track of recent job results
+        self.handler_fully_utilized = handler_fully_utilized
+
+    async def get_jobs(self, session):
+        while True:
+            tasks = [asyncio.create_task(get_job(session)) for _ in range(self.num_concurrent_requests)]
+            for job_future in asyncio.as_completed(tasks):
+                job = await job_future
+                self.job_history.append(job)
+
+                if job:
+                    job_list.add_job(job["id"])
+                    log.debug(f"{job['id']} | Set Job ID")
+                    yield job
+
+            await asyncio.sleep(1)
+
+            self.rescale_request_rate()
+
+    # Scale up or down the rate at which we are handling jobs from SLS.
+    def rescale_request_rate(self, force_downscale=False):
+        if force_downscale:
+            self.num_concurrent_requests = int(max(
+                self.num_concurrent_requests // SCALE_FACTOR, MIN_CONCURRENT_REQUESTS))
+            return
+
+        if len(self.job_history) == 0:
+            return
+
+        # Compute the availability ratio of the job queue.
+        none_jobs_count = sum(job is None for job in self.job_history)
+        availability_ratio = 1 - none_jobs_count / len(self.job_history)
+
+        # If our worker is fully utilized or the SLS queue is throttling, reduce the job query rate.
+        if self.handler_fully_utilized() is True:
+            # Reduce job query rate.
+            self.num_concurrent_requests = int(max(
+                self.num_concurrent_requests // SCALE_FACTOR, MIN_CONCURRENT_REQUESTS))
+        elif availability_ratio < 1 / SCALE_FACTOR:
+            # Reduce job query rate.
+            self.num_concurrent_requests = int(max(
+                self.num_concurrent_requests // SCALE_FACTOR, MIN_CONCURRENT_REQUESTS))
+        elif availability_ratio >= AVAILABILITY_RATIO_THRESHOLD:
+            # Assess if SLS queue has enough jobs to scale job query rate.
+            # Increase concurrent request count.
+            self.num_concurrent_requests = min(
+                self.num_concurrent_requests * SCALE_FACTOR, MAX_CONCURRENT_REQUESTS
+            )
+
+        # Clear the job history
+        self.job_history.clear()
+
+
 # ------------------------- Main Worker Running Loop ------------------------- #
+async def run_worker_multi(config: Dict[str, Any]) -> None:
+    """
+    Starts the worker loop for multi-processing.
+    """
+    auth_header = _get_auth_header()
+    connector = aiohttp.TCPConnector(limit=None)
+    scalar = Scaler(config.get('handler_fully_utilized'))
+    async with aiohttp.ClientSession(connector=connector, headers=auth_header, timeout=_TIMEOUT) as session:
+
+        heartbeat.start_ping()
+
+        kill_worker = False # Flag to kill the worker after job is complete.
+        while kill_worker is False:
+            async def process_job(job):
+                if inspect.isgeneratorfunction(config["handler"]):
+                    job_result = await run_job_generator(config["handler"], job)
+
+                    log.debug("Handler is a generator, streaming results.")
+                    for job_stream in job_result:
+                        await stream_result(session, job_stream, job)
+                    job_result = {}
+                else:
+                    job_result = await run_job(config["handler"], job)
+
+                # If refresh_worker is set, pod will be reset after job is complete.
+                if config.get("refresh_worker", False):
+                    log.info(f"refresh_worker | Flag set, stopping pod after job {job['id']}.")
+                    job_result["stopPod"] = True
+                    global kill_worker
+                    kill_worker = True
+
+                # If rp_debugger is set, debugger output will be returned.
+                if config["rp_args"].get("rp_debugger", False) and isinstance(job_result, dict):
+                    log.debug("rp_debugger | Flag set, return debugger output.")
+                    job_result["output"]["rp_debugger"] = rp_debugger.get_debugger_output()
+
+                    ready_delay = (config["reference_counter_start"] - REF_COUNT_ZERO) * 1000
+                    job_result["output"]["rp_debugger"]["ready_delay_ms"] = ready_delay
+                else:
+                    log.debug("rp_debugger | Flag not set, skipping debugger output.")
+                    rp_debugger.clear_debugger_output()
+
+                await send_result(session, job_result, job)
+
+                log.info(f'{job["id"]} | Finished')
+                job_list.remove_job(job["id"])
+
+            # Create process job task
+            async for job in scalar.get_jobs():
+                # Process the job here
+                task = asyncio.create_task(process_job(job))
+                scalar.background_tasks.add(task)
+                task.add_done_callback(scalar.background_tasks.discard)
+
+        asyncio.get_event_loop().stop() # Stops the worker loop if the kill_worker flag is set.
+
+
 async def run_worker(config: Dict[str, Any]) -> None:
     """
     Starts the worker loop.
@@ -64,14 +185,14 @@ async def run_worker(config: Dict[str, Any]) -> None:
             log.debug(f"{job['id']} | Set Job ID")
 
             if inspect.isgeneratorfunction(config["handler"]):
-                job_result = run_job_generator(config["handler"], job)
+                job_result = await run_job_generator(config["handler"], job)
 
                 log.debug("Handler is a generator, streaming results.")
                 for job_stream in job_result:
                     await stream_result(session, job_stream, job)
                 job_result = {}
             else:
-                job_result = run_job(config["handler"], job)
+                job_result = await run_job(config["handler"], job)
 
             # If refresh_worker is set, pod will be reset after job is complete.
             if config.get("refresh_worker", False):
@@ -110,7 +231,10 @@ def main(config: Dict[str, Any]) -> None:
     else:
         try:
             work_loop = asyncio.new_event_loop()
-            asyncio.ensure_future(run_worker(config), loop=work_loop)
+            if config['handler_fully_utilized'] is not None:
+                asyncio.ensure_future(run_worker_multi(config), loop=work_loop)
+            else:
+                asyncio.ensure_future(run_worker(config), loop=work_loop)
             work_loop.run_forever()
 
         finally:

--- a/runpod/serverless/worker.py
+++ b/runpod/serverless/worker.py
@@ -159,7 +159,7 @@ async def run_worker_multi(config: Dict[str, Any]) -> None:
                 job_list.remove_job(job["id"])
 
             # Create process job task
-            async for job in scalar.get_jobs():
+            async for job in scalar.get_jobs(session):
                 # Process the job here
                 task = asyncio.create_task(process_job(job))
                 scalar.background_tasks.add(task)


### PR DESCRIPTION
This PR enabled multi-job single-worker support inside Runpod-Python and was recently tested successfully with the vLLM serverless worker. Let's start refactoring this implementation, if possible.