### PR TITLE
Allow providing a custom API prefix for the serverless test server

### DIFF
--- a/runpod/serverless/__init__.py
+++ b/runpod/serverless/__init__.py
@@ -141,6 +141,11 @@ def start(config: Dict[str, Any]):
     realtime_port = _get_realtime_port()
     realtime_concurrency = _get_realtime_concurrency()
 
+    start_server = config["rp_args"]["rp_serve_api"] or realtime_port
+
+    if start_server:
+        log.info(f"Routes will be prefixed with {config['api_prefix']}")
+
     if config["rp_args"]["rp_serve_api"]:
         log.info("Starting API server.")
         api_server = rp_fastapi.WorkerAPI(config)

--- a/runpod/serverless/__init__.py
+++ b/runpod/serverless/__init__.py
@@ -46,6 +46,12 @@ parser.add_argument("--rp_api_concurrency", type=int, default=1,
                     help="Number of concurrent FastAPI workers.")
 parser.add_argument("--rp_api_host", type=str, default="localhost",
                     help="Host to start the FastAPI server on.")
+parser.add_argument("--rp_api_prefix", type=str, default=None,
+                    help="Optional prefix for the API routes. "
+                         "This option is mutually exclusive with --rp_endpoint_id.")
+parser.add_argument('--rp_endpoint_id', type=str, default=None,
+                    help="Simuluate an endpoint with a specific ID which will be available under /v2/{endpoint_id}. "
+                         "This option is mutually exclusive with --rp_api_prefix.")
 
 # Test input
 parser.add_argument("--test_input", type=str, default=None,
@@ -74,6 +80,16 @@ def _set_config_args(config) -> dict:
     # Set the log level
     if config["rp_args"]["rp_log_level"]:
         log.set_level(config["rp_args"]["rp_log_level"])
+
+    # Check for validity of arguments
+    if config["rp_args"]["rp_api_prefix"] and config["rp_args"]["rp_endpoint_id"]:
+        raise ValueError("Options --rp_api_prefix and --rp_endpoint_id are mutually exclusive.")
+    
+    if config["rp_args"]["rp_endpoint_id"]:
+        config["api_prefix"] = f"/v2/{config['rp_args']['rp_endpoint_id']}"
+    
+    if config["rp_args"]["rp_api_prefix"]:
+        config["api_prefix"] = config["rp_args"]["rp_api_prefix"].rstrip("/")
 
     return config
 

--- a/runpod/serverless/modules/rp_fastapi.py
+++ b/runpod/serverless/modules/rp_fastapi.py
@@ -210,7 +210,9 @@ class WorkerAPI:
         )
 
         # Create an APIRouter and add the route for processing jobs.
-        api_router = APIRouter()
+        api_router = APIRouter(
+            prefix=config.get("api_prefix", ""),
+        )
 
         # Docs Redirect /docs -> /
         api_router.add_api_route(


### PR DESCRIPTION
# Motivation

All the routes of the worker test server (e.g. `/run`, `/sync`, etc.) start at the root-level. This does not align with the public API schema where worker routes are of form `/v2/{endpoint_id}/<route>` and thus makes local testing difficult, particularly as the API prefix of the RP client cannot be modified directly.

# Proposal

This PR introduces two additional command line arguments to the serverless worker test server: `rp_api_prefix` and `rp_endpoint_id`. The first allows setting an explicit prefix for the routes of the worker server, e.g. `--rp_api_prefix=/v2/my_worker` while the second is a shorthand to set the route prefix to resemble the official route corresponding to an endpoint ID.