### PR TITLE
Observability: implement tracing for http requests

### DIFF
--- a/.github/workflows/CI-pylint.yml
+++ b/.github/workflows/CI-pylint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[test]
+          pip install '.[test]'
 
       - name: Pylint Source
         run: pylint --ignore-paths='build/*' --ignore='_version.py' $(find . -type f -name '*.py') \

--- a/.github/workflows/CI-pytests.yml
+++ b/.github/workflows/CI-pytests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[test]
+          pip install '.[test]'
 
       - name: Run Tests
         run: pytest --cov-config=.coveragerc --timeout=120 --timeout_method=thread --cov=runpod --cov-report=xml --cov-report=term-missing --cov-fail-under=100 -W error -p no:cacheprovider -p no:unraisableexception

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Here is a quick guide on how to contribute code to this project:
 6. Run tests to ensure that your changes do not break any existing functionality. You can run tests using the following command:
 
     ```bash
-    pip install .[test]
+    pip install '.[test]'
     pytest
     ```
 

--- a/examples/endpoints/asyncio_job_request.py
+++ b/examples/endpoints/asyncio_job_request.py
@@ -3,10 +3,9 @@ Example of calling an endpoint using asyncio.
 """
 
 import asyncio
-import aiohttp
 
 import runpod
-from runpod import AsyncioEndpoint, AsyncioJob
+from runpod import http_client, AsyncioEndpoint, AsyncioJob
 
 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # For Windows Users
 
@@ -17,7 +16,7 @@ async def main():
     '''
     Function to run the example.
     '''
-    async with aiohttp.ClientSession() as session:
+    async with http_client.AsyncClientSession() as session:
         # Invoke API
         payload = {}
         endpoint = AsyncioEndpoint("ENDPOINT_ID", session)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,11 @@ test = [
     "asynctest",
     "nest_asyncio",
     "pylint",
-    "pytest",
+    "pytest-asyncio",
     "pytest-cov",
     "pytest-timeout",
-    "pytest-asyncio",
+    "pytest-watch",
+    "pytest",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ runpod = "runpod.cli.entry:runpod_cli"
 test = [
     "asynctest",
     "nest_asyncio",
-    "pylint",
+    "pylint==3.2.5",
     "pytest-asyncio",
     "pytest-cov",
     "pytest-timeout",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --durations=10
+python_files = tests.py test_*.py *_test.py
+norecursedirs = venv *.egg-info .git build

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ backoff >= 2.2.1
 boto3 >= 1.26.165
 click >= 8.1.7
 colorama >= 0.2.5, < 0.4.7
+cryptography < 43.0.0
 fastapi[all] >= 0.94.0
 paramiko >= 3.3.1
 prettytable >= 3.9.0

--- a/runpod/__init__.py
+++ b/runpod/__init__.py
@@ -42,9 +42,7 @@ if _credentials is not None:
 else:
     api_key = None  # pylint: disable=invalid-name
 
-api_url_base = "https://api.runpod.io"  # pylint: disable=invalid-name
-
-endpoint_url_base = "https://api.runpod.ai/v2"  # pylint: disable=invalid-name
+endpoint_url_base = os.environ.get("RUNPOD_ENDPOINT_BASE_URL", "https://api.runpod.ai/v2")  # pylint: disable=invalid-name
 
 
 # --------------------------- Force Logging Levels --------------------------- #

--- a/runpod/api/graphql.py
+++ b/runpod/api/graphql.py
@@ -3,6 +3,7 @@ RunPod | API Wrapper | GraphQL
 """
 
 import json
+import os
 from typing import Any, Dict
 
 import requests
