### PR TITLE
Fix streaming for LLMs

### DIFF
--- a/runpod/serverless/worker.py
+++ b/runpod/serverless/worker.py
@@ -58,6 +58,8 @@ async def _process_job(job, session, job_scaler, config):
                 break
             if config.get('return_aggregate_stream', False):
                 job_result['output'].append(stream_output['output'])
+            else:
+                job_result['output'] = stream_output['output']
             await stream_result(session, stream_output, job)
     else:
         job_result = await run_job(config["handler"], job)

--- a/tests/test_serverless/test_worker.py
+++ b/tests/test_serverless/test_worker.py
@@ -227,7 +227,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
 
         # Since return_aggregate_stream is NOT activated, we should not submit any outputs.
         _, args, _ = mock_send_result.mock_calls[0]
-        assert args[1] == {'output': [], 'stopPod': True}
+        assert args[1] == {'output': 'test2', 'stopPod': True}
 
     @pytest.mark.asyncio
     @patch("runpod.serverless.modules.rp_scale.get_job")


### PR DESCRIPTION
The LLM endpoints require that we use streaming and additionally the final streamed output should be in the job done output. This enables this functionality.