### PR TITLE
Preserve the final job result's post condition in streaming scenario.

### DIFF
--- a/runpod/serverless/worker.py
+++ b/runpod/serverless/worker.py
@@ -68,9 +68,11 @@ async def run_worker(config: Dict[str, Any]) -> None:
                     job_result = run_job_generator(config["handler"], job)
 
                     log.debug("Handler is a generator, streaming results.")
+                    job_outputs = []
                     async for job_stream in job_result:
+                        job_outputs.append(job_stream)
                         await stream_result(session, job_stream, job)
-                    job_result = {}
+                    job_result = {'output': job_outputs}
                 else:
                     job_result = await run_job(config["handler"], job)
 


### PR DESCRIPTION
For serverless workers handling streaming, it makes sense to concatenate all the intermediate outputs into the final output to get our job done. I think this functionality can be handled either inside the Runpod-Python or SLS side, but for ease of implementation, incorporating it here makes sense.