@@ -18,7 +19,8 @@ def run_graphql_query(query: str) -> Dict[str, Any]:
     Run a GraphQL query
     '''
     from runpod import api_key  # pylint: disable=import-outside-toplevel, cyclic-import
-    url = f"https://api.runpod.io/graphql?api_key={api_key}"
+    api_url_base = os.environ.get("RUNPOD_API_BASE_URL", "https://api.runpod.io")
+    url = f"{api_url_base}/graphql?api_key={api_key}"
 
     headers = {
         "Content-Type": "application/json",

--- a/runpod/cli/groups/pod/commands.py
+++ b/runpod/cli/groups/pod/commands.py
@@ -33,6 +33,11 @@ def create_new_pod(name, image, gpu_type, gpu_count, support_public_ip): # pylin
     '''
     Creates a pod.
     '''
+    kwargs = {
+        "gpu_count": gpu_count,
+        "support_public_ip": support_public_ip,
+    }
+
     if not name:
         name = click.prompt('Enter pod name', default='RunPod-CLI-Pod')
 
@@ -40,12 +45,11 @@ def create_new_pod(name, image, gpu_type, gpu_count, support_public_ip): # pylin
     if quick_launch:
         image = 'runpod/base:0.0.0'
         gpu_type = 'NVIDIA GeForce RTX 3090'
-        ports ='22/tcp'
+        kwargs["ports"] ='22/tcp'
 
         click.echo('Launching default pod...')
 
-    new_pod = create_pod(name, image, gpu_type,
-                         gpu_count=gpu_count, support_public_ip=support_public_ip, ports=ports)
+    new_pod = create_pod(name, image, gpu_type, **kwargs)
 
     click.echo(f'Pod {new_pod["id"]} has been created.')
 

--- a/runpod/endpoint/asyncio/asyncio_runner.py
+++ b/runpod/endpoint/asyncio/asyncio_runner.py
@@ -18,7 +18,8 @@ class Job:
         self.job_id = job_id
         self.headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {api_key}"
+            "Authorization": f"Bearer {api_key}",
+            "X-Request-ID": job_id,
         }
         self.session = session
         self.endpoint_url_base = endpoint_url_base

--- a/runpod/endpoint/asyncio/asyncio_runner.py
+++ b/runpod/endpoint/asyncio/asyncio_runner.py
@@ -3,15 +3,15 @@
 
 from typing import Any, Dict
 import asyncio
-import aiohttp
 
+from runpod.http_client import AsyncClientSession
 from runpod.endpoint.helpers import FINAL_STATES, is_completed
 
 
 class Job:
     """Class representing a job for an asynchronous endpoint"""
 
-    def __init__(self, endpoint_id: str, job_id: str, session: aiohttp.ClientSession):
+    def __init__(self, endpoint_id: str, job_id: str, session: AsyncClientSession):
         from runpod import api_key, endpoint_url_base  # pylint: disable=import-outside-toplevel,cyclic-import
 
         self.endpoint_id = endpoint_id
@@ -100,7 +100,7 @@ class Job:
 class Endpoint:
     """Class for running endpoint"""
 
-    def __init__(self, endpoint_id: str, session: aiohttp.ClientSession):
+    def __init__(self, endpoint_id: str, session: AsyncClientSession):
         from runpod import api_key, endpoint_url_base  # pylint: disable=import-outside-toplevel
 
         self.endpoint_id = endpoint_id

--- a/runpod/endpoint/asyncio/asyncio_runner.py
+++ b/runpod/endpoint/asyncio/asyncio_runner.py
@@ -4,14 +4,14 @@
 from typing import Any, Dict
 import asyncio
 
-from runpod.http_client import AsyncClientSession
+from runpod.http_client import ClientSession
 from runpod.endpoint.helpers import FINAL_STATES, is_completed
 
 
 class Job:
     """Class representing a job for an asynchronous endpoint"""
 
-    def __init__(self, endpoint_id: str, job_id: str, session: AsyncClientSession):
+    def __init__(self, endpoint_id: str, job_id: str, session: ClientSession):
         from runpod import api_key, endpoint_url_base  # pylint: disable=import-outside-toplevel,cyclic-import
 
         self.endpoint_id = endpoint_id
@@ -101,7 +101,7 @@ class Job:
 class Endpoint:
     """Class for running endpoint"""
 
-    def __init__(self, endpoint_id: str, session: AsyncClientSession):
+    def __init__(self, endpoint_id: str, session: ClientSession):
         from runpod import api_key, endpoint_url_base  # pylint: disable=import-outside-toplevel
 
         self.endpoint_id = endpoint_id

--- a/runpod/http_client.py
+++ b/runpod/http_client.py
@@ -1,0 +1,89 @@
+"""
+HTTP Client abstractions
+"""
+
+import os
+import aiohttp
+import requests
+from .tracer import (
+    get_aiohttp_tracer,
+    get_request_tracer,
+)
+from .cli.groups.config.functions import get_credentials
+from .user_agent import USER_AGENT
+
+
+def get_auth_header():
+    """
+    Produce a header dict with the `Authorization` key derived from
+    credentials.get("api_key") OR os.getenv('RUNPOD_AI_API_KEY')
+    """
+    if credentials := get_credentials():
+        auth = credentials.get("api_key")
+    else:
+        auth = os.getenv("RUNPOD_AI_API_KEY")
+
+    return {
+        "Content-Type": "application/json",
+        "Authorization": f"{auth}",
+        "User-Agent": USER_AGENT,
+    }
+
+
+class AsyncClientSession(aiohttp.ClientSession):
+    """
+    Inherits aiohttp.ClientSession and overrides with our preferred params
+    TODO: use httpx
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            connector=aiohttp.TCPConnector(limit=0),
+            headers=get_auth_header(),
+            timeout=aiohttp.ClientTimeout(600, ceil_threshold=400),
+            trace_configs=[get_aiohttp_tracer()],
+            *args,
+            **kwargs,
+        )
+
+
+class SyncClientSession(requests.Session):
+    """
+    Inherits requests.Session to override `request()` method for tracing
+    TODO: use httpx
+    """
+
+    def request(self, method, url, **kwargs):  # pylint: disable=arguments-differ
+        """
+        Override for tracing. Not using super().request()
+        to capture metrics for connection and transfer times
+        """
+        with get_request_tracer() as tracer:
+            # Separate out the kwargs that are not applicable to `requests.Request`
+            request_kwargs = {
+                k: v
+                for k, v in kwargs.items()
+                if k in requests.Request.__init__.__code__.co_varnames
+            }
+            send_kwargs = {k: v for k, v in kwargs.items() if k not in request_kwargs}
+
+            # Create a PreparedRequest object to hold the request details
+            req = requests.Request(method, url, **request_kwargs)
+            prepped = self.prepare_request(req)
+            tracer.request = prepped  # Assign the request to the tracer
+
+            # Merge environment settings
+            settings = self.merge_environment_settings(
+                prepped.url,
+                send_kwargs.get("proxies"),
+                send_kwargs.get("stream"),
+                send_kwargs.get("verify"),
+                send_kwargs.get("cert"),
+            )
+            send_kwargs.update(settings)
+
+            # Send the request
+            response = self.send(prepped, **send_kwargs)
+            tracer.response = response  # Assign the response to the tracer
+
+            return response

--- a/runpod/http_client.py
+++ b/runpod/http_client.py
@@ -3,8 +3,12 @@ HTTP Client abstractions
 """
 
 import os
-import aiohttp
 import requests
+from aiohttp import (
+    ClientSession,
+    ClientTimeout,
+    TCPConnector,
+)
 from .tracer import (
     get_aiohttp_tracer,
     get_request_tracer,
@@ -30,21 +34,20 @@ def get_auth_header():
     }
 
 
-class AsyncClientSession(aiohttp.ClientSession):
+def AsyncClientSession(*args, **kwargs): # pylint: disable=invalid-name
     """
-    Inherits aiohttp.ClientSession and overrides with our preferred params
+    Deprecation from aiohttp.ClientSession forbids inheritance.
+    This is now a factory method
     TODO: use httpx
     """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(
-            connector=aiohttp.TCPConnector(limit=0),
-            headers=get_auth_header(),
-            timeout=aiohttp.ClientTimeout(600, ceil_threshold=400),
-            trace_configs=[get_aiohttp_tracer()],
-            *args,
-            **kwargs,
-        )
+    return ClientSession(
+        connector=TCPConnector(limit=0),
+        headers=get_auth_header(),
+        timeout=ClientTimeout(600, ceil_threshold=400),
+        trace_configs=[get_aiohttp_tracer()],
+        *args,
+        **kwargs,
+    )
 
 
 class SyncClientSession(requests.Session):

--- a/runpod/serverless/modules/rp_fastapi.py
+++ b/runpod/serverless/modules/rp_fastapi.py
@@ -18,6 +18,7 @@ from .rp_job import run_job, run_job_generator
 from .worker_state import Jobs
 from .rp_ping import Heartbeat
 from ...version import __version__ as runpod_version
+from ...http_client import SyncClientSession
 
 
 RUNPOD_ENDPOINT_ID = os.environ.get("RUNPOD_ENDPOINT_ID", None)
@@ -157,7 +158,7 @@ def _send_webhook(url: str, payload: Dict[str, Any]) -> bool:
     Returns:
         bool: True if the request was successful, False otherwise.
     """
-    with requests.Session() as session:
+    with SyncClientSession() as session:
         try:
             response = session.post(url, json=payload, timeout=10)
             response.raise_for_status()  # Raises exception for 4xx/5xx responses

--- a/runpod/serverless/modules/rp_http.py
+++ b/runpod/serverless/modules/rp_http.py
@@ -4,9 +4,8 @@
 
 import os
 import json
-import aiohttp
 from aiohttp_retry import RetryClient, ExponentialRetry
-
+from runpod.http_client import AsyncClientSession
 from runpod.serverless.modules.rp_logger import RunPodLogger
 from .worker_state import Jobs, WORKER_ID
 
@@ -20,7 +19,7 @@ log = RunPodLogger()
 job_list = Jobs()
 
 
-async def _transmit(client_session, url, job_data):
+async def _transmit(client_session: AsyncClientSession, url, job_data):
     """
     Wrapper for transmitting results via POST.
     """
@@ -37,7 +36,8 @@ async def _transmit(client_session, url, job_data):
         await client_response.text()
 
 
-async def _handle_result(session, job_data, job, url_template, log_message, is_stream=False): # pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments, disable=line-too-long
+async def _handle_result(session: AsyncClientSession, job_data, job, url_template, log_message, is_stream=False):
     """
     A helper function to handle the result, either for sending or streaming.
     """

--- a/runpod/serverless/modules/rp_http.py
+++ b/runpod/serverless/modules/rp_http.py
@@ -6,7 +6,7 @@ import os
 import json
 from aiohttp import ClientError
 from aiohttp_retry import RetryClient, FibonacciRetry
-from runpod.http_client import AsyncClientSession
+from runpod.http_client import ClientSession
 from runpod.serverless.modules.rp_logger import RunPodLogger
 from .worker_state import Jobs, WORKER_ID
 
@@ -20,7 +20,7 @@ log = RunPodLogger()
 job_list = Jobs()
 
 
-async def _transmit(client_session: AsyncClientSession, url, job_data):
+async def _transmit(client_session: ClientSession, url, job_data):
     """
     Wrapper for transmitting results via POST.
     """
@@ -38,7 +38,7 @@ async def _transmit(client_session: AsyncClientSession, url, job_data):
 
 
 # pylint: disable=too-many-arguments, disable=line-too-long
-async def _handle_result(session: AsyncClientSession, job_data, job, url_template, log_message, is_stream=False):
+async def _handle_result(session: ClientSession, job_data, job, url_template, log_message, is_stream=False):
     """
     A helper function to handle the result, either for sending or streaming.
     """

--- a/runpod/serverless/modules/rp_http.py
+++ b/runpod/serverless/modules/rp_http.py
@@ -4,7 +4,8 @@
 
 import os
 import json
-from aiohttp_retry import RetryClient, ExponentialRetry
+from aiohttp import ClientError
+from aiohttp_retry import RetryClient, FibonacciRetry
 from runpod.http_client import AsyncClientSession
 from runpod.serverless.modules.rp_logger import RunPodLogger
 from .worker_state import Jobs, WORKER_ID
@@ -23,7 +24,7 @@ async def _transmit(client_session: AsyncClientSession, url, job_data):
     """
     Wrapper for transmitting results via POST.
     """
-    retry_options = ExponentialRetry(attempts=3)
+    retry_options = FibonacciRetry(attempts=3)
     retry_client = RetryClient(client_session=client_session, retry_options=retry_options)
 
     kwargs = {
@@ -52,7 +53,7 @@ async def _handle_result(session: AsyncClientSession, job_data, job, url_templat
         await _transmit(session, url, serialized_job_data)
         log.debug(f"{log_message}", job['id'])
 
-    except aiohttp.ClientError as err:
+    except ClientError as err:
         log.error(f"Failed to return job results. | {err}", job['id'])
 
     except (TypeError, RuntimeError) as err:

--- a/runpod/serverless/modules/rp_http.py
+++ b/runpod/serverless/modules/rp_http.py
@@ -42,6 +42,8 @@ async def _handle_result(session: AsyncClientSession, job_data, job, url_templat
     A helper function to handle the result, either for sending or streaming.
     """
     try:
+        session.headers["X-Request-ID"] = job["id"]
+
         serialized_job_data = json.dumps(job_data, ensure_ascii=False)
 
         is_stream = "true" if is_stream else "false"

--- a/runpod/serverless/modules/rp_job.py
+++ b/runpod/serverless/modules/rp_job.py
@@ -10,8 +10,8 @@ import os
 import json
 import asyncio
 import traceback
-from aiohttp import ClientSession
 
+from runpod.http_client import AsyncClientSession
 from runpod.serverless.modules.rp_logger import RunPodLogger
 from .worker_state import WORKER_ID, Jobs
 from .rp_tips import check_return_size
@@ -37,13 +37,13 @@ def _job_get_url():
     return JOB_GET_URL + f"&job_in_progress={job_in_progress}"
 
 
-async def get_job(session: ClientSession, retry=True) -> Optional[Dict[str, Any]]:
+async def get_job(session: AsyncClientSession, retry=True) -> Optional[Dict[str, Any]]:
     """
     Get the job from the queue.
     Will continue trying to get a job until one is available.
 
     Args:
-        session (ClientSession): The aiohttp ClientSession to use for the request.
+        session (AsyncClientSession): The async http client to use for the request.
         retry (bool): Whether to retry if no job is available.
 
     Note: Retry True just for ease of, if testing improved this can be removed.

--- a/runpod/serverless/modules/rp_job.py
+++ b/runpod/serverless/modules/rp_job.py
@@ -11,7 +11,7 @@ import json
 import asyncio
 import traceback
 
-from runpod.http_client import AsyncClientSession
+from runpod.http_client import ClientSession
 from runpod.serverless.modules.rp_logger import RunPodLogger
 from .worker_state import WORKER_ID, Jobs
 from .rp_tips import check_return_size
@@ -37,13 +37,13 @@ def _job_get_url():
     return JOB_GET_URL + f"&job_in_progress={job_in_progress}"
 
 
-async def get_job(session: AsyncClientSession, retry=True) -> Optional[Dict[str, Any]]:
+async def get_job(session: ClientSession, retry=True) -> Optional[Dict[str, Any]]:
     """
     Get the job from the queue.
     Will continue trying to get a job until one is available.
 
     Args:
-        session (AsyncClientSession): The async http client to use for the request.
+        session (ClientSession): The async http client to use for the request.
         retry (bool): Whether to retry if no job is available.
 
     Note: Retry True just for ease of, if testing improved this can be removed.

--- a/runpod/serverless/modules/rp_logger.py
+++ b/runpod/serverless/modules/rp_logger.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 
 MAX_MESSAGE_LENGTH = 4096
-LOG_LEVELS = ['NOTSET', 'DEBUG', 'INFO', 'WARN', 'ERROR']
+LOG_LEVELS = ['NOTSET', 'DEBUG', 'TRACE', 'INFO', 'WARN', 'ERROR']
 
 
 def _validate_log_level(log_level):
@@ -32,7 +32,7 @@ def _validate_log_level(log_level):
         return log_level
 
     if isinstance(log_level, int):
-        if log_level < 0 or log_level > 4:
+        if log_level < 0 or log_level >= len(LOG_LEVELS):
             raise ValueError(f'Invalid debug level: {log_level}')
 
         return LOG_LEVELS[log_level]
@@ -134,3 +134,9 @@ class RunPodLogger:
         tip log
         '''
         self.log(message, 'TIP')
