### PR TITLE
feat: implement CustomEndpoint

### DIFF
--- a/runpod/__init__.py
+++ b/runpod/__init__.py
@@ -26,7 +26,7 @@ from .cli.groups.config.functions import (
     get_credentials,
     set_credentials,
 )
-from .endpoint import AsyncioEndpoint, AsyncioJob, Endpoint
+from .endpoint import AsyncioEndpoint, AsyncioJob, Endpoint, CustomEndpoint
 from .serverless.modules.rp_logger import RunPodLogger
 from .version import __version__
 

--- a/runpod/endpoint/__init__.py
+++ b/runpod/endpoint/__init__.py
@@ -1,5 +1,5 @@
 ''' Allows endpoints to be imported as a module. '''
 
-from .runner import Endpoint, Job
+from .runner import Endpoint, Job, CustomEndpoint
 from .asyncio.asyncio_runner import Endpoint as AsyncioEndpoint
 from .asyncio.asyncio_runner import Job as AsyncioJob


### PR DESCRIPTION
closes runpod/runpod-python#318

This branch adds the possibility to use the runpod-python package also with regulard Pods running on adapted Serverless templates.

To do so, a `CustomEndpoint` class has been created.

Usage example follows

```python
import runpod
import time

input_payload = {
    'input': {
        'foo':'bar'
    }
}

endpoint = runpod.CustomEndpoint("https://some-runpod-host-8000.proxy.runpod.net")
run_request = endpoint.run(input_payload, timeout=90)

print("STATUS: ", run_request.status())
```