### PR TITLE
Retrieve Pod machine readiness info from get pod API calls

### DIFF
--- a/runpod/api/queries/pods.py
+++ b/runpod/api/queries/pods.py
@@ -37,6 +37,10 @@ query myPods {
             }
             machine {
                 gpuDisplayName
+                gpuAvailable
+                maintenanceStart
+                maintenanceEnd
+                maintenanceNote
             }
         }
     }
@@ -82,6 +86,10 @@ def generate_pod_query(pod_id):
             }}
             machine {{
                 gpuDisplayName
+                gpuAvailable
+                maintenanceStart
+                maintenanceEnd
+                maintenanceNote
             }}
         }}
     }}

--- a/tests/test_api/test_ctl_commands.py
+++ b/tests/test_api/test_ctl_commands.py
@@ -229,7 +229,13 @@ class TestCTL(unittest.TestCase):
                                 "vcpuCount": 21,
                                 "volumeInGb": 200,
                                 "volumeMountPath": "/workspace",
-                                "machine": {"gpuDisplayName": "RTX 3090"},
+                                "machine": {
+                                    "gpuDisplayName": "RTX 3090",
+                                    "gpuAvailable": 5,
+                                    "maintenanceStart": None,
+                                    "maintenanceEnd": None,
+                                    "maintenanceNote": None
+                                },
                             }
                         ]
                     }
@@ -269,7 +275,13 @@ class TestCTL(unittest.TestCase):
                         "vcpuCount": 21,
                         "volumeInGb": 200,
                         "volumeMountPath": "/workspace",
-                        "machine": {"gpuDisplayName": "RTX 3090"},
+                        "machine": {
+                            "gpuDisplayName": "RTX 3090",
+                            "gpuAvailable": 5,
+                            "maintenanceStart": None,
+                            "maintenanceEnd": None,
+                            "maintenanceNote": None
+                        },
                     }
                 }
             }


### PR DESCRIPTION
Retrieve the following additional properties of a pod (or a set of pods) machine from the runpod GraphQL API when running the `get_pod` or `get_pods` calls:

* Upcoming machine maintenance
* Requested GPU availability

This enables use cases where people want to query the readiness of their pods so they can safely and automatically launch them, scale them or send notifications when the readiness status of the pods changes.

I've updated the unit tests and ensured they all pass.

~~I've also added `nest-asyncio` to the `requirements.txt`, as it was missing and without it the unit tests fail. There are some unit test failures present but none of them are related to this change as they are also failing on the `HEAD` of `main`.~~

(EDIT: nevermind about the unit tests, I had set up the project incorrectly. All unit tests pass now)