### PR TITLE
fix for runpod.get_pods() and runpod.get_pod(id)

### DIFF
--- a/runpod/__init__.py
+++ b/runpod/__init__.py
@@ -7,7 +7,7 @@ from .endpoint import Endpoint
 from .endpoint import AsyncioEndpoint, AsyncioJob
 from .api_wrapper.ctl_commands import(
     get_gpus, get_gpu,
-    get_pods,
+    get_pods, get_pod,
     create_pod, stop_pod, resume_pod, terminate_pod
 )
 from .cli.config import set_credentials, check_credentials, get_credentials

--- a/runpod/api_wrapper/queries/pods.py
+++ b/runpod/api_wrapper/queries/pods.py
@@ -3,9 +3,9 @@ RunPod | API Wrapper | Queries | GPUs
 """
 
 QUERY_POD = """
-query myPods {{
-    myself {{
-        pods {{
+query myPods {
+    myself {
+        pods {
             id
             containerDiskInGb
             costPerHr
@@ -26,12 +26,12 @@ query myPods {{
             vcpuCount
             volumeInGb
             volumeMountPath
-            machine {{
+            machine {
                 gpuDisplayName
-            }}
-        }}
-    }}
-}}
+            }
+        }
+    }
+}
 """
 
 def generate_pod_query(pod_id):


### PR DESCRIPTION
get_pods() was failing due to double curly brackets in a non-fstring; get_pod(id) simply wasn't imported in __init__