### PR TITLE
Data Race in TakeJob

### DIFF
--- a/runpod/serverless/modules/rp_scale.py
+++ b/runpod/serverless/modules/rp_scale.py
@@ -99,26 +99,11 @@ class JobScaler():
             if not self.is_alive():
                 break
 
-            sequential = True
-            tasks = []
-            if sequential:
-                for _ in range(self.num_concurrent_get_job_requests):
-                    job = await get_job(session, retry=False)
-                    self.job_history.append(1 if job else 0)
-                    if job:
-                        yield job
-            else:
-                tasks = [
-                    asyncio.create_task(
-                        get_job(session, retry=False)
-                    ) for _ in range(self.num_concurrent_get_job_requests)]
-
-                for job_future in asyncio.as_completed(tasks):
-                    job = await job_future
-                    self.job_history.append(1 if job else 0)
-
-                    if job:
-                        yield job
+            for _ in range(self.num_concurrent_get_job_requests):
+                job = await get_job(session, retry=False)
+                self.job_history.append(1 if job else 0)
+                if job:
+                    yield job
 
             # During the single processing scenario, wait for the job to finish processing.
             if self.concurrency_controller is None:


### PR DESCRIPTION
In our job acquisition logic, we need to ensure sequential execution rather than parallel execution, in order to prevent a potential data race within the TakeJob logic in SLS.