### PR TITLE
fix this

### DIFF
--- a/runpod/serverless/modules/rp_job.py
+++ b/runpod/serverless/modules/rp_job.py
@@ -155,8 +155,12 @@ async def run_job_generator(
     '''
     try:
         job_output = handler(job)
-        async for output_partial in job_output:
-            yield {"output": output_partial}
+        if inspect.isasyncgenfunction(handler):
+            async for output_partial in job_output:
+                yield {"output": output_partial}
+        else:
+            for output_partial in job_output:
+                yield {"output": output_partial}
     except Exception as err:    # pylint: disable=broad-except
         log.error(f'Error while running job {job["id"]}: {err}')
         yield {"error": f"handler: {str(err)} \ntraceback: {traceback.format_exc()}"}

--- a/runpod/serverless/modules/rp_job.py
+++ b/runpod/serverless/modules/rp_job.py
@@ -155,7 +155,7 @@ async def run_job_generator(
     '''
     try:
         job_output = handler(job)
-        for output_partial in job_output:
+        async for output_partial in job_output:
             yield {"output": output_partial}
     except Exception as err:    # pylint: disable=broad-except
         log.error(f'Error while running job {job["id"]}: {err}')


### PR DESCRIPTION
We need to update `run_job_generator` to use `async for` instead of `for` in order to support both the regular generator functins and async generator functions.