+
+    def trace(self, message, request_id: Optional[str] = None):
+        '''
+        trace log (buffered until flushed)
+        '''
+        self.log(message, 'TRACE', request_id)

--- a/runpod/serverless/modules/rp_ping.py
+++ b/runpod/serverless/modules/rp_ping.py
@@ -9,6 +9,7 @@ import threading
 import requests
 from urllib3.util.retry import Retry
 
+from runpod.http_client import SyncClientSession
 from runpod.version import __version__ as runpod_version
 from runpod.serverless.modules.rp_logger import RunPodLogger
 from runpod.serverless.modules.worker_state import Jobs, WORKER_ID
@@ -31,7 +32,7 @@ class Heartbeat:
         '''
         Initializes the Heartbeat class.
         '''
-        self._session = requests.Session()
+        self._session = SyncClientSession()
         self._session.headers.update({"Authorization": f"{os.environ.get('RUNPOD_AI_API_KEY')}"})
 
         retry_strategy = Retry(

--- a/runpod/serverless/modules/rp_progress.py
+++ b/runpod/serverless/modules/rp_progress.py
@@ -2,30 +2,15 @@
 RunPod Progress Module
 """
 
-import os
 import asyncio
 import threading
 from typing import Dict, Any
 
-import aiohttp
-
+from runpod.http_client import AsyncClientSession
 from runpod.serverless.modules.rp_logger import RunPodLogger
 from .rp_http import send_result
 
 log = RunPodLogger()
-
-
-async def _create_session_async():
-    """
-    Creates an aiohttp session.
-    """
-    auth_header = {"Authorization": f"{os.environ.get('RUNPOD_AI_API_KEY')}"}
-    timeout = aiohttp.ClientTimeout(total=300, connect=2, sock_connect=2)
-
-    return aiohttp.ClientSession(
-        connector=aiohttp.TCPConnector(limit=None),
-        headers=auth_header, timeout=timeout
-    )
 
 
 async def _async_progress_update(session, job, progress):
@@ -49,7 +34,7 @@ def _thread_target(job: Dict[str, Any], progress: Any):
 
     try:
         async def main():
-            session = await _create_session_async()
+            session = AsyncClientSession()
             async with session:
                 await _async_progress_update(session, job, progress)
 

--- a/runpod/serverless/modules/worker_state.py
+++ b/runpod/serverless/modules/worker_state.py
@@ -16,13 +16,6 @@ WORKER_ID = os.environ.get('RUNPOD_POD_ID', str(uuid.uuid4()))
 IS_LOCAL_TEST = os.environ.get("RUNPOD_WEBHOOK_GET_JOB", None) is None
 
 
-def get_auth_header():
-    '''
-    Returns the authorization header with the API key.
-    '''
-    return {"Authorization": f"{os.environ.get('RUNPOD_AI_API_KEY')}"}
-
-
 # ------------------------------- Job Tracking ------------------------------- #
 class Job:
     """

--- a/runpod/serverless/worker.py
+++ b/runpod/serverless/worker.py
@@ -6,9 +6,7 @@ import os
 import asyncio
 from typing import Dict, Any
 
-import aiohttp
-
-from runpod.user_agent import USER_AGENT
+from runpod.http_client import AsyncClientSession
 from runpod.serverless.modules import (
     rp_logger, rp_local, rp_handler, rp_ping,
     rp_scale
@@ -21,14 +19,6 @@ from .utils import rp_debugger
 log = rp_logger.RunPodLogger()
 job_list = Jobs()
 heartbeat = rp_ping.Heartbeat()
-
-
-def _get_auth_header() -> Dict[str, str]:
-    """ Returns the authorization header with the API key. """
-    return {
-        "Authorization": f"{os.environ.get('RUNPOD_AI_API_KEY')}",
-        "User-Agent": USER_AGENT
-    }
 
 
 def _is_local(config) -> bool:
@@ -94,11 +84,7 @@ async def run_worker(config: Dict[str, Any]) -> None:
     """
     heartbeat.start_ping()
 
-    client_session = aiohttp.ClientSession(
-        connector=aiohttp.TCPConnector(limit=0),
-        headers=_get_auth_header(),
-        timeout=aiohttp.ClientTimeout(total=300, connect=2, sock_connect=2)
-    )
+    client_session = AsyncClientSession()
 
     async with client_session as session:
         job_scaler = rp_scale.JobScaler(

--- a/runpod/tracer.py
+++ b/runpod/tracer.py
@@ -1,0 +1,178 @@
+# pylint: disable-all
+# Temporary tracer while we're still using aiohttp and requests
+# TODO: use httpx and opentelemetry
+
+import asyncio
+import json
+import types
+from time import time
+from uuid import uuid4
+from requests import (
+    Response,
+    PreparedRequest,
+    structures,
+)
+from aiohttp import (
+    TraceConfig,
+    TraceRequestStartParams,
+    TraceConnectionCreateEndParams,
+    TraceConnectionReuseconnParams,
+    TraceRequestEndParams,
+    TraceRequestExceptionParams,
+    TraceRequestChunkSentParams,
+    TraceResponseChunkReceivedParams,
+)
+
+from .serverless.modules.rp_logger import RunPodLogger
+
+
+log = RunPodLogger()
+
+
+def headers_to_context(context: types.SimpleNamespace, headers: dict):
+    context.trace_id = str(uuid4())
+    context.request_id = None
+    context.user_agent = None
+
+    if headers:
+        headers = structures.CaseInsensitiveDict(headers)
+        context.trace_id = headers.get("x-trace-id", context.trace_id)
+        context.request_id = headers.get("x-request-id")
+        context.user_agent = headers.get("user-agent")
+
+    return context
+
+
+# Tracer for aiohttp
+
+
+async def on_request_start(session, context, params: TraceRequestStartParams):
+    headers = params.headers if hasattr(params, "headers") else {}
+    context = headers_to_context(context, headers)
+    context.on_request_start = asyncio.get_event_loop().time()
+    context.method = params.method
+    context.url = params.url.human_repr()
+    context.mode = "async"
+
+    if hasattr(context, "trace_request_ctx") and context.trace_request_ctx:
+        context.retries = context.trace_request_ctx["current_attempt"]
+
+
+async def on_connection_create_end(
+    session, context, params: TraceConnectionCreateEndParams
+):
+    context.connect = asyncio.get_event_loop().time() - context.on_request_start
+
+
+async def on_connection_reuseconn(
+    session, context, params: TraceConnectionReuseconnParams
+):
+    context.connect = asyncio.get_event_loop().time() - context.on_request_start
+
+
+async def on_request_chunk_sent(session, context, params: TraceRequestChunkSentParams):
+    if not hasattr(context, "payload_size_bytes"):
+        context.payload_size_bytes = 0
+    context.payload_size_bytes += len(params.chunk)
+
+
+async def on_response_chunk_received(
+    session, context, params: TraceResponseChunkReceivedParams
+):
+    if not hasattr(context, "response_size_bytes"):
+        context.response_size_bytes = 0
+    context.response_size_bytes += len(params.chunk)
+
+
+async def on_request_end(session, context, params: TraceRequestEndParams):
+    elapsed = asyncio.get_event_loop().time() - context.on_request_start
+    context.transfer = elapsed - context.connect
+    # log to trace level
+    report_trace(context, params, elapsed)
+
+
+async def on_request_exception(session, context, params: TraceRequestExceptionParams):
+    context.exception = str(params.exception)
+    elapsed = asyncio.get_event_loop().time() - context.on_request_start
+    context.transfer = elapsed - context.connect
+    # log to error level
+    report_trace(context, params, elapsed, log.error)
+
+
+def report_trace(context: types.SimpleNamespace, params, elapsed, logger=log.trace):
+    context.total = round(elapsed * 1000, 1)
+
+    if hasattr(context, "transfer") and context.transfer:
+        context.transfer = round(context.transfer * 1000, 1)
+
+    if hasattr(context, "connect") and context.connect:
+        context.connect = round(context.connect * 1000, 1)
+
+    if hasattr(context, "on_request_start"):
+        delattr(context, "on_request_start")
+
+    if hasattr(context, "trace_request_ctx"):
+        delattr(context, "trace_request_ctx")
+
+    if hasattr(params, "response") and params.response:
+        context.response_status = params.response.status
+
+    logger(json.dumps(vars(context)), context.request_id)
+
+
+def get_aiohttp_tracer() -> TraceConfig:
+    # https://docs.aiohttp.org/en/stable/tracing_reference.html
+    trace_config = TraceConfig()
+
+    trace_config.on_request_start.append(on_request_start)
+    trace_config.on_connection_create_end.append(on_connection_create_end)
+    trace_config.on_connection_reuseconn.append(on_connection_reuseconn)
+    trace_config.on_request_chunk_sent.append(on_request_chunk_sent)
+    trace_config.on_response_chunk_received.append(on_response_chunk_received)
+    trace_config.on_request_end.append(on_request_end)
+    trace_config.on_request_exception.append(on_request_exception)
+
+    return trace_config
+
+
+# Tracer for requests
+
+
+class TraceRequest:
+    def __init__(self):
+        self.context = types.SimpleNamespace()
+        self.request: PreparedRequest = None
+        self.response: Response = None
+        self.request_start = None
+
+    def __enter__(self):
+        self.request_start = time()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.request is not None:
+            self.context = headers_to_context(self.context, self.request.headers)
+            self.context.method = self.request.method
+            self.context.url = self.request.url
+            self.context.mode = "sync"
+
+            if isinstance(self.request.body, bytes):
+                self.context.payload_size_bytes = len(self.request.body)
+
+        if self.response is not None:
+            request_end = time() - self.request_start
+            self.context.transfer = self.response.elapsed.total_seconds()
+            self.context.connect = request_end - self.context.transfer
+
+            self.context.response_status = self.response.status_code
+            self.context.response_size_bytes = len(self.response.content)
+
+            if hasattr(self.response.raw, "retries"):
+                self.context.retries = self.response.raw.retries.total
+
+            logger = log.trace if self.response.ok else log.error
+            report_trace(self.context, {}, request_end, logger)
+
+
+def get_request_tracer():
+    return TraceRequest()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
     'test': [
         'asynctest',
         'nest_asyncio',
-        'pylint',
+        'pylint==3.2.5',
         'pytest',
         'pytest-cov',
         'pytest-timeout',

--- a/tests/test_cli/test_cli_groups/test_project_functions.py
+++ b/tests/test_cli/test_cli_groups/test_project_functions.py
@@ -1,6 +1,7 @@
 """ Test functions in runpod.cli.groups.project.functions module. """
 
 import os
+import shutil
 import unittest
 from unittest.mock import patch, mock_open
 
@@ -12,6 +13,10 @@ from runpod.cli.groups.project.functions import (
 
 class TestCreateNewProject(unittest.TestCase):
     """ Test the create_new_project function."""
+    def tearDown(self):
+        toml_file_location = os.path.join(os.getcwd(), "test_project")
+        if os.path.exists(toml_file_location):
+            shutil.rmtree(toml_file_location)
 
     @patch("os.makedirs")
     @patch("os.path.exists", return_value=False)

--- a/tests/test_serverless/test_modules/test_http.py
+++ b/tests/test_serverless/test_modules/test_http.py
@@ -111,7 +111,9 @@ class TestHTTP(unittest.IsolatedAsyncioTestCase):
             mock_dumps.side_effect = TypeError("Forced exception")
 
             mock_jobs.return_value = set(['test_id'])
-            send_return_local = await rp_http.send_result("No Session", self.job_data, self.job)
+            send_return_local = await rp_http.send_result(
+                aiohttp.ClientSession(), self.job_data, self.job
+            )
 
             assert send_return_local is None
             assert mock_log.debug.call_count == 0

--- a/tests/test_serverless/test_modules/test_logger.py
+++ b/tests/test_serverless/test_modules/test_logger.py
@@ -39,13 +39,16 @@ class TestLogger(unittest.TestCase):
         '''
         logger = rp_logger.RunPodLogger()
 
+        logger.set_level("TRACE")
+        self.assertEqual(logger.level, "TRACE")
+
         logger.set_level("INFO")
         self.assertEqual(logger.level, "INFO")
 
         logger.set_level("WARN")
         self.assertEqual(logger.level, "WARN")
 
-        logger.set_level(2)
+        logger.set_level(3)
         self.assertEqual(logger.level, "INFO")
 
     def test_call_log(self):
@@ -109,6 +112,17 @@ class TestLogger(unittest.TestCase):
         with patch("runpod.serverless.modules.rp_logger.RunPodLogger.log") as mock_log:
             self.logger.tip("test_tip")
             mock_log.assert_called_once_with("test_tip", "TIP")
+
+    def test_log_trace(self):
+        '''
+        Tests that the trace method logs a trace.
+        '''
+        with patch("runpod.serverless.modules.rp_logger.RunPodLogger.log") as mock_log:
+            self.logger.trace("This is a trace message")
+            mock_log.assert_called_once_with("This is a trace message", "TRACE", None)
+
+            self.logger.trace("This is another trace message", "test-request-id")
+            mock_log.assert_called_with("This is another trace message", "TRACE", "test-request-id")
 
     def test_log_job_id(self):
         """ Tests that the log method logs a job id """

--- a/tests/test_serverless/test_modules/test_ping.py
+++ b/tests/test_serverless/test_modules/test_ping.py
@@ -41,7 +41,7 @@ class TestPing(unittest.TestCase):
         self.assertEqual(rp_ping.Heartbeat.PING_URL, "https://test.com/ping")
         self.assertEqual(rp_ping.Heartbeat.PING_INTERVAL, 20)
 
-    @patch("requests.Session.get", side_effect=mock_get)
+    @patch("runpod.serverless.modules.rp_ping.SyncClientSession.get", side_effect=mock_get)
     def test_start_ping(self, mock_get_return):
         '''
         Tests that the start_ping function works correctly

--- a/tests/test_serverless/test_modules/test_progress.py
+++ b/tests/test_serverless/test_modules/test_progress.py
@@ -11,10 +11,9 @@ from runpod.serverless.modules.rp_progress import progress_update, _thread_targe
 class TestProgressUpdate(unittest.TestCase):
     """ Tests for the progress_update function. """
 
-    @patch("runpod.serverless.modules.rp_progress.os.environ.get")
     @patch("runpod.serverless.modules.rp_progress.send_result")
     @patch("runpod.serverless.modules.rp_progress._thread_target")
-    def test_progress_update(self, mock_thread_target, mock_result, mock_os_get):
+    def test_progress_update(self, mock_thread_target, mock_result):
         """
         Tests that the progress_update function.
         """
@@ -32,9 +31,6 @@ class TestProgressUpdate(unittest.TestCase):
 
         mock_thread_target.side_effect = mock_thread_function
 
-        # Set mock values
-        mock_os_get.return_value = "fake_api_key"
-
         # Call the function
         job = {"id": "fake_job"}
         progress = "50%"
@@ -47,7 +43,6 @@ class TestProgressUpdate(unittest.TestCase):
         assert thread_event.wait(timeout=30), "Thread did not complete within expected time"
 
         # Assertions
-        mock_os_get.assert_called_with('RUNPOD_AI_API_KEY')
         expected_job_data = {
             "status": "IN_PROGRESS",
             "output": progress

--- a/tests/test_serverless/test_modules/test_state.py
+++ b/tests/test_serverless/test_modules/test_state.py
@@ -4,7 +4,7 @@ import os
 import unittest
 
 from runpod.serverless.modules.worker_state import (
-    Job, Jobs, IS_LOCAL_TEST, WORKER_ID, get_auth_header
+    Job, Jobs, IS_LOCAL_TEST, WORKER_ID
 )
 
 
@@ -32,12 +32,6 @@ class TestEnvVars(unittest.TestCase):
         os.environ["RUNPOD_POD_ID"] = WORKER_ID
 
         self.assertEqual(WORKER_ID, os.environ.get('RUNPOD_POD_ID'))
-
-    def test_get_auth_header(self):
-        '''
-        Tests if get_auth_header() function works as expected
-        '''
-        self.assertEqual(get_auth_header(), {'Authorization': self.test_api_key})
 
 
 class TestJobs(unittest.TestCase):

--- a/tests/test_serverless/test_utils/test_download.py
+++ b/tests/test_serverless/test_utils/test_download.py
@@ -4,9 +4,7 @@
 import os
 import unittest
 from unittest.mock import patch, mock_open, MagicMock
-
-import requests
-
+from requests import RequestException
 from runpod.serverless.utils.rp_download import(
     calculate_chunk_size, download_files_from_urls, file
 )
@@ -19,7 +17,7 @@ JOB_ID = "job_123"
 
 def mock_requests_get(*args, **kwargs):
     '''
-    Mocks requests.get
+    Mocks SyncClientSession.get
     '''
     headers = {
         'Content-Disposition': 'attachment; filename="picture.jpg"',
@@ -27,11 +25,11 @@ def mock_requests_get(*args, **kwargs):
     }
 
     class MockResponse:
-        ''' Mocks requests.get response '''
+        ''' Mocks SyncClientSession.get response '''
 
         def __init__(self, content, status_code, headers=None):
             '''
-            Mocks requests.get response
+            Mocks SyncClientSession.get response
             '''
             self.content = content
             self.status_code = status_code
@@ -40,7 +38,7 @@ def mock_requests_get(*args, **kwargs):
         def raise_for_status(self):
             ''' Mocks raise_for_status function '''
             if 400 <= self.status_code < 600:
-                raise requests.exceptions.RequestException(f"Status code: {self.status_code}")
+                raise RequestException(f"Status code: {self.status_code}")
 
         def iter_content(self, chunk_size=1024):
             ''' Mocks iter_content method '''
@@ -73,7 +71,7 @@ class TestDownloadFilesFromUrls(unittest.TestCase):
         self.assertEqual(calculate_chunk_size(1024*1024*1024*10), 1024*1024*10)
 
     @patch('os.makedirs', return_value=None)
-    @patch('requests.get', side_effect=mock_requests_get)
+    @patch('runpod.http_client.SyncClientSession.get', side_effect=mock_requests_get)
     @patch('builtins.open', new_callable=mock_open)
     def test_download_files_from_urls(self, mock_open_file, mock_get, mock_makedirs):
         '''
@@ -85,7 +83,7 @@ class TestDownloadFilesFromUrls(unittest.TestCase):
 
         self.assertEqual(len(downloaded_files), 1)
 
-        # Check that the url was called with requests.get
+        # Check that the url was called with SyncClientSession.get
         self.assertIn('https://example.com/picture.jpg', mock_get.call_args_list[0][0])
 
         # Check that the file has the correct extension
@@ -103,14 +101,14 @@ class TestDownloadFilesFromUrls(unittest.TestCase):
         self.assertEqual(download_files_from_urls(JOB_ID, [None]), [None])
 
         # Test requests exception
-        mock_get.side_effect = requests.exceptions.RequestException('Error')
+        mock_get.side_effect = RequestException('Error')
         self.assertEqual(
             download_files_from_urls(JOB_ID, ['https://example.com/picture.jpg']),
             [None]
         )
 
     @patch('os.makedirs', return_value=None)
-    @patch('requests.get', side_effect=mock_requests_get)
+    @patch('runpod.http_client.SyncClientSession.get', side_effect=mock_requests_get)
     @patch('builtins.open', new_callable=mock_open)
     def test_download_files_from_urls_signed(self, mock_open_file, mock_get, mock_makedirs):
         '''
@@ -123,7 +121,7 @@ class TestDownloadFilesFromUrls(unittest.TestCase):
         # Confirms that the same number of files were downloaded as urls provided
         self.assertEqual(len(downloaded_files), 1)
 
-        # Check that the url was called with requests.get
+        # Check that the url was called with SyncClientSession.get
         self.assertIn(URL_LIST[1], mock_get.call_args_list[0][0])
 
         # Check that the file has the correct extension
@@ -136,13 +134,13 @@ class TestDownloadFilesFromUrls(unittest.TestCase):
 class FileDownloaderTestCase(unittest.TestCase):
     ''' Tests for file_downloader '''
 
-    @patch('runpod.serverless.utils.rp_download.requests.get')
+    @patch('runpod.serverless.utils.rp_download.SyncClientSession.get')
     @patch('builtins.open', new_callable=mock_open)
     def test_download_file(self, mock_file, mock_get):
         '''
         Tests download_file
         '''
-        # Mock the response from requests.get
+        # Mock the response from SyncClientSession.get
         mock_response = MagicMock()
         mock_response.content = b"file content"
         mock_response.headers = {"Content-Disposition": "filename=test_file.txt"}
@@ -160,14 +158,14 @@ class FileDownloaderTestCase(unittest.TestCase):
         # Check that the file was written correctly
         mock_file().write.assert_called_once_with(b"file content")
 
-    @patch('runpod.serverless.utils.rp_download.requests.get')
+    @patch('runpod.serverless.utils.rp_download.SyncClientSession.get')
     @patch('builtins.open', new_callable=mock_open)
     @patch('runpod.serverless.utils.rp_download.zipfile.ZipFile')
     def test_download_zip_file(self, mock_zip, mock_file, mock_get):
         '''
         Tests download_file with a zip file
         '''
-        # Mock the response from requests.get
+        # Mock the response from SyncClientSession.get
         mock_response = MagicMock()
         mock_response.content = b"zip file content"
         mock_response.headers = {"Content-Disposition": "filename=test_file.zip"}

--- a/tests/test_serverless/test_worker.py
+++ b/tests/test_serverless/test_worker.py
@@ -2,7 +2,6 @@
 # pylint: disable=protected-access
 
 import os
-import platform
 import argparse
 from unittest import mock
 from unittest.mock import patch, mock_open, Mock, MagicMock
@@ -11,7 +10,6 @@ from unittest import IsolatedAsyncioTestCase
 import nest_asyncio
 
 import runpod
-from runpod._version import __version__ as runpod_version
 from runpod.serverless.modules.rp_logger import RunPodLogger
 from runpod.serverless import _signal_handler
 
@@ -27,17 +25,6 @@ class TestWorker(IsolatedAsyncioTestCase):
             "handler": self.mock_handler,
             "rp_args": {"test_input": None},
         }
-
-    def test_get_auth_header(self):
-        """Test retrieval of the authentication header from _get_auth_header."""
-        os_info = f"{platform.system()} {platform.release()}; {platform.machine()}"
-        with patch("runpod.serverless.worker.os") as mock_os:
-            mock_os.environ.get.return_value = "test"
-            assert runpod.serverless.worker._get_auth_header(
-            ) == {
-                'Authorization': 'test',
-                'User-Agent': f'RunPod-Python-SDK/{runpod_version} ({os_info}) Language/Python {platform.python_version()}'  # pylint: disable=line-too-long
-            }
 
     def test_is_local(self):
         '''
@@ -197,7 +184,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
             }
         }
 
-    @patch("aiohttp.ClientSession")
+    @patch("runpod.serverless.worker.AsyncClientSession")
     @patch("runpod.serverless.modules.rp_scale.get_job")
     @patch("runpod.serverless.worker.run_job")
     @patch("runpod.serverless.worker.stream_result")
@@ -329,7 +316,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
         _, args, _ = mock_send_result.mock_calls[0]
         assert args[1] == {'output': ['test1', 'test2'], 'stopPod': True}
 
-    @patch("aiohttp.ClientSession")
+    @patch("runpod.serverless.worker.AsyncClientSession")
     @patch("runpod.serverless.modules.rp_scale.get_job")
     @patch("runpod.serverless.worker.run_job")
     @patch("runpod.serverless.worker.stream_result")
@@ -368,7 +355,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
         assert mock_stream_result.called is False
         assert mock_session.called
 
-    @patch("aiohttp.ClientSession")
+    @patch("runpod.serverless.worker.AsyncClientSession")
     @patch("runpod.serverless.modules.rp_scale.get_job")
     @patch("runpod.serverless.worker.run_job")
     @patch("runpod.serverless.worker.stream_result")

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,0 +1,181 @@
+# pylint: disable-all
+# Temporary tracer while we're still using aiohttp and requests
+# TODO: use httpx and opentelemetry
+import asyncio
+import json
+import unittest
+from time import time
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+from yarl import URL
+from aiohttp import (
+    TraceConfig,
+    TraceRequestStartParams,
+    TraceConnectionCreateEndParams,
+    TraceConnectionReuseconnParams,
+    TraceRequestExceptionParams,
+    TraceRequestChunkSentParams,
+    TraceResponseChunkReceivedParams,
+)
+from runpod.tracer import (
+    on_request_start,
+    on_connection_create_end,
+    on_connection_reuseconn,
+    on_request_chunk_sent,
+    on_response_chunk_received,
+    on_request_end,
+    on_request_exception,
+    report_trace,
+    get_aiohttp_tracer,
+)
+
+
+class TestTracer(unittest.TestCase):
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+    def tearDown(self):
+        self.loop.close()
+
+    def test_get_aiohttp_tracer(self):
+        assert isinstance(get_aiohttp_tracer(), TraceConfig)
+
+    def test_on_request_start(self):
+        session = MagicMock()
+        context = SimpleNamespace()
+        params = TraceRequestStartParams("GET", URL("http://test.com/"), { "X-Request-ID": "myRequestId" })
+
+        self.loop.run_until_complete(on_request_start(session, context, params))
+        assert hasattr(context, 'on_request_start')
+        assert hasattr(context, 'trace_id')
+        assert context.method == params.method
+        assert context.url == params.url.human_repr()
+
+    def test_on_connection_create_end(self):
+        session = MagicMock()
+        context = SimpleNamespace(on_request_start=self.loop.time())
+        params = TraceConnectionCreateEndParams()
+
+        self.loop.run_until_complete(on_connection_create_end(session, context, params))
+
+    def test_on_connection_reuseconn(self):
+        session = MagicMock()
+        context = SimpleNamespace(on_request_start=self.loop.time())
+        params = TraceConnectionReuseconnParams()
+
+        self.loop.run_until_complete(on_connection_reuseconn(session, context, params))
+
+    def test_on_request_chunk_sent(self):
+        session = MagicMock()
+        context = SimpleNamespace(on_request_start=self.loop.time())
+        params = TraceRequestChunkSentParams("GET", URL("http://test.com/"), chunk=b'test data')
+
+        # Initial call to on_request_start to initialize context
+        self.loop.run_until_complete(on_request_start(session, context, params))
+
+        # Call on_request_chunk_sent multiple times to simulate multiple chunks being sent
+        for _ in range(3):
+            self.loop.run_until_complete(on_request_chunk_sent(session, context, params))
+        
+        # Verify that payload_size_bytes has accumulated
+        assert context.payload_size_bytes == len(params.chunk) * 3
+
+    def test_on_response_chunk_received(self):
+        session = MagicMock()
+        context = SimpleNamespace(on_request_start=self.loop.time())
+        params = TraceResponseChunkReceivedParams("GET", URL("http://test.com/"), chunk=b'received data')
+
+        # Initial call to on_request_start to initialize context
+        self.loop.run_until_complete(on_request_start(session, context, params))
+
+        # Call on_response_chunk_received multiple times to simulate multiple chunks being received
+        for _ in range(3):
+            self.loop.run_until_complete(on_response_chunk_received(session, context, params))
+
+        # Verify that payload_size_bytes has accumulated
+        assert context.response_size_bytes == len(params.chunk) * 3
+
+    @patch('runpod.tracer.report_trace')
+    def test_on_request_end(self, mock_report_trace):
+        session = MagicMock()
+        context = SimpleNamespace(on_request_start=self.loop.time(), connect=0.5)
+        params = MagicMock()
+
+        self.loop.run_until_complete(on_request_end(session, context, params))
+        mock_report_trace.assert_called_once()
+
+    @patch('runpod.tracer.report_trace')
+    def test_on_request_exception(self, mock_report_trace):
+        session = MagicMock()
+        context = SimpleNamespace(on_request_start=self.loop.time(), connect=0.5)
+        params = TraceRequestExceptionParams("GET", URL("http://test.com/"), headers={}, exception=Exception("Test Exception"))
+
+        self.loop.run_until_complete(on_request_exception(session, context, params))
+        mock_report_trace.assert_called_once()
+        assert context.exception
+
+    @patch('runpod.tracer.log')
+    def test_report_trace(self, mock_log):
+        context = SimpleNamespace()
+        context.trace_id = "test-trace-id"
+        context.request_id = "test-request-id"
+        context.on_request_start = time()
+        context.connect = 0.5
+        context.payload_size_bytes = 1024
+        context.response_size_bytes = 2048
+        context.retries = 0
+        context.transfer = 1.0
+
+        params = MagicMock()
+        params.response.status = 200
+
+        elapsed = 1.5
+
+        expected_report = {
+            "trace_id": "test-trace-id",
+            "request_id": "test-request-id",
+            "connect": 500.0,
+            "payload_size_bytes": 1024,
+            "response_size_bytes": 2048,
+            "retries": 0,
+            "total": 1500.0,  # 1.5 seconds to milliseconds
+            "transfer": 1000.0,  # 1.5 - 0.5 seconds to milliseconds
+            "response_status": 200
+        }
+
+        report_trace(context, params, elapsed, mock_log.trace)
+
+        assert expected_report == json.loads(mock_log.trace.call_args[0][0])
+
+    @patch('runpod.tracer.log')
+    def test_report_trace_error_log(self, mock_log):
+        context = SimpleNamespace()
+        context.trace_id = "test-trace-id"
+        context.request_id = "test-request-id"
+        context.on_request_start = time()
+        context.connect = 0.5
+        context.retries = 3
+        context.exception = str(Exception("Test Exception"))
+        context.transfer = 1.0
+
+        params = MagicMock()
+        params.response.status = 502
+
+        elapsed = 1.5
+
+        expected_report = {
+            "trace_id": "test-trace-id",
+            "request_id": "test-request-id",
+            "connect": 500.0,
+            "retries": 3,
+            "exception": "Test Exception",
+            "total": 1500.0,  # 1.5 seconds to milliseconds
+            "transfer": 1000.0,  # 1.5 - 0.5 seconds to milliseconds
+            "response_status": 502
+        }
+
+        report_trace(context, params, elapsed, mock_log.error)
+
+        assert expected_report == json.loads(mock_log.error.call_args[0][0])


### PR DESCRIPTION
The following changes are made:
- `runpod.tracer` for instrumenting aiohttp.ClientSession and requests.Session. This will be used for future changes (OpenTelemetry instrumentation)
- `runpod.http_client` abstracts aiohttp.ClientSession and requests.Session direct calls for better control and modularity to prepare for future changes (using httpx)
- `runpod.http_client.AsyncClientSession` for async call is (temporarily) a factory method that returns a pre-configured aiohttp.ClientSession that is instrumented for tracing
- Request header: `X-Request-ID` holds Job ID for tracing purposes
- Support for env var overrides: `RUNPOD_API_BASE_URL` & `RUNPOD_ENDPOINT_BASE_URL`
- New logger level: `TRACE` value for env var `RUNPOD_LOG_LEVEL`
- Misc. corrections for pylint, unittest and build