### PR TITLE
Fixing "timeout context manager should be used inside a task"

### DIFF
--- a/runpod/serverless/modules/rp_ping.py
+++ b/runpod/serverless/modules/rp_ping.py
@@ -50,13 +50,13 @@ class HeartbeatSender:
 
             if PING_URL not in [None, 'PING_NOT_SET']:
                 try:
-                    result = session.get(
+                    result = await session.get(
                         PING_URL,
                         params=ping_params,
                         timeout=int(PING_INTERVAL / 1000)
                     )
 
-                    log.debug(f"Heartbeat Sent | URL: {PING_URL} | Status: {result.status_code}")
+                    log.debug(f"Heartbeat Sent | URL: {PING_URL} | Status: {result.status}")
                     log.debug(f"Heartbeat | Interval: {PING_INTERVAL}ms | Params: {ping_params}")
 
                 except aiohttp.ClientError as err:

--- a/runpod/serverless/worker.py
+++ b/runpod/serverless/worker.py
@@ -23,7 +23,6 @@ job_list = Jobs()
 heartbeat = HeartbeatSender()
 
 
-_CONNECTOR = aiohttp.TCPConnector(limit=None)
 _TIMEOUT = aiohttp.ClientTimeout(total=300, connect=2, sock_connect=2)
 
 def _get_auth_header () -> Dict[str, str]:
@@ -54,6 +53,7 @@ async def run_worker(config: Dict[str, Any]) -> None:
     Args:
         config (Dict[str, Any]): Configuration parameters for the worker.
     """
+    connector = aiohttp.TCPConnector(limit=None)
     async with aiohttp.ClientSession(
         connector=_CONNECTOR, headers=_get_auth_header(),timeout=_TIMEOUT) as session:
 

--- a/runpod/serverless/worker.py
+++ b/runpod/serverless/worker.py
@@ -55,7 +55,7 @@ async def run_worker(config: Dict[str, Any]) -> None:
     """
     connector = aiohttp.TCPConnector(limit=None)
     async with aiohttp.ClientSession(
-        connector=_CONNECTOR, headers=_get_auth_header(),timeout=_TIMEOUT) as session:
+        connector=connector, headers=_get_auth_header(),timeout=_TIMEOUT) as session:
 
         job_scaler = JobScaler(
             concurrency_controller=config.get('concurrency_controller', None)


### PR DESCRIPTION
Note for future:

The root cause is linked to the creation of TCPConnector() outside of an existing event loop context. TCPConnector establishes its own internal event loop during construction, becoming tightly bound to it. Consequently, when executing the asyncio.ensure_future() function, a separate event loop instance is used to run get_job(). However, this method attempts to use the TCPConnector associated with a different event loop, resulting in a mismatch and leading to the observed error.

To address this issue, the recommended solution involves relocating the line "TCPConnector()" into the body of the run_worker function. This adjustment effectively resolves the problem, preventing the occurrence of the error.