### PR TITLE
Support passing a template ID to createPod (#145)

### DIFF
--- a/runpod/api/ctl_commands.py
+++ b/runpod/api/ctl_commands.py
@@ -61,7 +61,7 @@ def create_pod(
         gpu_count:int=1, volume_in_gb:int=0, container_disk_in_gb:int=5,
         min_vcpu_count:int=1, min_memory_in_gb:int=1, docker_args:str="",
         ports:Optional[str]=None, volume_mount_path:str="/workspace",
-        env:Optional[dict]=None
+        env:Optional[dict]=None, template_id:Optional[str]=None
     ) -> dict:
     '''
     Create a pod
@@ -79,6 +79,7 @@ def create_pod(
     :param env: the environment variables to inject into the pod,
                 for example {EXAMPLE_VAR:"example_value", EXAMPLE_VAR2:"example_value 2"}, will
                 inject EXAMPLE_VAR and EXAMPLE_VAR2 into the pod with the mentioned values
+    :param template_id: the id of the template to use for the pod
 
     :example:
 
@@ -95,7 +96,7 @@ def create_pod(
             cloud_type, support_public_ip,
             data_center_id, country_code, gpu_count,
             volume_in_gb, container_disk_in_gb, min_vcpu_count, min_memory_in_gb, docker_args,
-            ports, volume_mount_path, env)
+            ports, volume_mount_path, env, template_id)
     )
 
     cleaned_response = raw_response["data"]["podFindAndDeployOnDemand"]

--- a/runpod/api/mutations/pods.py
+++ b/runpod/api/mutations/pods.py
@@ -10,7 +10,7 @@ def generate_pod_deployment_mutation(
         data_center_id=None, country_code=None,
         gpu_count=None, volume_in_gb=None, container_disk_in_gb=None, min_vcpu_count=None,
         min_memory_in_gb=None, docker_args=None, ports=None, volume_mount_path=None,
-        env=None):
+        env=None, template_id=None):
     '''
     Generates a mutation to deploy a pod on demand.
     '''
@@ -55,6 +55,8 @@ def generate_pod_deployment_mutation(
         env_string = ", ".join(
             [f'{{ key: "{key}", value: "{value}" }}' for key, value in env.items()])
         input_fields.append(f"env: [{env_string}]")
+    if template_id is not None:
+        input_fields.append(f'templateId: "{template_id}"')
 
 
     # Format input fields

--- a/tests/test_api/test_mutations_pods.py
+++ b/tests/test_api/test_mutations_pods.py
@@ -27,7 +27,8 @@ class TestPodMutations(unittest.TestCase):
             ports="8080",
             volume_mount_path="/path",
             env={"ENV": "test"},
-            support_public_ip=True)
+            support_public_ip=True,
+            template_id="abcde")
 
         # Here you should check the correct structure of the result
         self.assertIn("mutation", result)


### PR DESCRIPTION
This fixes https://github.com/runpod/runpod-python/issues/145 and https://github.com/runpod/runpod-python/issues/123 by add an optional `template_id` parameter to `createPod()`

I re-ran the unit tests locally via pytest, and everything is passing:

```
pytest
==================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.11.5, pytest-7.4.2, pluggy-1.3.0
rootdir: /Users/tleyden/Development/runpod-python
plugins: anyio-3.7.1
collected 129 items                                                                                                                                                                          

tests/test_whatever.py ...                                                                                                                                                             [  2%]
tests/test_api/test_ctl_commands.py .........                                                                                                                                          [  9%]
tests/test_api/test_mutations_pods.py ....                                                                                                                                             [ 12%]
tests/test_cli/test_commands.py ..                                                                                                                                                     [ 13%]
tests/test_cli/test_config.py ....                                                                                                                                                     [ 17%]
tests/test_endpoint/test_asyncio_runner.py ......                                                                                                                                      [ 21%]
tests/test_endpoint/test_runner.py .........                                                                                                                                           [ 28%]
tests/test_serverless/test_worker.py ..............                                                                                                                                    [ 39%]
tests/test_serverless/test_modules/test_fastapi.py ..                                                                                                                                  [ 41%]
tests/test_serverless/test_modules/test_http.py ....                                                                                                                                   [ 44%]
tests/test_serverless/test_modules/test_job.py ...............                                                                                                                         [ 55%]
tests/test_serverless/test_modules/test_local.py .....                                                                                                                                 [ 59%]
tests/test_serverless/test_modules/test_logger.py ........                                                                                                                             [ 65%]
tests/test_serverless/test_modules/test_ping.py ..                                                                                                                                     [ 67%]
tests/test_serverless/test_modules/test_progress.py .                                                                                                                                  [ 68%]
tests/test_serverless/test_modules/test_state.py .......                                                                                                                               [ 73%]
tests/test_serverless/test_modules/test_tips.py ..                                                                                                                                     [ 75%]
tests/test_serverless/test_utils/test_cleanup.py ...                                                                                                                                   [ 77%]
tests/test_serverless/test_utils/test_cuda.py ...                                                                                                                                      [ 79%]
tests/test_serverless/test_utils/test_debugger.py .......                                                                                                                              [ 85%]
tests/test_serverless/test_utils/test_download.py .....                                                                                                                                [ 89%]
tests/test_serverless/test_utils/test_upload.py ......                                                                                                                                 [ 93%]
tests/test_serverless/test_utils/test_validate.py .......                                                                                                                              [ 99%]
tests/test_shared/test_auth.py .                                                                                                                                                       [100%]

====================================================================================== warnings summary ======================================================================================
runpod/__init__.py:3
  /Users/tleyden/Development/runpod-python/runpod/__init__.py:3: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import get_distribution, DistributionNotFound

tests/test_serverless/test_modules/test_fastapi.py:49
  /Users/tleyden/Development/runpod-python/tests/test_serverless/test_modules/test_fastapi.py:49: PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.asyncio

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================== 129 passed, 2 warnings in 49.92s ==============================================================================
```