### PR TITLE
Update create_endpoint.py

### DIFF
--- a/examples/api/create_endpoint.py
+++ b/examples/api/create_endpoint.py
@@ -20,8 +20,7 @@ try:
         template_id=new_template["id"],
         gpu_ids="AMPERE_16",
         workers_min=0,
-        workers_max=1,
-        flashboot=True
+        workers_max=1
     )
 
     print(new_endpoint)


### PR DESCRIPTION
Flashboot is not an option.
See API docs:

https://rachfop.github.io/ghpages/runpod.api.ctl_commands.html#create_endpoint




## Parameters for `create_endpoint`

| Parameter         | Type  | Description                                                                                     |
|-------------------|-------|-------------------------------------------------------------------------------------------------|
| `name`            | `str` | The name of the endpoint.                                                                       |
| `template_id`     | `str` | The ID of the template to use for the endpoint.                                                 |
| `gpu_ids`         | `str` | The IDs of the GPUs to use for the endpoint.                                                    |
| `network_volume_id` | `str` | The ID of the network volume to use for the endpoint.                                           |
| `locations`       | `str` | The locations to use for the endpoint.                                                          |
| `idle_timeout`    | `int` | The idle timeout for the endpoint, in seconds.                                                  |
| `scaler_type`     | `str` | The scaler type for the endpoint (e.g., 'manual', 'auto').                                      |
| `scaler_value`    | `int` | The scaler value for the endpoint, used in conjunction with `scaler_type` for scaling settings. |
| `workers_min`     | `int` | The minimum number of workers for the endpoint.                                                 |
| `workers_max`     | `int` | The maximum number of workers for the endpoint.                                                 |