### PR TITLE
Allow newer aiohttp versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp[speedups] == 3.9.3
+aiohttp[speedups] >= 3.9.3
 aiohttp-retry >= 2.8.3
 
 backoff >= 2.2.1


### PR DESCRIPTION
In order to resolve multiple security vulnerabilities in aiohttp releases prior to 3.9.5, relax the dependency requirement so that 3.9.5 is an allowed version.