### PR TITLE
Run `black` and `isort` to format and unify the code.

### DIFF
--- a/examples/api/create_endpoint.py
+++ b/examples/api/create_endpoint.py
@@ -8,9 +8,7 @@ import runpod
 try:
 
     new_template = runpod.create_template(
-        name="test",
-        image_name="runpod/base:0.4.4",
-        is_serverless=True
+        name="test", image_name="runpod/base:0.4.4", is_serverless=True
     )
 
     print(new_template)
@@ -21,7 +19,7 @@ try:
         gpu_ids="AMPERE_16",
         workers_min=0,
         workers_max=1,
-        flashboot=True
+        flashboot=True,
     )
 
     print(new_endpoint)

--- a/examples/api/create_template.py
+++ b/examples/api/create_template.py
@@ -7,10 +7,7 @@ import runpod
 
 try:
 
-    new_template = runpod.create_template(
-        name="test",
-        image_name="runpod/base:0.1.0"
-    )
+    new_template = runpod.create_template(name="test", image_name="runpod/base:0.1.0")
 
     print(new_template)
 

--- a/examples/api/get_endpoints.py
+++ b/examples/api/get_endpoints.py
@@ -1,6 +1,5 @@
 """ Get all endpoints from the API """
 
-
 import runpod
 
 endpoints = runpod.get_endpoints()

--- a/examples/endpoints/asyncio_job_request.py
+++ b/examples/endpoints/asyncio_job_request.py
@@ -5,17 +5,19 @@ Example of calling an endpoint using asyncio.
 import asyncio
 
 import runpod
-from runpod import http_client, AsyncioEndpoint, AsyncioJob
+from runpod import AsyncioEndpoint, AsyncioJob, http_client
 
-asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # For Windows Users
+asyncio.set_event_loop_policy(
+    asyncio.WindowsSelectorEventLoopPolicy()
+)  # For Windows Users
 
 runpod.api_key = "YOUR_API_KEY"
 
 
 async def main():
-    '''
+    """
     Function to run the example.
-    '''
+    """
     async with http_client.AsyncClientSession() as session:
         # Invoke API
         payload = {}
@@ -33,5 +35,6 @@ async def main():
 
         # Print output
         print(output)
+
 
 asyncio.run(main())

--- a/examples/endpoints/run.py
+++ b/examples/endpoints/run.py
@@ -1,6 +1,6 @@
-'''
+"""
 Example of calling an endpoint using the RunPod Python Language Library.
-'''
+"""
 
 import runpod
 
@@ -9,11 +9,9 @@ import runpod
 
 endpoint = runpod.Endpoint("sdxl")  # Where "sdxl" is the endpoint ID
 
-run_request = endpoint.run({
-    "input": {
-        "prompt": "a photo of a horse the size of a Boeing 787"
-    }
-})
+run_request = endpoint.run(
+    {"input": {"prompt": "a photo of a horse the size of a Boeing 787"}}
+)
 
 # Check the status of the run request
 print(run_request.status())

--- a/examples/endpoints/run_sync.py
+++ b/examples/endpoints/run_sync.py
@@ -1,6 +1,6 @@
-'''
+"""
 Example of calling an endpoint using the RunPod Python Language Library.
-'''
+"""
 
 import runpod
 
@@ -12,12 +12,8 @@ endpoint = runpod.Endpoint("sdxl")  # Where "sdxl" is the endpoint ID
 try:
     # Run the endpoint synchronously, blocking until the endpoint run is complete.
     run_request = endpoint.run_sync(
-        {
-            "input": {
-                "prompt": "a photo of a horse the size of a Boeing 787"
-            }
-        },
-        timeout=60  # Seconds
+        {"input": {"prompt": "a photo of a horse the size of a Boeing 787"}},
+        timeout=60,  # Seconds
     )
 
     print(run_request)

--- a/examples/endpoints/streaming.py
+++ b/examples/endpoints/streaming.py
@@ -7,12 +7,14 @@ import runpod
 
 endpoint = runpod.Endpoint("gwp4kx5yd3nur1")
 
-run_request = endpoint.run({
-    "input": {
-        "mock_return": ["a", "b", "c", "d", "e", "f", "g"],
-        "mock_delay": 1,
+run_request = endpoint.run(
+    {
+        "input": {
+            "mock_return": ["a", "b", "c", "d", "e", "f", "g"],
+            "mock_delay": 1,
+        }
     }
-})
+)
 
 for output in run_request.stream():
     print(output)

--- a/examples/graphql_wrapper.py
+++ b/examples/graphql_wrapper.py
@@ -1,10 +1,10 @@
-''''
+"""'
 GraphQL wrapper for the RunPod API
-'''
+"""
 
 import time
-import runpod
 
+import runpod
 
 runpod.api_key = "YOUR_RUNPOD_API_KEY"
 

--- a/examples/serverless/concurrent_handler.py
+++ b/examples/serverless/concurrent_handler.py
@@ -5,12 +5,14 @@ import runpod
 
 # ---------------------------------- Handler --------------------------------- #
 async def async_generator_handler(job):
-    '''
+    """
     Async generator type handler.
-    '''
+    """
     return job
 
 
-runpod.serverless.start({
-    "handler": async_generator_handler,
-})
+runpod.serverless.start(
+    {
+        "handler": async_generator_handler,
+    }
+)

--- a/examples/serverless/logger.py
+++ b/examples/serverless/logger.py
@@ -1,15 +1,15 @@
-""" Example of using the RunPodLogger class. """""
+""" Example of using the RunPodLogger class. """ ""
 
 import runpod
 
-JOB_ID = '1234567890'
+JOB_ID = "1234567890"
 log = runpod.RunPodLogger()
 
 
-log.debug('A debug message')
-log.info('An info message')
-log.warn('A warning message')
-log.error('An error message')
+log.debug("A debug message")
+log.info("An info message")
+log.warn("A warning message")
+log.error("An error message")
 
 # Output:
 # DEBUG   | A debug message
@@ -18,10 +18,10 @@ log.error('An error message')
 # ERROR   | An error message
 
 
-log.debug('A debug message', request_id=JOB_ID)
-log.info('An info message', request_id=JOB_ID)
-log.warn('A warning message', request_id=JOB_ID)
-log.error('An error message', request_id=JOB_ID)
+log.debug("A debug message", request_id=JOB_ID)
+log.info("An info message", request_id=JOB_ID)
+log.warn("A warning message", request_id=JOB_ID)
+log.error("An error message", request_id=JOB_ID)
 
 # Output:
 # {"requestId": "1234567890", "message": "A debug message", "level": "DEBUG"}

--- a/examples/serverless/simple_handler.py
+++ b/examples/serverless/simple_handler.py
@@ -8,7 +8,7 @@ import runpod
 
 
 def handler(job):
-    """ Simple handler """
+    """Simple handler"""
     job_input = job["input"]
 
     return f"Hello {job_input['name']}!"

--- a/runpod/__init__.py
+++ b/runpod/__init__.py
@@ -1,7 +1,7 @@
 """ Allows runpod to be imported as a module. """
 
-import os
 import logging
+import os
 
 from . import serverless
 from .api.ctl_commands import (
@@ -42,7 +42,9 @@ if _credentials is not None:
 else:
     api_key = None  # pylint: disable=invalid-name
 
-endpoint_url_base = os.environ.get("RUNPOD_ENDPOINT_BASE_URL", "https://api.runpod.ai/v2")  # pylint: disable=invalid-name
+endpoint_url_base = os.environ.get(
+    "RUNPOD_ENDPOINT_BASE_URL", "https://api.runpod.ai/v2"
+)  # pylint: disable=invalid-name
 
 
 # --------------------------- Force Logging Levels --------------------------- #

--- a/runpod/api/__init__.py
+++ b/runpod/api/__init__.py
@@ -1,1 +1,1 @@
-''' Allows api_wrapper to be imported as a module.'''
+""" Allows api_wrapper to be imported as a module."""

--- a/runpod/api/ctl_commands.py
+++ b/runpod/api/ctl_commands.py
@@ -1,6 +1,7 @@
 """
 RunPod | API Wrapper | CTL Commands
 """
+
 # pylint: disable=too-many-arguments,too-many-locals
 
 from typing import Optional

--- a/runpod/api/graphql.py
+++ b/runpod/api/graphql.py
@@ -15,10 +15,11 @@ HTTP_STATUS_UNAUTHORIZED = 401
 
 
 def run_graphql_query(query: str) -> Dict[str, Any]:
-    '''
+    """
     Run a GraphQL query
-    '''
+    """
     from runpod import api_key  # pylint: disable=import-outside-toplevel, cyclic-import
+
     api_url_base = os.environ.get("RUNPOD_API_BASE_URL", "https://api.runpod.io")
     url = f"{api_url_base}/graphql?api_key={api_key}"
 
@@ -31,12 +32,11 @@ def run_graphql_query(query: str) -> Dict[str, Any]:
     response = requests.post(url, headers=headers, data=data, timeout=30)
 
     if response.status_code == HTTP_STATUS_UNAUTHORIZED:
-        raise error.AuthenticationError("Unauthorized request, please check your API key.")
+        raise error.AuthenticationError(
+            "Unauthorized request, please check your API key."
+        )
 
     if "errors" in response.json():
-        raise error.QueryError(
-            response.json()["errors"][0]["message"],
-            query
-        )
+        raise error.QueryError(response.json()["errors"][0]["message"], query)
 
     return response.json()

--- a/runpod/api/mutations/endpoints.py
+++ b/runpod/api/mutations/endpoints.py
@@ -4,12 +4,19 @@
 
 
 def generate_endpoint_mutation(
-    name: str, template_id: str, gpu_ids: str = "AMPERE_16",
-    network_volume_id: str = None, locations: str = None,
-    idle_timeout: int = 5, scaler_type: str = "QUEUE_DELAY", scaler_value: int = 4,
-    workers_min: int = 0, workers_max: int = 3, flashboot=False
+    name: str,
+    template_id: str,
+    gpu_ids: str = "AMPERE_16",
+    network_volume_id: str = None,
+    locations: str = None,
+    idle_timeout: int = 5,
+    scaler_type: str = "QUEUE_DELAY",
+    scaler_value: int = 4,
+    workers_min: int = 0,
+    workers_max: int = 3,
+    flashboot=False,
 ):
-    """ Generate a string for a GraphQL mutation to create a new endpoint. """
+    """Generate a string for a GraphQL mutation to create a new endpoint."""
     input_fields = []
 
     # ------------------------------ Required Fields ----------------------------- #
@@ -31,11 +38,11 @@ def generate_endpoint_mutation(
     else:
         input_fields.append('locations: ""')
 
-    input_fields.append(f'idleTimeout: {idle_timeout}')
+    input_fields.append(f"idleTimeout: {idle_timeout}")
     input_fields.append(f'scalerType: "{scaler_type}"')
-    input_fields.append(f'scalerValue: {scaler_value}')
-    input_fields.append(f'workersMin: {workers_min}')
-    input_fields.append(f'workersMax: {workers_max}')
+    input_fields.append(f"scalerValue: {scaler_value}")
+    input_fields.append(f"workersMin: {workers_min}")
+    input_fields.append(f"workersMax: {workers_max}")
 
     # Format the input fields into a string
     input_fields_string = ", ".join(input_fields)
@@ -63,10 +70,8 @@ def generate_endpoint_mutation(
     """
 
 
-def update_endpoint_template_mutation(
-    endpoint_id: str, template_id: str
-):
-    """ Generate a string for a GraphQL mutation to update an existing endpoint's template. """
+def update_endpoint_template_mutation(endpoint_id: str, template_id: str):
+    """Generate a string for a GraphQL mutation to update an existing endpoint's template."""
     input_fields = []
 
     # ------------------------------ Required Fields ----------------------------- #

--- a/runpod/api/mutations/pods.py
+++ b/runpod/api/mutations/pods.py
@@ -1,22 +1,37 @@
 """
 RunPod | API Wrapper | Mutations | Pods
 """
+
 # pylint: disable=too-many-arguments, too-many-locals, too-many-branches
 
-from typing import Optional, List
+from typing import List, Optional
 
 
 def generate_pod_deployment_mutation(
-        name: str, image_name: str, gpu_type_id: str,
-        cloud_type: str = "ALL", support_public_ip: bool = True, start_ssh: bool = True,
-        data_center_id=None, country_code=None,
-        gpu_count=None, volume_in_gb=None, container_disk_in_gb=None, min_vcpu_count=None,
-        min_memory_in_gb=None, docker_args=None, ports=None, volume_mount_path=None,
-        env: dict = None, template_id=None, network_volume_id=None,
-        allowed_cuda_versions: Optional[List[str]] = None):
-    '''
+    name: str,
+    image_name: str,
+    gpu_type_id: str,
+    cloud_type: str = "ALL",
+    support_public_ip: bool = True,
+    start_ssh: bool = True,
+    data_center_id=None,
+    country_code=None,
+    gpu_count=None,
+    volume_in_gb=None,
+    container_disk_in_gb=None,
+    min_vcpu_count=None,
+    min_memory_in_gb=None,
+    docker_args=None,
+    ports=None,
+    volume_mount_path=None,
+    env: dict = None,
+    template_id=None,
+    network_volume_id=None,
+    allowed_cuda_versions: Optional[List[str]] = None,
+):
+    """
     Generates a mutation to deploy a pod on demand.
-    '''
+    """
     input_fields = []
 
     # ------------------------------ Required Fields ----------------------------- #
@@ -25,15 +40,15 @@ def generate_pod_deployment_mutation(
     input_fields.append(f'gpuTypeId: "{gpu_type_id}"')
 
     # ------------------------------ Default Fields ------------------------------ #
-    input_fields.append(f'cloudType: {cloud_type}')
+    input_fields.append(f"cloudType: {cloud_type}")
 
     if start_ssh:
-        input_fields.append('startSsh: true')
+        input_fields.append("startSsh: true")
 
     if support_public_ip:
-        input_fields.append('supportPublicIp: true')
+        input_fields.append("supportPublicIp: true")
     else:
-        input_fields.append('supportPublicIp: false')
+        input_fields.append("supportPublicIp: false")
 
     # ------------------------------ Optional Fields ----------------------------- #
     if data_center_id is not None:
@@ -59,7 +74,8 @@ def generate_pod_deployment_mutation(
         input_fields.append(f'volumeMountPath: "{volume_mount_path}"')
     if env is not None:
         env_string = ", ".join(
-            [f'{{ key: "{key}", value: "{value}" }}' for key, value in env.items()])
+            [f'{{ key: "{key}", value: "{value}" }}' for key, value in env.items()]
+        )
         input_fields.append(f"env: [{env_string}]")
     if template_id is not None:
         input_fields.append(f'templateId: "{template_id}"')
@@ -69,8 +85,9 @@ def generate_pod_deployment_mutation(
 
     if allowed_cuda_versions is not None:
         allowed_cuda_versions_string = ", ".join(
-            [f'"{version}"' for version in allowed_cuda_versions])
-        input_fields.append(f'allowedCudaVersions: [{allowed_cuda_versions_string}]')
+            [f'"{version}"' for version in allowed_cuda_versions]
+        )
+        input_fields.append(f"allowedCudaVersions: [{allowed_cuda_versions_string}]")
 
     # Format input fields
     input_string = ", ".join(input_fields)
@@ -96,9 +113,9 @@ def generate_pod_deployment_mutation(
 
 
 def generate_pod_stop_mutation(pod_id: str) -> str:
-    '''
+    """
     Generates a mutation to stop a pod.
-    '''
+    """
     return f"""
     mutation {{
         podStop(input: {{ podId: "{pod_id}" }}) {{
@@ -110,9 +127,9 @@ def generate_pod_stop_mutation(pod_id: str) -> str:
 
 
 def generate_pod_resume_mutation(pod_id: str, gpu_count: int) -> str:
-    '''
+    """
     Generates a mutation to resume a pod.
-    '''
+    """
     return f"""
     mutation {{
         podResume(input: {{ podId: "{pod_id}", gpuCount: {gpu_count} }}) {{
@@ -130,9 +147,9 @@ def generate_pod_resume_mutation(pod_id: str, gpu_count: int) -> str:
 
 
 def generate_pod_terminate_mutation(pod_id: str) -> str:
-    '''
+    """
     Generates a mutation to terminate a pod.
-    '''
+    """
     return f"""
     mutation {{
         podTerminate(input: {{ podId: "{pod_id}" }})

--- a/runpod/api/mutations/user.py
+++ b/runpod/api/mutations/user.py
@@ -1,14 +1,15 @@
-'''
+"""
 RunPod | API | Mutations | User
-'''
+"""
+
 
 def generate_user_mutation(pubkey):
-    ''''
+    """'
     Generates a mutation to edit a user.
-    '''
+    """
     input_fields = []
 
-    escaped_pubkey = pubkey.replace('\n', '\\n')
+    escaped_pubkey = pubkey.replace("\n", "\\n")
     input_fields.append(f'pubKey: "{escaped_pubkey}"')
 
     # Format input fields

--- a/runpod/api/queries/__init__.py
+++ b/runpod/api/queries/__init__.py
@@ -1,1 +1,1 @@
-''' Allows queries to be imported as a module.'''
+""" Allows queries to be imported as a module."""

--- a/runpod/api/queries/gpus.py
+++ b/runpod/api/queries/gpus.py
@@ -14,9 +14,9 @@ query GpuTypes {
 
 
 def generate_gpu_query(gpu_id, gpu_count=1):
-    '''
+    """
     Generate a query for a specific GPU type
-    '''
+    """
 
     return f"""
     query GpuTypes {{

--- a/runpod/api/queries/pods.py
+++ b/runpod/api/queries/pods.py
@@ -43,10 +43,11 @@ query myPods {
 }
 """
 
+
 def generate_pod_query(pod_id):
-    '''
+    """
     Generate a query for a specific GPU type
-    '''
+    """
 
     return f"""
     query pod {{

--- a/runpod/api/queries/user.py
+++ b/runpod/api/queries/user.py
@@ -1,8 +1,8 @@
-'''
+"""
 RunPod | API | Queries | User
 
 Query for user information.
-'''
+"""
 
 QUERY_USER = """
 query myself {

--- a/runpod/cli/__init__.py
+++ b/runpod/cli/__init__.py
@@ -1,4 +1,4 @@
-''' Allows the CLI to be imported as a module. '''
+""" Allows the CLI to be imported as a module. """
 
 import threading
 
@@ -8,13 +8,16 @@ STOP_EVENT = threading.Event()
 
 
 # --------------------------- runpod.toml Defaults --------------------------- #
-BASE_DOCKER_IMAGE = 'runpod/base:0.4.3-cuda{cuda_version}'
+BASE_DOCKER_IMAGE = "runpod/base:0.4.3-cuda{cuda_version}"
 GPU_TYPES = [
-    "NVIDIA RTX A4000", "NVIDIA RTX A4500", "NVIDIA RTX A5000",
-    "NVIDIA GeForce RTX 3090", "NVIDIA RTX A6000"
+    "NVIDIA RTX A4000",
+    "NVIDIA RTX A4500",
+    "NVIDIA RTX A5000",
+    "NVIDIA GeForce RTX 3090",
+    "NVIDIA RTX A6000",
 ]
 ENV_VARS = {
     "POD_INACTIVITY_TIMEOUT": "120",
     "RUNPOD_DEBUG_LEVEL": "debug",
-    "UVICORN_LOG_LEVEL": "warning"
+    "UVICORN_LOG_LEVEL": "warning",
 }

--- a/runpod/cli/entry.py
+++ b/runpod/cli/entry.py
@@ -1,24 +1,26 @@
-'''
+"""
 RunPod | CLI | Entry
 
 The entry point for the CLI.
-'''
+"""
+
 import click
 
-from .groups.project.commands import project_cli
-
 from .groups.config.commands import config_wizard
-from .groups.ssh.commands import ssh_cli
-from .groups.pod.commands import pod_cli
 from .groups.exec.commands import exec_cli
+from .groups.pod.commands import pod_cli
+from .groups.project.commands import project_cli
+from .groups.ssh.commands import ssh_cli
+
 
 @click.group()
 def runpod_cli():
-    '''A collection of CLI functions for RunPod.'''
+    """A collection of CLI functions for RunPod."""
 
-runpod_cli.add_command(config_wizard) # runpod config
 
-runpod_cli.add_command(ssh_cli) # runpod ssh
-runpod_cli.add_command(pod_cli) # runpod pod
-runpod_cli.add_command(exec_cli) # runpod exec
-runpod_cli.add_command(project_cli) # runpod project
+runpod_cli.add_command(config_wizard)  # runpod config
+
+runpod_cli.add_command(ssh_cli)  # runpod ssh
+runpod_cli.add_command(pod_cli)  # runpod pod
+runpod_cli.add_command(exec_cli)  # runpod exec
+runpod_cli.add_command(project_cli)  # runpod project

--- a/runpod/cli/groups/__init__.py
+++ b/runpod/cli/groups/__init__.py
@@ -1,1 +1,1 @@
-''' Allow CLI groups to be imported from the runpod.cli module. '''
+""" Allow CLI groups to be imported from the runpod.cli module. """

--- a/runpod/cli/groups/config/__init__.py
+++ b/runpod/cli/groups/config/__init__.py
@@ -1,1 +1,1 @@
-''' Config related CLI functions. '''
+""" Config related CLI functions. """

--- a/runpod/cli/groups/config/commands.py
+++ b/runpod/cli/groups/config/commands.py
@@ -1,37 +1,45 @@
-'''
+"""
 Commands for the config command group
-'''
+"""
+
 import sys
+
 import click
 
-from .functions import set_credentials, check_credentials
+from .functions import check_credentials, set_credentials
 
-@click.command('config', help="Configures the RunPod CLI with the user's API key.")
-@click.argument('api-key', required=False, default=None)
-@click.option('--profile', default='default', help='The profile to set the credentials for.')
-@click.option('--check', is_flag=True, help='Check if credentials are already set.')
+
+@click.command("config", help="Configures the RunPod CLI with the user's API key.")
+@click.argument("api-key", required=False, default=None)
+@click.option(
+    "--profile", default="default", help="The profile to set the credentials for."
+)
+@click.option("--check", is_flag=True, help="Check if credentials are already set.")
 def config_wizard(api_key, profile, check):
-    """ Starts the configuration wizard to set up the RunPod CLI.
+    """Starts the configuration wizard to set up the RunPod CLI.
     If credentials are already set, prompts the user to overwrite them.
     """
     valid, error = check_credentials(profile)
 
     if check and valid:
-        click.echo('Credentials already set for profile: ' + profile)
+        click.echo("Credentials already set for profile: " + profile)
         sys.exit(0)
     elif check and not valid:
         click.echo(error)
         sys.exit(1)
 
     if valid:
-        click.confirm(f'Credentials already set for profile: {profile}. Overwrite?', abort=True)
+        click.confirm(
+            f"Credentials already set for profile: {profile}. Overwrite?", abort=True
+        )
 
     if api_key is None:
-        click.echo('Please enter your RunPod API Key.')
-        click.echo('You can find it at https://www.runpod.io/console/user/settings')
-        api_key = click.prompt('    > RunPod API Key', hide_input=False, confirmation_prompt=False)
-
+        click.echo("Please enter your RunPod API Key.")
+        click.echo("You can find it at https://www.runpod.io/console/user/settings")
+        api_key = click.prompt(
+            "    > RunPod API Key", hide_input=False, confirmation_prompt=False
+        )
 
     set_credentials(api_key, profile, overwrite=True)
 
-    click.echo(f'Credentials set for profile: {profile} in ~/.runpod/config.toml')
+    click.echo(f"Credentials set for profile: {profile} in ~/.runpod/config.toml")

--- a/runpod/cli/groups/config/functions.py
+++ b/runpod/cli/groups/config/functions.py
@@ -1,19 +1,20 @@
-'''
+"""
 runpod | cli | config.py
 
 A collection of functions to set and validate configurations.
 Configurations are TOML files located under ~/.runpod/
-'''
+"""
+
 import os
 from pathlib import Path
 
 import tomli as toml
 
-CREDENTIAL_FILE = os.path.expanduser('~/.runpod/config.toml')
+CREDENTIAL_FILE = os.path.expanduser("~/.runpod/config.toml")
 
 
-def set_credentials(api_key: str, profile:str="default", overwrite=False) -> None:
-    '''
+def set_credentials(api_key: str, profile: str = "default", overwrite=False) -> None:
+    """
     Sets the user's credentials in ~/.runpod/config.toml
     If profile already exists user must use `update_credentials` instead.
 
@@ -25,52 +26,57 @@ def set_credentials(api_key: str, profile:str="default", overwrite=False) -> Non
 
     [default]
     api_key = "RUNPOD_API_KEY"
-    '''
+    """
     os.makedirs(os.path.dirname(CREDENTIAL_FILE), exist_ok=True)
     Path(CREDENTIAL_FILE).touch(exist_ok=True)
 
     if not overwrite:
-        with open(CREDENTIAL_FILE, 'rb') as cred_file:
+        with open(CREDENTIAL_FILE, "rb") as cred_file:
             if profile in toml.load(cred_file):
-                raise ValueError('Profile already exists. Use `update_credentials` instead.')
+                raise ValueError(
+                    "Profile already exists. Use `update_credentials` instead."
+                )
 
-    with open(CREDENTIAL_FILE, 'w', encoding="UTF-8") as cred_file:
-        cred_file.write('[' + profile + ']\n')
+    with open(CREDENTIAL_FILE, "w", encoding="UTF-8") as cred_file:
+        cred_file.write("[" + profile + "]\n")
         cred_file.write('api_key = "' + api_key + '"\n')
 
 
-def check_credentials(profile:str="default"):
-    '''
+def check_credentials(profile: str = "default"):
+    """
     Checks if the credentials file exists and is valid.
-    '''
+    """
     if not os.path.exists(CREDENTIAL_FILE):
-        return False, '~/.runpod/config.toml does not exist.'
+        return False, "~/.runpod/config.toml does not exist."
 
     # Check for default api_key
     try:
-        with open(CREDENTIAL_FILE, 'rb') as cred_file:
+        with open(CREDENTIAL_FILE, "rb") as cred_file:
             config = toml.load(cred_file)
 
         if profile not in config:
-            return False, f'~/.runpod/config.toml is missing {profile} profile.'
+            return False, f"~/.runpod/config.toml is missing {profile} profile."
 
-        if 'api_key' not in config[profile]:
-            return False, f'~/.runpod/config.toml is missing api_key for {profile} profile.'
+        if "api_key" not in config[profile]:
+            return (
+                False,
+                f"~/.runpod/config.toml is missing api_key for {profile} profile.",
+            )
 
     except (TypeError, ValueError):
-        return False, '~/.runpod/config.toml is not a valid TOML file.'
+        return False, "~/.runpod/config.toml is not a valid TOML file."
 
     return True, None
 
 
-def get_credentials(profile='default'):
-    '''
+def get_credentials(profile="default"):
+    """
     Returns the credentials for the specified profile from ~/.runpod/config.toml
-    '''
+    """
     if not os.path.exists(CREDENTIAL_FILE):
         return None
 
-    with open(CREDENTIAL_FILE, 'rb') as cred_file:
+    with open(CREDENTIAL_FILE, "rb") as cred_file:
         credentials = toml.load(cred_file)
 
     if profile not in credentials:

--- a/runpod/cli/groups/exec/__init__.py
+++ b/runpod/cli/groups/exec/__init__.py
@@ -1,1 +1,1 @@
-''' A collection of CLI execution tools '''
+""" A collection of CLI execution tools """

--- a/runpod/cli/groups/exec/commands.py
+++ b/runpod/cli/groups/exec/commands.py
@@ -1,25 +1,27 @@
-'''
+"""
 RunPod | CLI | Exec | Commands
-'''
+"""
 
 import click
 
 from .functions import python_over_ssh
 from .helpers import get_session_pod
 
-@click.group('exec', help='Execute commands in a pods.')
-def exec_cli():
-    '''A collection of CLI functions for Exec.'''
 
-@exec_cli.command('python')
-@click.option('--pod_id', default=None, help='The pod ID to run the command on.')
-@click.argument('file', type=click.Path(exists=True), required=True)
+@click.group("exec", help="Execute commands in a pods.")
+def exec_cli():
+    """A collection of CLI functions for Exec."""
+
+
+@exec_cli.command("python")
+@click.option("--pod_id", default=None, help="The pod ID to run the command on.")
+@click.argument("file", type=click.Path(exists=True), required=True)
 def remote_python(pod_id, file):
-    '''
+    """
     Runs a remote Python shell.
-    '''
+    """
     if pod_id is None:
         pod_id = get_session_pod()
 
-    click.echo('Running remote Python shell...')
+    click.echo("Running remote Python shell...")
     python_over_ssh(pod_id, file)

--- a/runpod/cli/groups/exec/functions.py
+++ b/runpod/cli/groups/exec/functions.py
@@ -1,14 +1,15 @@
-'''
+"""
 RunPod | CLI | Exec | Functions
-'''
+"""
+
 from runpod.cli.utils import ssh_cmd
 
 
 def python_over_ssh(pod_id, file):
-    '''
+    """
     Runs a Python file over SSH.
-    '''
+    """
     ssh = ssh_cmd.SSHConnection(pod_id)
-    ssh.put_file(file, f'/root/{file}')
-    ssh.run_commands([f'python3.10 /root/{file}'])
+    ssh.put_file(file, f"/root/{file}")
+    ssh.run_commands([f"python3.10 /root/{file}"])
     ssh.close()

--- a/runpod/cli/groups/exec/helpers.py
+++ b/runpod/cli/groups/exec/helpers.py
@@ -1,11 +1,12 @@
 """Helper functions for the runpod cli group exec command"""
 
 import os
+
 import click
 
 from runpod import get_pod
 
-POD_ID_FILE = os.path.join(os.path.expanduser('~'), '.runpod', 'pod_id')
+POD_ID_FILE = os.path.join(os.path.expanduser("~"), ".runpod", "pod_id")
 
 
 def get_session_pod():
@@ -20,7 +21,7 @@ def get_session_pod():
     pod_id = None
 
     if os.path.exists(POD_ID_FILE):
-        with open(POD_ID_FILE, 'r', encoding="UTF-8") as pod_file:
+        with open(POD_ID_FILE, "r", encoding="UTF-8") as pod_file:
             pod_id = pod_file.read().strip()
 
     # Confirm that the pod_id is valid
@@ -28,9 +29,9 @@ def get_session_pod():
         return pod_id
 
     # If file doesn't exist or is empty, prompt user for the pod_id
-    pod_id = click.prompt('Please provide the pod ID')
+    pod_id = click.prompt("Please provide the pod ID")
     os.makedirs(os.path.dirname(POD_ID_FILE), exist_ok=True)
-    with open(POD_ID_FILE, 'w', encoding="UTF-8") as pod_file:
+    with open(POD_ID_FILE, "w", encoding="UTF-8") as pod_file:
         pod_file.write(pod_id)
 
     return pod_id

--- a/runpod/cli/groups/pod/__init__.py
+++ b/runpod/cli/groups/pod/__init__.py
@@ -1,1 +1,1 @@
-''' A collection of commands for managing pods. '''
+""" A collection of commands for managing pods. """

--- a/runpod/cli/groups/pod/commands.py
+++ b/runpod/cli/groups/pod/commands.py
@@ -1,64 +1,73 @@
-'''
+"""
 RunPod | CLI | Pod | Commands
-'''
+"""
+
 import click
 from prettytable import PrettyTable
 
-from runpod import get_pods, create_pod
+from runpod import create_pod, get_pods
 
 from ...utils import ssh_cmd
 
-@click.group('pod', help='Manage and interact with pods.')
-def pod_cli():
-    '''A collection of CLI functions for Pod.'''
 
-@pod_cli.command('list')
+@click.group("pod", help="Manage and interact with pods.")
+def pod_cli():
+    """A collection of CLI functions for Pod."""
+
+
+@pod_cli.command("list")
 def list_pods():
-    '''
+    """
     Lists the pods for the current user.
-    '''
-    table = PrettyTable(['ID', 'Name', 'Status', 'Image'])
+    """
+    table = PrettyTable(["ID", "Name", "Status", "Image"])
     for pod in get_pods():
-        table.add_row((pod['id'], pod['name'], pod['desiredStatus'], pod['imageName']))
+        table.add_row((pod["id"], pod["name"], pod["desiredStatus"], pod["imageName"]))
 
     click.echo(table)
 
-@pod_cli.command('create')
-@click.argument('name', required=False)
-@click.option('--image', default=None, help='The image to use for the pod.')
-@click.option('--gpu-type', default=None, help='The GPU type to use for the pod.')
-@click.option('--gpu-count', default=1, help='The number of GPUs to use for the pod.')
-@click.option('--support-public-ip', default=True, help='Whether or not to support a public IP.')
-def create_new_pod(name, image, gpu_type, gpu_count, support_public_ip): # pylint: disable=too-many-arguments
-    '''
+
+@pod_cli.command("create")
+@click.argument("name", required=False)
+@click.option("--image", default=None, help="The image to use for the pod.")
+@click.option("--gpu-type", default=None, help="The GPU type to use for the pod.")
+@click.option("--gpu-count", default=1, help="The number of GPUs to use for the pod.")
+@click.option(
+    "--support-public-ip", default=True, help="Whether or not to support a public IP."
+)
+def create_new_pod(
+    name, image, gpu_type, gpu_count, support_public_ip
+):  # pylint: disable=too-many-arguments
+    """
     Creates a pod.
-    '''
+    """
     kwargs = {
         "gpu_count": gpu_count,
         "support_public_ip": support_public_ip,
     }
 
     if not name:
-        name = click.prompt('Enter pod name', default='RunPod-CLI-Pod')
+        name = click.prompt("Enter pod name", default="RunPod-CLI-Pod")
 
-    quick_launch = click.confirm('Would you like to launch default pod?', abort=True)
+    quick_launch = click.confirm("Would you like to launch default pod?", abort=True)
     if quick_launch:
-        image = 'runpod/base:0.0.0'
-        gpu_type = 'NVIDIA GeForce RTX 3090'
-        kwargs["ports"] ='22/tcp'
+        image = "runpod/base:0.0.0"
+        gpu_type = "NVIDIA GeForce RTX 3090"
+        kwargs["ports"] = "22/tcp"
 
-        click.echo('Launching default pod...')
+        click.echo("Launching default pod...")
 
     new_pod = create_pod(name, image, gpu_type, **kwargs)
 
     click.echo(f'Pod {new_pod["id"]} has been created.')
 
-@pod_cli.command('connect')
-@click.argument('pod_id')
+
+@pod_cli.command("connect")
+@click.argument("pod_id")
 def connect_to_pod(pod_id):
-    '''
+    """
     Connects to a pod.
-    '''
-    click.echo(f'Connecting to pod {pod_id}...')
+    """
+    click.echo(f"Connecting to pod {pod_id}...")
     ssh = ssh_cmd.SSHConnection(pod_id)
     ssh.launch_terminal()

--- a/runpod/cli/groups/project/__init__.py
+++ b/runpod/cli/groups/project/__init__.py
@@ -1,1 +1,1 @@
-''' Allows project import '''
+""" Allows project import """

--- a/runpod/cli/groups/project/commands.py
+++ b/runpod/cli/groups/project/commands.py
@@ -1,37 +1,54 @@
-'''
+"""
 RunPod | CLI | Project | Commands
-'''
+"""
 
 import os
 import sys
+
 import click
 from InquirerPy import prompt as cli_select
 
 from runpod import get_user
-from .functions import create_new_project, start_project, create_project_endpoint
+
+from .functions import create_new_project, create_project_endpoint, start_project
 from .helpers import validate_project_name
 
 
-@click.group('project', help='Create, deploy, and manage RunPod projects.')
+@click.group("project", help="Create, deploy, and manage RunPod projects.")
 def project_cli():
-    ''' Create and deploy projects on RunPod. '''
+    """Create and deploy projects on RunPod."""
 
 
 # -------------------------------- New Project ------------------------------- #
-@project_cli.command('new')
-@click.option('--name', '-n', 'project_name', type=str, default=None, help="The project name.")
-@click.option('--type', '-t', 'model_type', type=click.Choice(['llama2'], case_sensitive=False),
-              default=None, help="The type of Hugging Face model.")
-@click.option('--model', '-m', 'model_name', type=str, default=None,
-              help="The name of the Hugging Face model. (e.g. meta-llama/Llama-2-7b)")
-@click.option('--init', '-i', 'init_current_dir', is_flag=True, default=False)
+@project_cli.command("new")
+@click.option(
+    "--name", "-n", "project_name", type=str, default=None, help="The project name."
+)
+@click.option(
+    "--type",
+    "-t",
+    "model_type",
+    type=click.Choice(["llama2"], case_sensitive=False),
+    default=None,
+    help="The type of Hugging Face model.",
+)
+@click.option(
+    "--model",
+    "-m",
+    "model_name",
+    type=str,
+    default=None,
+    help="The name of the Hugging Face model. (e.g. meta-llama/Llama-2-7b)",
+)
+@click.option("--init", "-i", "init_current_dir", is_flag=True, default=False)
 def new_project_wizard(project_name, model_type, model_name, init_current_dir):
-    """ Create a new project. """
-    network_volumes = get_user()['networkVolumes']
+    """Create a new project."""
+    network_volumes = get_user()["networkVolumes"]
     if len(network_volumes) == 0:
         click.echo("You do not have any network volumes.")
         click.echo(
-            "Please create a network volume (https://runpod.io/console/user/storage) and try again.")  # pylint: disable=line-too-long
+            "Please create a network volume (https://runpod.io/console/user/storage) and try again."
+        )  # pylint: disable=line-too-long
         sys.exit(1)
 
     click.echo("Creating a new project...")
@@ -46,33 +63,33 @@ def new_project_wizard(project_name, model_type, model_name, init_current_dir):
 
     def print_net_vol(vol):
         return {
-            'name': f"{vol['id']}: {vol['name']} ({vol['size']} GB, {vol['dataCenterId']})",
-            'value': vol['id']
+            "name": f"{vol['id']}: {vol['name']} ({vol['size']} GB, {vol['dataCenterId']})",
+            "value": vol["id"],
         }
 
     network_volumes = list(map(print_net_vol, network_volumes))
     questions = [
         {
-            'type': 'rawlist',
-            'name': 'volume-id',
-            'qmark': '',
-            'amark': '',
-            'message': '   > Select a Network Volume:',
-            'choices': network_volumes
+            "type": "rawlist",
+            "name": "volume-id",
+            "qmark": "",
+            "amark": "",
+            "message": "   > Select a Network Volume:",
+            "choices": network_volumes,
         }
     ]
-    runpod_volume_id = cli_select(questions)['volume-id']
+    runpod_volume_id = cli_select(questions)["volume-id"]
 
     cuda_version = click.prompt(
         "   > Select a CUDA version, or press enter to use the default",
-        type=click.Choice(['11.1.1', '11.8.0', '12.1.0'], case_sensitive=False),
-        default='11.8.0'
+        type=click.Choice(["11.1.1", "11.8.0", "12.1.0"], case_sensitive=False),
+        default="11.8.0",
     )
 
     python_version = click.prompt(
         "   > Select a Python version, or press enter to use the default",
-        type=click.Choice(['3.8', '3.9', '3.10', '3.11'], case_sensitive=False),
-        default='3.10'
+        type=click.Choice(["3.8", "3.9", "3.10", "3.11"], case_sensitive=False),
+        default="3.10",
     )
 
     click.echo("")
@@ -87,22 +104,35 @@ def new_project_wizard(project_name, model_type, model_name, init_current_dir):
     click.echo("The project will be created in the current directory.")
     click.confirm("Do you want to continue?", abort=True)
 
-    create_new_project(project_name, runpod_volume_id, cuda_version,
-                       python_version, model_type, model_name, init_current_dir)  # pylint: disable=too-many-arguments
+    create_new_project(
+        project_name,
+        runpod_volume_id,
+        cuda_version,
+        python_version,
+        model_type,
+        model_name,
+        init_current_dir,
+    )  # pylint: disable=too-many-arguments
 
     click.echo(f"Project {project_name} created successfully!")
     click.echo("")
-    click.echo("From your project root run `runpod project start` to start a development pod.")
+    click.echo(
+        "From your project root run `runpod project start` to start a development pod."
+    )
 
 
 # ------------------------------- Start Project ------------------------------ #
-@project_cli.command('start')
+@project_cli.command("start")
 def start_project_pod():
-    '''
+    """
     Start the project development pod from runpod.toml
-    '''
-    click.echo("Starting the project will create a development pod on RunPod, if one does not already exist.")  # pylint: disable=line-too-long
-    click.echo("    - You will be charged based on the GPU type specified in runpod.toml.")
+    """
+    click.echo(
+        "Starting the project will create a development pod on RunPod, if one does not already exist."
+    )  # pylint: disable=line-too-long
+    click.echo(
+        "    - You will be charged based on the GPU type specified in runpod.toml."
+    )
     click.echo("    - When you are finished close the connection with CTRL+C.")
     click.echo("")
     click.confirm("Do you want to continue?", abort=True)
@@ -113,9 +143,9 @@ def start_project_pod():
 
 
 # ------------------------------ Deploy Project ------------------------------ #
-@project_cli.command('deploy')
+@project_cli.command("deploy")
 def deploy_project():
-    """ Deploy the project to RunPod. """
+    """Deploy the project to RunPod."""
     click.echo("Deploying project...")
 
     endpoint_id = create_project_endpoint()

--- a/runpod/cli/groups/project/functions.py
+++ b/runpod/cli/groups/project/functions.py
@@ -1,6 +1,6 @@
-'''
+"""
 RunPod | CLI | Project | Functions
-'''
+"""
 
 import os
 import sys
@@ -8,59 +8,84 @@ import uuid
 from datetime import datetime
 
 import tomlkit
-from tomlkit import document, comment, table, nl
+from tomlkit import comment, document, nl, table
 
-from runpod import __version__, get_pod, create_template, create_endpoint, update_endpoint_template
-from runpod.cli import BASE_DOCKER_IMAGE, GPU_TYPES, ENV_VARS
-from runpod.cli.utils.ssh_cmd import SSHConnection
-from .helpers import (
-    get_project_pod, copy_template_files,
-    attempt_pod_launch, load_project_config, get_project_endpoint
+from runpod import (
+    __version__,
+    create_endpoint,
+    create_template,
+    get_pod,
+    update_endpoint_template,
 )
-from ...utils.rp_sync import sync_directory
+from runpod.cli import BASE_DOCKER_IMAGE, ENV_VARS, GPU_TYPES
+from runpod.cli.utils.ssh_cmd import SSHConnection
 
-STARTER_TEMPLATES = os.path.join(os.path.dirname(__file__), 'starter_templates')
+from ...utils.rp_sync import sync_directory
+from .helpers import (
+    attempt_pod_launch,
+    copy_template_files,
+    get_project_endpoint,
+    get_project_pod,
+    load_project_config,
+)
+
+STARTER_TEMPLATES = os.path.join(os.path.dirname(__file__), "starter_templates")
 
 
 def _launch_dev_pod():
-    """ Launch a development pod. """
+    """Launch a development pod."""
     config = load_project_config()  # Load runpod.toml
 
     print("Deploying development pod on RunPod...")
 
     # Prepare the environment variables
     environment_variables = {"RUNPOD_PROJECT_ID": config["project"]["uuid"]}
-    for variable in config['project'].get('env_vars', {}):
-        environment_variables[variable] = config['project']['env_vars'][variable]
+    for variable in config["project"].get("env_vars", {}):
+        environment_variables[variable] = config["project"]["env_vars"][variable]
 
     # Prepare the GPU types
-    selected_gpu_types = config['project'].get('gpu_types', [])
-    if config['project'].get('gpu', None):
-        selected_gpu_types.append(config['project']['gpu'])
+    selected_gpu_types = config["project"].get("gpu_types", [])
+    if config["project"].get("gpu", None):
+        selected_gpu_types.append(config["project"]["gpu"])
 
     # Attempt to launch a pod with the given configuration
     new_pod = attempt_pod_launch(config, environment_variables)
     if new_pod is None:
-        print("Selected GPU types unavailable, try again later or use a different type.")
+        print(
+            "Selected GPU types unavailable, try again later or use a different type."
+        )
         return None
 
     print("Waiting for pod to come online... ", end="")
     sys.stdout.flush()
 
     # Wait for the pod to come online
-    while new_pod.get('desiredStatus', None) != 'RUNNING' or new_pod.get('runtime') is None:
-        new_pod = get_pod(new_pod['id'])
+    while (
+        new_pod.get("desiredStatus", None) != "RUNNING"
+        or new_pod.get("runtime") is None
+    ):
+        new_pod = get_pod(new_pod["id"])
 
-    project_pod_id = new_pod['id']
+    project_pod_id = new_pod["id"]
 
-    print(f"Project {config['project']['name']} pod ({project_pod_id}) created.", end="\n\n")
+    print(
+        f"Project {config['project']['name']} pod ({project_pod_id}) created.",
+        end="\n\n",
+    )
     return project_pod_id
 
 
 # -------------------------------- New Project ------------------------------- #
-def create_new_project(project_name, runpod_volume_id, cuda_version, python_version,  # pylint: disable=too-many-locals, too-many-arguments, too-many-statements
-                       model_type=None, model_name=None, init_current_dir=False):
-    """ Create a new project. """
+def create_new_project(
+    project_name,
+    runpod_volume_id,
+    cuda_version,
+    python_version,  # pylint: disable=too-many-locals, too-many-arguments, too-many-statements
+    model_type=None,
+    model_name=None,
+    init_current_dir=False,
+):
+    """Create a new project."""
     if not init_current_dir:
         project_folder = os.path.join(os.getcwd(), project_name)
         if not os.path.exists(project_folder):
@@ -75,27 +100,29 @@ def create_new_project(project_name, runpod_volume_id, cuda_version, python_vers
 
         # Replace placeholders in requirements.txt
         requirements_path = os.path.join(project_folder, "builder/requirements.txt")
-        with open(requirements_path, 'r', encoding='utf-8') as requirements_file:
+        with open(requirements_path, "r", encoding="utf-8") as requirements_file:
             requirements_content = requirements_file.read()
 
         if "dev" in __version__:
             requirements_content = requirements_content.replace(
-                '<<RUNPOD>>', 'git+https://github.com/runpod/runpod-python.git')
+                "<<RUNPOD>>", "git+https://github.com/runpod/runpod-python.git"
+            )
         else:
             requirements_content = requirements_content.replace(
-                '<<RUNPOD>>', f'runpod=={__version__}')
+                "<<RUNPOD>>", f"runpod=={__version__}"
+            )
 
-        with open(requirements_path, 'w', encoding='utf-8') as requirements_file:
+        with open(requirements_path, "w", encoding="utf-8") as requirements_file:
             requirements_file.write(requirements_content)
 
         # If there's a model_name, replace placeholders in handler.py
         if model_name:
             handler_path = os.path.join(project_name, "src/handler.py")
-            with open(handler_path, 'r', encoding='utf-8') as file:
+            with open(handler_path, "r", encoding="utf-8") as file:
                 handler_content = file.read()
-                handler_content = handler_content.replace('<<MODEL_NAME>>', model_name)
+                handler_content = handler_content.replace("<<MODEL_NAME>>", model_name)
 
-            with open(handler_path, 'w', encoding='utf-8') as file:
+            with open(handler_path, "w", encoding="utf-8") as file:
                 file.write(handler_content)
     else:
         project_folder = os.getcwd()
@@ -103,7 +130,7 @@ def create_new_project(project_name, runpod_volume_id, cuda_version, python_vers
     project_uuid = str(uuid.uuid4())[:8]
 
     toml_config = document()
-    toml_config.add(comment('RunPod Project Configuration'))
+    toml_config.add(comment("RunPod Project Configuration"))
     toml_config.add(nl())
     toml_config.add("title", project_name)
 
@@ -131,13 +158,15 @@ def create_new_project(project_name, runpod_volume_id, cuda_version, python_vers
     runtime_table.add("requirements_path", "builder/requirements.txt")
     toml_config.add("runtime", runtime_table)
 
-    with open(os.path.join(project_folder, "runpod.toml"), 'w', encoding="UTF-8") as config_file:
+    with open(
+        os.path.join(project_folder, "runpod.toml"), "w", encoding="UTF-8"
+    ) as config_file:
         tomlkit.dump(toml_config, config_file)
 
 
 # ------------------------------- Start Project ------------------------------ #
 def start_project():  # pylint: disable=too-many-locals, too-many-branches
-    '''
+    """
     Start the project development environment from runpod.toml
     - Check if the project pod already exists.
 
@@ -151,14 +180,14 @@ def start_project():  # pylint: disable=too-many-locals, too-many-branches
 
     - If the project pod does exist:
 
-    '''
+    """
     config = load_project_config()  # Load runpod.toml
 
-    for config_item in config['project']:
+    for config_item in config["project"]:
         print(f'    - {config_item}: {config["project"][config_item]}')
     print("")
 
-    project_pod_id = get_project_pod(config['project']['uuid'])
+    project_pod_id = get_project_pod(config["project"]["uuid"])
 
     # Check if the project pod already exists, if not create it.
     if not project_pod_id:
@@ -169,28 +198,38 @@ def start_project():  # pylint: disable=too-many-locals, too-many-branches
 
     with SSHConnection(project_pod_id) as ssh_conn:
 
-        project_path_uuid = f'{config["project"]["volume_mount_path"]}/{config["project"]["uuid"]}'
-        project_path_uuid_dev = os.path.join(project_path_uuid, 'dev')
-        project_path_uuid_prod = os.path.join(project_path_uuid, 'prod')
-        remote_project_path = os.path.join(project_path_uuid_dev, config["project"]["name"])
+        project_path_uuid = (
+            f'{config["project"]["volume_mount_path"]}/{config["project"]["uuid"]}'
+        )
+        project_path_uuid_dev = os.path.join(project_path_uuid, "dev")
+        project_path_uuid_prod = os.path.join(project_path_uuid, "prod")
+        remote_project_path = os.path.join(
+            project_path_uuid_dev, config["project"]["name"]
+        )
 
         # Create the project folder on the pod
-        print(f'Checking pod project folder: {remote_project_path} on pod {project_pod_id}')
-        ssh_conn.run_commands([f'mkdir -p {remote_project_path} {project_path_uuid_prod}'])
+        print(
+            f"Checking pod project folder: {remote_project_path} on pod {project_pod_id}"
+        )
+        ssh_conn.run_commands(
+            [f"mkdir -p {remote_project_path} {project_path_uuid_prod}"]
+        )
 
         # Copy local files to the pod project folder
-        print(f'Syncing files to pod {project_pod_id}')
+        print(f"Syncing files to pod {project_pod_id}")
         ssh_conn.rsync(os.getcwd(), project_path_uuid_dev)
 
         # Create the virtual environment
         venv_path = os.path.join(project_path_uuid_dev, "venv")
-        print(f'Activating Python virtual environment: {venv_path} on pod {project_pod_id}')
+        print(
+            f"Activating Python virtual environment: {venv_path} on pod {project_pod_id}"
+        )
         commands = [
             f'python{config["runtime"]["python_version"]} -m virtualenv {venv_path}',
-            f'source {venv_path}/bin/activate &&'
-            f'cd {remote_project_path} &&'
-            'python -m pip install --upgrade pip &&'
-            f'python -m pip install -v --requirement {config["runtime"]["requirements_path"]}'
+            f"source {venv_path}/bin/activate &&"
+            f"cd {remote_project_path} &&"
+            "python -m pip install --upgrade pip &&"
+            f'python -m pip install -v --requirement {config["runtime"]["requirements_path"]}',
         ]
         ssh_conn.run_commands(commands)
 
@@ -198,10 +237,15 @@ def start_project():  # pylint: disable=too-many-locals, too-many-branches
         sync_directory(ssh_conn, os.getcwd(), project_path_uuid_dev)
 
         project_name = config["project"]["name"]
-        pip_req_path = os.path.join(remote_project_path, config['runtime']['requirements_path'])
-        handler_path = os.path.join(remote_project_path, config['runtime']['handler_path'])
+        pip_req_path = os.path.join(
+            remote_project_path, config["runtime"]["requirements_path"]
+        )
+        handler_path = os.path.join(
+            remote_project_path, config["runtime"]["handler_path"]
+        )
 
-        launch_api_server = [f'''
+        launch_api_server = [
+            f"""
             pkill inotify
 
             function force_kill {{
@@ -292,7 +336,8 @@ def start_project():  # pylint: disable=too-many-locals, too-many-branches
 
                 echo "Restarted API server with PID: $last_pid"
             done
-        ''']
+        """
+        ]
 
         print("")
         print("Starting project development endpoint...")
@@ -301,14 +346,14 @@ def start_project():  # pylint: disable=too-many-locals, too-many-branches
 
 # ------------------------------ Deploy Project ------------------------------ #
 def create_project_endpoint():
-    """ Create a project endpoint.
+    """Create a project endpoint.
     - Move code in dev to prod folder
     - TODO: git commit the diff from current state to new state
     - Create a serverless template for the project
     - Create a new endpoint using the template
     """
     config = load_project_config()
-    project_pod_id = get_project_pod(config['project']['uuid'])
+    project_pod_id = get_project_pod(config["project"]["uuid"])
 
     # Check if the project pod already exists, if not create it.
     if not project_pod_id:
@@ -318,58 +363,67 @@ def create_project_endpoint():
         return None
 
     with SSHConnection(project_pod_id) as ssh_conn:
-        project_path_uuid = f'{config["project"]["volume_mount_path"]}/{config["project"]["uuid"]}'
-        project_path_uuid_prod = os.path.join(project_path_uuid, 'prod')
-        remote_project_path = os.path.join(project_path_uuid_prod, config["project"]["name"])
+        project_path_uuid = (
+            f'{config["project"]["volume_mount_path"]}/{config["project"]["uuid"]}'
+        )
+        project_path_uuid_prod = os.path.join(project_path_uuid, "prod")
+        remote_project_path = os.path.join(
+            project_path_uuid_prod, config["project"]["name"]
+        )
 
         # Copy local files to the pod project folder
-        ssh_conn.run_commands([f'mkdir -p {remote_project_path}'])
-        print(f'Syncing files to pod {project_pod_id} prod')
+        ssh_conn.run_commands([f"mkdir -p {remote_project_path}"])
+        print(f"Syncing files to pod {project_pod_id} prod")
         ssh_conn.rsync(os.getcwd(), project_path_uuid_prod)
 
         # Create the virtual environment
-        venv_path = os.path.join(project_path_uuid_prod, 'venv')
-        print(f'Activating Python virtual environment: {venv_path} on pod {project_pod_id}')
+        venv_path = os.path.join(project_path_uuid_prod, "venv")
+        print(
+            f"Activating Python virtual environment: {venv_path} on pod {project_pod_id}"
+        )
         commands = [
             f'python{config["runtime"]["python_version"]} -m venv {venv_path}',
-            f'source {venv_path}/bin/activate &&'
-            f'cd {remote_project_path} &&'
-            'python -m pip install --upgrade pip &&'
-            f'python -m pip install -v --requirement {config["runtime"]["requirements_path"]}'
+            f"source {venv_path}/bin/activate &&"
+            f"cd {remote_project_path} &&"
+            "python -m pip install --upgrade pip &&"
+            f'python -m pip install -v --requirement {config["runtime"]["requirements_path"]}',
         ]
         ssh_conn.run_commands(commands)
         ssh_conn.close()
 
     environment_variables = {}
-    for variable in config['project']['env_vars']:
-        environment_variables[variable] = config['project']['env_vars'][variable]
+    for variable in config["project"]["env_vars"]:
+        environment_variables[variable] = config["project"]["env_vars"][variable]
 
     # Construct the docker start command
-    activate_cmd = f'. /runpod-volume/{config["project"]["uuid"]}/prod/venv/bin/activate'
+    activate_cmd = (
+        f'. /runpod-volume/{config["project"]["uuid"]}/prod/venv/bin/activate'
+    )
     python_cmd = f'python -u /runpod-volume/{config["project"]["uuid"]}/prod/{config["project"]["name"]}/{config["runtime"]["handler_path"]}'  # pylint: disable=line-too-long
-    docker_start_cmd = 'bash -c "' + activate_cmd + ' && ' + python_cmd + '"'
+    docker_start_cmd = 'bash -c "' + activate_cmd + " && " + python_cmd + '"'
 
     project_endpoint_template = create_template(
         name=f'{config["project"]["name"]}-endpoint | {config["project"]["uuid"]} | {datetime.now()}',  # pylint: disable=line-too-long
-        image_name=config['project']['base_image'],
-        container_disk_in_gb=config['project']['container_disk_size_gb'],
+        image_name=config["project"]["base_image"],
+        container_disk_in_gb=config["project"]["container_disk_size_gb"],
         docker_start_cmd=docker_start_cmd,
-        env=environment_variables, is_serverless=True
+        env=environment_variables,
+        is_serverless=True,
     )
 
-    deployed_endpoint = get_project_endpoint(config['project']['uuid'])
+    deployed_endpoint = get_project_endpoint(config["project"]["uuid"])
     if not deployed_endpoint:
         deployed_endpoint = create_endpoint(
             name=f'{config["project"]["name"]}-endpoint | {config["project"]["uuid"]}',
-            template_id=project_endpoint_template['id'],
-            network_volume_id=config['project']['storage_id'],
+            template_id=project_endpoint_template["id"],
+            network_volume_id=config["project"]["storage_id"],
         )
     else:
         deployed_endpoint = update_endpoint_template(
-            endpoint_id=deployed_endpoint['id'],
-            template_id=project_endpoint_template['id'],
+            endpoint_id=deployed_endpoint["id"],
+            template_id=project_endpoint_template["id"],
         )
 
     # does user want to tear down and recreate workers immediately?
 
-    return deployed_endpoint['id']
+    return deployed_endpoint["id"]

--- a/runpod/cli/groups/project/helpers.py
+++ b/runpod/cli/groups/project/helpers.py
@@ -1,23 +1,26 @@
 """Helper functions for project group commands."""
 
-import re
 import os
+import re
 import shutil
 
 import click
 import tomlkit
 
-from runpod import get_pods, create_pod, get_endpoints
+from runpod import create_pod
 from runpod import error as rp_error
+from runpod import get_endpoints, get_pods
 
 
 def validate_project_name(name):
-    '''
+    """
     Validate the project name.
-    '''
+    """
     match = re.search(r"[<>:\"/\\|?*\s]", name)
     if match:
-        raise click.BadParameter(f"Project name contains an invalid character: '{match.group()}'.")
+        raise click.BadParameter(
+            f"Project name contains an invalid character: '{match.group()}'."
+        )
     return name
 
 
@@ -26,8 +29,8 @@ def get_project_pod(project_id: str):
     Return the pod_id if it exists, else return None.
     """
     for pod in get_pods():
-        if project_id in pod['name']:
-            return pod['id']
+        if project_id in pod["name"]:
+            return pod["id"]
 
     return None
 
@@ -37,7 +40,7 @@ def get_project_endpoint(project_id: str):
     Return the endpoint if it exists, else return None.
     """
     for endpoint in get_endpoints():
-        if project_id in endpoint['name']:
+        if project_id in endpoint["name"]:
             return endpoint
 
     return None
@@ -56,20 +59,20 @@ def copy_template_files(template_dir, destination):
 
 def attempt_pod_launch(config, environment_variables):
     """Attempt to launch a pod with the given configuration."""
-    for gpu_type in config['project'].get('gpu_types', []):
+    for gpu_type in config["project"].get("gpu_types", []):
         print(f"Trying to get a pod with {gpu_type}... ", end="")
         try:
             created_pod = create_pod(
                 f'{config["project"]["name"]}-dev ({config["project"]["uuid"]})',
-                config['project']['base_image'],
+                config["project"]["base_image"],
                 gpu_type,
-                gpu_count=int(config['project']['gpu_count']),
+                gpu_count=int(config["project"]["gpu_count"]),
                 support_public_ip=True,
                 ports=f'{config["project"]["ports"]}',
                 network_volume_id=f'{config["project"]["storage_id"]}',
                 volume_mount_path=f'{config["project"]["volume_mount_path"]}',
                 container_disk_in_gb=int(config["project"]["container_disk_size_gb"]),
-                env=environment_variables
+                env=environment_variables,
             )
             print("Success!")
             return created_pod
@@ -80,8 +83,8 @@ def attempt_pod_launch(config, environment_variables):
 
 def load_project_config():
     """Load the project config file."""
-    project_config_file = os.path.join(os.getcwd(), 'runpod.toml')
+    project_config_file = os.path.join(os.getcwd(), "runpod.toml")
     if not os.path.exists(project_config_file):
         raise FileNotFoundError("runpod.toml not found in the current directory.")
-    with open(project_config_file, 'r', encoding="UTF-8") as config_file:
+    with open(project_config_file, "r", encoding="UTF-8") as config_file:
         return tomlkit.load(config_file)

--- a/runpod/cli/groups/project/starter_templates/default/src/handler.py
+++ b/runpod/cli/groups/project/starter_templates/default/src/handler.py
@@ -1,13 +1,15 @@
-''' A template for a handler file. '''
+""" A template for a handler file. """
 
 import runpod
 
+
 def handler(job):
-    '''
+    """
     This is the handler function for the job.
-    '''
-    job_input = job['input']
-    name = job_input.get('name', 'World')
+    """
+    job_input = job["input"]
+    name = job_input.get("name", "World")
     return f"Hello, {name}!"
+
 
 runpod.serverless.start({"handler": handler})

--- a/runpod/cli/groups/project/starter_templates/llama2/src/handler.py
+++ b/runpod/cli/groups/project/starter_templates/llama2/src/handler.py
@@ -1,11 +1,15 @@
-''' A template for a Llama2 handler file. '''
+""" A template for a Llama2 handler file. """
+
 # pylint: skip-file
 
-import runpod
 import inspect
+
 from transformers import HfApi
 
+import runpod
+
 SELECTED_MODEL = "<<MODEL_NAME>>"
+
 
 def get_model_framework(model_name):
     api = HfApi()
@@ -18,6 +22,7 @@ def get_model_framework(model_name):
         return "TensorFlow"
     else:
         return "Unknown"
+
 
 def prepare_inputs(text, **kwargs):
     # Filter kwargs based on what the tokenizer accepts
@@ -32,5 +37,6 @@ def handle_request(text, **input_args):
     with torch.no_grad():
         outputs = model(**inputs)
     return process_outputs(outputs)
+
 
 runpod.serverless.start({"handler": handle_request})

--- a/runpod/cli/groups/ssh/__init__.py
+++ b/runpod/cli/groups/ssh/__init__.py
@@ -1,3 +1,3 @@
-''' CLI functions for SSH. '''
+""" CLI functions for SSH. """
 
 from . import functions

--- a/runpod/cli/groups/ssh/commands.py
+++ b/runpod/cli/groups/ssh/commands.py
@@ -1,38 +1,46 @@
-'''
+"""
 RunPod | CLI | SSH | Commands
-'''
+"""
 
 import click
 from prettytable import PrettyTable
-from .functions import get_user_pub_keys, generate_ssh_key_pair
 
-@click.group('ssh', help='Manage and configure SSH keys for secure access to pods.')
+from .functions import generate_ssh_key_pair, get_user_pub_keys
+
+
+@click.group("ssh", help="Manage and configure SSH keys for secure access to pods.")
 def ssh_cli():
-    '''Manage and configure SSH keys.'''
+    """Manage and configure SSH keys."""
 
-@ssh_cli.command('list-keys')
+
+@ssh_cli.command("list-keys")
 def list_keys():
-    '''
+    """
     Lists the SSH keys for the current user.
-    '''
+    """
     key_list = get_user_pub_keys()
-    table = PrettyTable(['Public Key', 'Type', 'Fingerprint'])
+    table = PrettyTable(["Public Key", "Type", "Fingerprint"])
     for key in key_list:
-        table.add_row((key['name'], key['type'], key['fingerprint']))
+        table.add_row((key["name"], key["type"], key["fingerprint"]))
     click.echo(table)
 
-@ssh_cli.command('add-key')
-@click.option('--key', default=None, help='The public key to add.')
-@click.option('--key-file', default=None, help='The file containing the public key to add.')
+
+@ssh_cli.command("add-key")
+@click.option("--key", default=None, help="The public key to add.")
+@click.option(
+    "--key-file", default=None, help="The file containing the public key to add."
+)
 def add_key(key, key_file):
-    '''
+    """
     Adds an SSH key to the current user account.
     If no key is provided, one will be generated.
-    '''
+    """
     if not key and not key_file:
-        click.confirm('Would you like to add an SSH key to your account?', abort=True)
-        key_name = click.prompt('Please enter a name for this key', default='RunPod-Key', type=str)
-        key_name = key_name.replace(' ', '-')
+        click.confirm("Would you like to add an SSH key to your account?", abort=True)
+        key_name = click.prompt(
+            "Please enter a name for this key", default="RunPod-Key", type=str
+        )
+        key_name = key_name.replace(" ", "-")
         generate_ssh_key_pair(key_name)
 
-    click.echo('The key has been added to your account.')
+    click.echo("The key has been added to your account.")

--- a/runpod/cli/groups/ssh/functions.py
+++ b/runpod/cli/groups/ssh/functions.py
@@ -1,54 +1,55 @@
-'''
+"""
 RunPod | CLI | SSH | Functions
-'''
+"""
 
-import os
 import base64
 import hashlib
+import os
+
 import paramiko
 
 from runpod.api.ctl_commands import get_user, update_user_settings
 
-SSH_FILES = os.path.expanduser('~/.runpod/ssh')
+SSH_FILES = os.path.expanduser("~/.runpod/ssh")
 
 
 def get_ssh_key_fingerprint(public_key):
-    '''
+    """
     Get the fingerprint of an SSH key
-    '''
+    """
     parts = public_key.split()
     if len(parts) < 2:
         raise ValueError("Invalid SSH public key")
 
     key_data = base64.b64decode(parts[1])
     fingerprint = hashlib.sha256(key_data).digest()
-    return "SHA256:" + base64.b64encode(fingerprint).decode('utf-8').strip('=')
+    return "SHA256:" + base64.b64encode(fingerprint).decode("utf-8").strip("=")
 
 
 def get_user_pub_keys():
-    '''
+    """
     Get the current user's SSH keys
-    '''
+    """
     user = get_user()
-    keys = '' if user['pubKey'] is None else user['pubKey']
+    keys = "" if user["pubKey"] is None else user["pubKey"]
 
     # Parse the keys
-    keys = keys.split('\n')
-    keys = [key for key in keys if key != '']
+    keys = keys.split("\n")
+    keys = [key for key in keys if key != ""]
 
     key_list = []
     for key in keys:
-        key_parts = key.split(' ')
+        key_parts = key.split(" ")
 
         # Basic validation
         if len(key_parts) < 2:
             continue
 
         key_dict = {}
-        key_dict['type'] = key_parts[0]
-        key_dict['key'] = key_parts[1]
-        key_dict['fingerprint'] = get_ssh_key_fingerprint(key)
-        key_dict['name'] = key_parts[2] if len(key_parts) > 2 else "N/A"
+        key_dict["type"] = key_parts[0]
+        key_dict["key"] = key_parts[1]
+        key_dict["fingerprint"] = get_ssh_key_fingerprint(key)
+        key_dict["name"] = key_parts[2] if len(key_parts) > 2 else "N/A"
         key_list.append(key_dict)
 
     return key_list
@@ -86,14 +87,14 @@ def add_ssh_key(public_key):
     Checks if the key already exists before adding it.
     """
     user = get_user()
-    current_keys = '' if user['pubKey'] is None else user['pubKey']
+    current_keys = "" if user["pubKey"] is None else user["pubKey"]
 
     # Check if the key already exists
     if public_key in current_keys:
         print("Key already exists")
         return
 
-    updated_keys = current_keys + ('\n\n' if current_keys else '') + public_key
+    updated_keys = current_keys + ("\n\n" if current_keys else "") + public_key
 
     # Update the user's keys
     update_user_settings(f"{updated_keys}")

--- a/runpod/cli/utils/__init__.py
+++ b/runpod/cli/utils/__init__.py
@@ -1,3 +1,3 @@
-''' Collection of utility functions for the CLI '''
+""" Collection of utility functions for the CLI """
 
 from .rp_info import get_pod_ssh_ip_port

--- a/runpod/cli/utils/rp_info.py
+++ b/runpod/cli/utils/rp_info.py
@@ -7,32 +7,37 @@ import time
 
 from runpod import get_pod
 
+
 def get_pod_ssh_ip_port(pod_id, timeout=300):
-    '''
+    """
     Returns the IP and port for SSH access to a pod.
-    '''
+    """
     start_time = time.time()
     pod_ip = None
     pod_port = None
 
     while time.time() - start_time < timeout and (pod_ip is None or pod_port is None):
         pod = get_pod(pod_id)
-        desired_status = pod.get('desiredStatus', None)
-        runtime = pod.get('runtime', None)
+        desired_status = pod.get("desiredStatus", None)
+        runtime = pod.get("runtime", None)
 
-        if desired_status == 'RUNNING' and runtime and 'ports' in pod['runtime']:
-            for port in pod['runtime']['ports']:
-                if port['privatePort'] == 22:
-                    pod_ip = port['ip']
-                    pod_port = int(port['publicPort'])
+        if desired_status == "RUNNING" and runtime and "ports" in pod["runtime"]:
+            for port in pod["runtime"]["ports"]:
+                if port["privatePort"] == 22:
+                    pod_ip = port["ip"]
+                    pod_port = int(port["publicPort"])
                     break
 
         time.sleep(1)
 
-    if desired_status != 'RUNNING':
-        raise TimeoutError(f"Pod {pod_id} did not reach 'RUNNING' state within {timeout} seconds.")
+    if desired_status != "RUNNING":
+        raise TimeoutError(
+            f"Pod {pod_id} did not reach 'RUNNING' state within {timeout} seconds."
+        )
 
     if runtime is None:
-        raise TimeoutError(f"Pod {pod_id} did not report runtime data within {timeout} seconds.")
+        raise TimeoutError(
+            f"Pod {pod_id} did not report runtime data within {timeout} seconds."
+        )
 
     return pod_ip, pod_port

--- a/runpod/cli/utils/rp_runpodignore.py
+++ b/runpod/cli/utils/rp_runpodignore.py
@@ -1,48 +1,48 @@
 """ Reads the .runpodignore file and returns a list of files to ignore. """
 
-import os
 import fnmatch
+import os
 
 EXCLUDE_PATTERNS = [
-        "__pycache__/",
-        "*.pyc",
-        ".*.swp",
-        ".git/",
-        "*.tmp",
-        "*.log",
-    ]
+    "__pycache__/",
+    "*.pyc",
+    ".*.swp",
+    ".git/",
+    "*.tmp",
+    "*.log",
+]
 
 
 def get_ignore_list():
-    """ Reads the .runpodignore file and returns a list of files to ignore. """
+    """Reads the .runpodignore file and returns a list of files to ignore."""
     ignore_list = EXCLUDE_PATTERNS.copy()
-    ignore_file = os.path.join(os.getcwd(), '.runpodignore')
+    ignore_file = os.path.join(os.getcwd(), ".runpodignore")
 
     if not os.path.isfile(ignore_file):
         return ignore_list
 
-    with open(ignore_file, 'r', encoding="UTF-8") as ignore_file_handle:
+    with open(ignore_file, "r", encoding="UTF-8") as ignore_file_handle:
         for line in ignore_file_handle:
             stripped_line = line.strip()
-            if stripped_line and not stripped_line.startswith('#'):
+            if stripped_line and not stripped_line.startswith("#"):
                 ignore_list.append(stripped_line)
 
     return ignore_list
 
 
 def should_ignore(file_path, ignore_list=None):
-    """ Returns True if the file should be ignored, False otherwise. """
+    """Returns True if the file should be ignored, False otherwise."""
     if ignore_list is None:
         ignore_list = get_ignore_list()
 
     relative_path = os.path.relpath(file_path, os.getcwd())
 
     for pattern in ignore_list:
-        if pattern.startswith('/'):
+        if pattern.startswith("/"):
             pattern = pattern[1:]
 
-        if pattern.endswith('/'):
-            pattern += '*'
+        if pattern.endswith("/"):
+            pattern += "*"
 
         if fnmatch.fnmatch(relative_path, pattern):
             return True

--- a/runpod/cli/utils/rp_sync.py
+++ b/runpod/cli/utils/rp_sync.py
@@ -2,14 +2,16 @@
 Watches a directory for changes and syncs them to a remote directory.
 """
 
-import time
 import threading
+import time
 
-from watchdog.observers.polling import PollingObserver as Observer
 from watchdog.events import FileSystemEventHandler
+from watchdog.observers.polling import PollingObserver as Observer
 
 from runpod.cli import STOP_EVENT
+
 from .rp_runpodignore import get_ignore_list, should_ignore
+
 
 class WatcherHandler(FileSystemEventHandler):
     """Watches a directory for changes and syncs them to a remote directory."""
@@ -22,7 +24,7 @@ class WatcherHandler(FileSystemEventHandler):
         self.debouncer = None
 
     def on_any_event(self, event):
-        """ Called on any event. """
+        """Called on any event."""
         if event.is_directory or should_ignore(event.src_path, self.ignore_list):
             return
 
@@ -32,6 +34,7 @@ class WatcherHandler(FileSystemEventHandler):
         # Start a new timer that will call the action function after 1 second
         self.debouncer = threading.Timer(0.5, self.action_function)
         self.debouncer.start()
+
 
 def start_watcher(action_function, local_path):
     """
@@ -49,14 +52,16 @@ def start_watcher(action_function, local_path):
         observer.stop()
         observer.join()
 
+
 def sync_directory(ssh_client, local_path, remote_path):
     """
     Syncs a local directory to a remote directory.
     """
+
     def sync():
         print("Syncing files...")
         ssh_client.rsync(local_path, remote_path, quiet=True)
 
     threading.Thread(target=start_watcher, daemon=True, args=(sync, local_path)).start()
 
-    return sync # For testing purposes
+    return sync  # For testing purposes

--- a/runpod/cli/utils/rp_userspace.py
+++ b/runpod/cli/utils/rp_userspace.py
@@ -1,8 +1,11 @@
-'''
+"""
 RunPod | CLI | Utils | Userspace
-'''
+"""
+
 import os
+
 import paramiko
+
 from runpod import SSH_KEY_PATH
 
 
@@ -20,11 +23,11 @@ def find_ssh_key_file(pod_ip, pod_port):
     for file in os.listdir(SSH_KEY_PATH):
         file_path = os.path.join(SSH_KEY_PATH, file)
 
-        if not os.path.isfile(file_path) or file.endswith('.pub'):
+        if not os.path.isfile(file_path) or file.endswith(".pub"):
             continue
 
         try:
-            ssh.connect(pod_ip, port=pod_port, username='root', key_filename=file_path)
+            ssh.connect(pod_ip, port=pod_port, username="root", key_filename=file_path)
             ssh.close()
             print(f"Connected to pod {pod_ip}:{pod_port} using key {file}")
             return file_path

--- a/runpod/cli/utils/ssh_cmd.py
+++ b/runpod/cli/utils/ssh_cmd.py
@@ -1,25 +1,28 @@
-'''
+"""
 RunPod | CLI | Utils | SSH Command
 
 Connect and run commands over SSH.
-'''
-import sys
+"""
+
 import signal
-import threading
 import subprocess
+import sys
+import threading
+
 import colorama
 import paramiko
 
 from runpod.cli import STOP_EVENT
+
 from .rp_info import get_pod_ssh_ip_port
-from .rp_userspace import find_ssh_key_file
 from .rp_runpodignore import get_ignore_list
+from .rp_userspace import find_ssh_key_file
 
 colorama.init(autoreset=True)  # Initialize colorama
 
 
 class SSHConnection:
-    ''' Connect and run commands over SSH. '''
+    """Connect and run commands over SSH."""
 
     def __init__(self, pod_id):
         self.pod_id = pod_id
@@ -30,8 +33,12 @@ class SSHConnection:
 
             self.ssh = paramiko.SSHClient()
             self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            self.ssh.connect(self.pod_ip, port=self.pod_port,
-                             username='root', key_filename=self.key_file)
+            self.ssh.connect(
+                self.pod_ip,
+                port=self.pod_port,
+                username="root",
+                key_filename=self.key_file,
+            )
         except paramiko.SSHException as err:
             print(colorama.Fore.RED + f"[{pod_id}]", err)
             sys.exit(1)
@@ -46,16 +53,20 @@ class SSHConnection:
         self.close()
 
     def _get_ssh_options(self):
-        """ Get the SSH options for connecting to the pod. """
+        """Get the SSH options for connecting to the pod."""
         return [
-            "-o", "StrictHostKeyChecking=no",
-            "-o", "LogLevel=ERROR",
-            "-p", str(self.pod_port),
-            "-i", self.key_file
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "LogLevel=ERROR",
+            "-p",
+            str(self.pod_port),
+            "-i",
+            self.key_file,
         ]
 
     def _signal_handler(self, signum, frame):
-        ''' Handle signals. '''
+        """Handle signals."""
         del signum, frame
         self.close()
         print(colorama.Fore.BLUE + f"[{self.pod_id}]", "SSH Connection Closed")
@@ -63,25 +74,34 @@ class SSHConnection:
         sys.exit(0)
 
     def run_commands(self, commands):
-        ''' Runs a list of bash commands over SSH. '''
+        """Runs a list of bash commands over SSH."""
+
         def handle_stream(stream, color, prefix):
             for line in stream:
                 if line:
                     print(color + f"[{prefix}]", line.strip())
 
         for command in commands:
-            full_command = ' && '.join([
-                'source /root/.bashrc',
-                'source /etc/rp_environment',
-                'while IFS= read -r -d \'\' line; do export "$line"; done < /proc/1/environ',
-                command
-            ])
+            full_command = " && ".join(
+                [
+                    "source /root/.bashrc",
+                    "source /etc/rp_environment",
+                    "while IFS= read -r -d '' line; do export \"$line\"; done < /proc/1/environ",
+                    command,
+                ]
+            )
             _, stdout, stderr = self.ssh.exec_command(full_command)
 
             stdout_thread = threading.Thread(
-                target=handle_stream, args=(stdout, colorama.Fore.GREEN, self.pod_id), daemon=True)
+                target=handle_stream,
+                args=(stdout, colorama.Fore.GREEN, self.pod_id),
+                daemon=True,
+            )
             stderr_thread = threading.Thread(
-                target=handle_stream, args=(stderr, colorama.Fore.RED, self.pod_id), daemon=True)
+                target=handle_stream,
+                args=(stderr, colorama.Fore.RED, self.pod_id),
+                daemon=True,
+            )
 
             stdout_thread.start()
             stderr_thread.start()
@@ -90,23 +110,23 @@ class SSHConnection:
             stderr_thread.join()
 
     def put_file(self, local_path, remote_path):
-        ''' Copy local file to remote machine over SSH. '''
+        """Copy local file to remote machine over SSH."""
         with self.ssh.open_sftp() as sftp:
             sftp.put(local_path, remote_path)
 
     def get_file(self, remote_path, local_path):
-        ''' Fetch a remote file to local machine over SSH. '''
+        """Fetch a remote file to local machine over SSH."""
         with self.ssh.open_sftp() as sftp:
             sftp.get(remote_path, local_path)
 
     def launch_terminal(self):
-        ''' Launch an interactive terminal over SSH. '''
+        """Launch an interactive terminal over SSH."""
         cmd = ["ssh"] + self._get_ssh_options() + [f"root@{self.pod_ip}"]
 
         subprocess.run(cmd, check=True)
 
     def rsync(self, local_path, remote_path, quiet=False):
-        """ Sync a local directory to a remote directory over SSH.
+        """Sync a local directory to a remote directory over SSH.
 
         A .runpodignore file can be used to ignore files and directories.
         This file should be placed in the root of the local directory to sync.
@@ -123,15 +143,17 @@ class SSHConnection:
         if quiet:
             rsync_cmd.append("--quiet")
 
-        rsync_cmd.extend([
-            "-e", f"ssh {' '.join(self._get_ssh_options())}",
-            local_path,
-            f"root@{self.pod_ip}:{remote_path}"
-        ])
+        rsync_cmd.extend(
+            [
+                "-e",
+                f"ssh {' '.join(self._get_ssh_options())}",
+                local_path,
+                f"root@{self.pod_ip}:{remote_path}",
+            ]
+        )
 
         return subprocess.run(rsync_cmd, check=True)
 
-
     def close(self):
-        ''' Close the SSH connection. '''
+        """Close the SSH connection."""
         self.ssh.close()

--- a/runpod/endpoint/__init__.py
+++ b/runpod/endpoint/__init__.py
@@ -1,5 +1,5 @@
-''' Allows endpoints to be imported as a module. '''
+""" Allows endpoints to be imported as a module. """
 
-from .runner import Endpoint, Job
 from .asyncio.asyncio_runner import Endpoint as AsyncioEndpoint
 from .asyncio.asyncio_runner import Job as AsyncioJob
+from .runner import Endpoint, Job

--- a/runpod/endpoint/asyncio/asyncio_runner.py
+++ b/runpod/endpoint/asyncio/asyncio_runner.py
@@ -1,18 +1,22 @@
 """ Module for running endpoints asynchronously. """
+
 # pylint: disable=too-few-public-methods,R0801
 
-from typing import Any, Dict
 import asyncio
+from typing import Any, Dict
 
-from runpod.http_client import ClientSession
 from runpod.endpoint.helpers import FINAL_STATES, is_completed
+from runpod.http_client import ClientSession
 
 
 class Job:
     """Class representing a job for an asynchronous endpoint"""
 
     def __init__(self, endpoint_id: str, job_id: str, session: ClientSession):
-        from runpod import api_key, endpoint_url_base  # pylint: disable=import-outside-toplevel,cyclic-import
+        from runpod import (  # pylint: disable=import-outside-toplevel,cyclic-import
+            api_key,
+            endpoint_url_base,
+        )
 
         self.endpoint_id = endpoint_id
         self.job_id = job_id
@@ -28,12 +32,14 @@ class Job:
         self.job_output = None
 
     async def _fetch_job(self, source: str = "status") -> Dict[str, Any]:
-        """ Returns the raw json of the status, reaises an exception if invalid.
+        """Returns the raw json of the status, reaises an exception if invalid.
 
         Args:
             source: The URL source path of the job status.
         """
-        status_url = f"{self.endpoint_url_base}/{self.endpoint_id}/{source}/{self.job_id}"
+        status_url = (
+            f"{self.endpoint_url_base}/{self.endpoint_id}/{source}/{self.job_id}"
+        )
         job_state = await self.session.get(status_url, headers=self.headers)
         job_state = await job_state.json()
 
@@ -79,7 +85,7 @@ class Job:
         return job_data.get("output", None)
 
     async def stream(self) -> Any:
-        """ Returns a generator that yields the output of the job request. """
+        """Returns a generator that yields the output of the job request."""
         while True:
             await asyncio.sleep(1)
             stream_partial = await self._fetch_job(source="stream")
@@ -102,13 +108,14 @@ class Endpoint:
     """Class for running endpoint"""
 
     def __init__(self, endpoint_id: str, session: ClientSession):
-        from runpod import api_key, endpoint_url_base  # pylint: disable=import-outside-toplevel
+        from runpod import api_key  # pylint: disable=import-outside-toplevel
+        from runpod import endpoint_url_base
 
         self.endpoint_id = endpoint_id
         self.endpoint_url = f"{endpoint_url_base}/{self.endpoint_id}/run"
         self.headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {api_key}"
+            "Authorization": f"Bearer {api_key}",
         }
         self.session = session
 
@@ -134,7 +141,9 @@ class Endpoint:
         Returns:
             Health of endpoint
         """
-        async with self.session.get(f"{self.endpoint_id}/health", headers=self.headers) as resp:
+        async with self.session.get(
+            f"{self.endpoint_id}/health", headers=self.headers
+        ) as resp:
             return await resp.json()
 
     async def purge_queue(self) -> dict:
@@ -143,5 +152,7 @@ class Endpoint:
         Returns:
             Purge status
         """
-        async with self.session.post(f"{self.endpoint_id}/purge", headers=self.headers) as resp:
+        async with self.session.post(
+            f"{self.endpoint_id}/purge", headers=self.headers
+        ) as resp:
             return await resp.json()

--- a/runpod/endpoint/helpers.py
+++ b/runpod/endpoint/helpers.py
@@ -4,10 +4,13 @@ FINAL_STATES = ["COMPLETED", "FAILED", "TIMED_OUT"]
 
 # Exception Messages
 UNAUTHORIZED_MSG = "401 Unauthorized | Make sure Runpod API key is set and valid."
-API_KEY_NOT_SET_MSG = ("Expected `run_pod.api_key` to be initialized. "
-                       "You can solve this by setting `run_pod.api_key = 'your-key'. "
-                       "An API key can be generated at "
-                       "https://runpod.io/console/user/settings")
+API_KEY_NOT_SET_MSG = (
+    "Expected `run_pod.api_key` to be initialized. "
+    "You can solve this by setting `run_pod.api_key = 'your-key'. "
+    "An API key can be generated at "
+    "https://runpod.io/console/user/settings"
+)
+
 
 def is_completed(status: str) -> bool:
     """Returns true if status is one of the possible final states for a serverless request."""

--- a/runpod/error.py
+++ b/runpod/error.py
@@ -1,16 +1,17 @@
-'''
+"""
 runpd | error.py
 
 This file contains the error classes for the runpod package.
-'''
+"""
 
 from typing import Optional
 
 
 class RunPodError(Exception):
-    '''
+    """
     Base class for all runpod errors
-    '''
+    """
+
     def __init__(self, message: Optional[str] = None):
         super().__init__(message)
         self.message = message
@@ -22,15 +23,16 @@ class RunPodError(Exception):
 
 
 class AuthenticationError(RunPodError):
-    '''
+    """
     Raised when authentication fails
-    '''
+    """
 
 
 class QueryError(RunPodError):
-    '''
+    """
     Raised when a GraphQL query fails
-    '''
+    """
+
     def __init__(self, message: Optional[str] = None, query: Optional[str] = None):
         super().__init__(message)
         self.query = query

--- a/runpod/http_client.py
+++ b/runpod/http_client.py
@@ -3,17 +3,12 @@ HTTP Client abstractions
 """
 
 import os
+
 import requests
-from aiohttp import (
-    ClientSession,
-    ClientTimeout,
-    TCPConnector,
-)
-from .tracer import (
-    create_aiohttp_tracer,
-    create_request_tracer,
-)
+from aiohttp import ClientSession, ClientTimeout, TCPConnector
+
 from .cli.groups.config.functions import get_credentials
+from .tracer import create_aiohttp_tracer, create_request_tracer
 from .user_agent import USER_AGENT
 
 
@@ -34,7 +29,7 @@ def get_auth_header():
     }
 
 
-def AsyncClientSession(*args, **kwargs): # pylint: disable=invalid-name
+def AsyncClientSession(*args, **kwargs):  # pylint: disable=invalid-name
     """
     Deprecation from aiohttp.ClientSession forbids inheritance.
     This is now a factory method

--- a/runpod/serverless/__init__.py
+++ b/runpod/serverless/__init__.py
@@ -4,21 +4,21 @@ Contains the main entrypoint for the RunPod Serverless Worker.
 Arguments can be passed in when the worker is started, and will be passed to the worker.
 """
 
-import os
-import sys
-import json
-import time
-import signal
 import argparse
-from typing import Dict, Any
+import json
+import os
+import signal
+import sys
+import time
+from typing import Any, Dict
 
 from runpod.serverless import core
+
+from ..version import __version__ as runpod_version
 from . import worker
 from .modules import rp_fastapi
 from .modules.rp_logger import RunPodLogger
 from .modules.rp_progress import progress_update
-from ..version import __version__ as runpod_version
-
 
 log = RunPodLogger()
 
@@ -27,29 +27,53 @@ log = RunPodLogger()
 # ---------------------------------------------------------------------------- #
 # Arguments will be passed in with the config under the key "rp_args"
 parser = argparse.ArgumentParser(
-    prog="runpod",
-    description="Runpod Serverless Worker Arguments."
+    prog="runpod", description="Runpod Serverless Worker Arguments."
 )
-parser.add_argument("--rp_log_level", type=str, default=None,
-                    help="""Controls what level of logs are printed to the console.
-                    Options: ERROR, WARN, INFO, and DEBUG.""")
+parser.add_argument(
+    "--rp_log_level",
+    type=str,
+    default=None,
+    help="""Controls what level of logs are printed to the console.
+                    Options: ERROR, WARN, INFO, and DEBUG.""",
+)
 
-parser.add_argument("--rp_debugger", action="store_true", default=None,
-                    help="Flag to enable the Debugger.")
+parser.add_argument(
+    "--rp_debugger",
+    action="store_true",
+    default=None,
+    help="Flag to enable the Debugger.",
+)
 
 # Hosted API
-parser.add_argument("--rp_serve_api", action="store_true", default=None,
-                    help="Flag to start the API server.")
-parser.add_argument("--rp_api_port", type=int, default=8000,
-                    help="Port to start the FastAPI server on.")
-parser.add_argument("--rp_api_concurrency", type=int, default=1,
-                    help="Number of concurrent FastAPI workers.")
-parser.add_argument("--rp_api_host", type=str, default="localhost",
-                    help="Host to start the FastAPI server on.")
+parser.add_argument(
+    "--rp_serve_api",
+    action="store_true",
+    default=None,
+    help="Flag to start the API server.",
+)
+parser.add_argument(
+    "--rp_api_port", type=int, default=8000, help="Port to start the FastAPI server on."
+)
+parser.add_argument(
+    "--rp_api_concurrency",
+    type=int,
+    default=1,
+    help="Number of concurrent FastAPI workers.",
+)
+parser.add_argument(
+    "--rp_api_host",
+    type=str,
+    default="localhost",
+    help="Host to start the FastAPI server on.",
+)
 
 # Test input
-parser.add_argument("--test_input", type=str, default=None,
-                    help="Test input for the worker, formatted as JSON.")
+parser.add_argument(
+    "--test_input",
+    type=str,
+    default=None,
+    help="Test input for the worker, formatted as JSON.",
+)
 
 
 def _set_config_args(config) -> dict:
@@ -129,9 +153,9 @@ def start(config: Dict[str, Any]):
         api_server = rp_fastapi.WorkerAPI(config)
 
         api_server.start_uvicorn(
-            api_host=config['rp_args']['rp_api_host'],
-            api_port=config['rp_args']['rp_api_port'],
-            api_concurrency=config['rp_args']['rp_api_concurrency']
+            api_host=config["rp_args"]["rp_api_host"],
+            api_port=config["rp_args"]["rp_api_port"],
+            api_concurrency=config["rp_args"]["rp_api_concurrency"],
         )
 
     elif realtime_port:
@@ -139,13 +163,15 @@ def start(config: Dict[str, Any]):
         api_server = rp_fastapi.WorkerAPI(config)
 
         api_server.start_uvicorn(
-            api_host='0.0.0.0',
+            api_host="0.0.0.0",
             api_port=realtime_port,
-            api_concurrency=realtime_concurrency
+            api_concurrency=realtime_concurrency,
         )
 
     # --------------------------------- SLS-Core --------------------------------- #
-    elif os.environ.get("RUNPOD_USE_CORE", None) or os.environ.get("RUNPOD_CORE_PATH", None):
+    elif os.environ.get("RUNPOD_USE_CORE", None) or os.environ.get(
+        "RUNPOD_CORE_PATH", None
+    ):
         log.info("Starting worker with SLS-Core.")
         core.main(config)
 

--- a/runpod/serverless/core.py
+++ b/runpod/serverless/core.py
@@ -1,17 +1,17 @@
 """ Core functionality for the runpod serverless worker. """
 
+import asyncio
 import ctypes
 import inspect
 import json
 import os
 import pathlib
-import asyncio
 from ctypes import CDLL, byref, c_char_p, c_int
-from typing import Any, Callable,  List, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
-from runpod.version import __version__ as runpod_version
-from runpod.serverless.modules.rp_logger import RunPodLogger
 from runpod.serverless.modules import rp_job
+from runpod.serverless.modules.rp_logger import RunPodLogger
+from runpod.version import __version__ as runpod_version
 
 log = RunPodLogger()
 
@@ -32,7 +32,7 @@ class CGetJobResult(ctypes.Structure):  # pylint: disable=too-few-public-methods
 
 
 class Hook:  # pylint: disable=too-many-instance-attributes
-    """ Singleton class for interacting with sls_core.so"""
+    """Singleton class for interacting with sls_core.so"""
 
     _instance = None
 
@@ -58,13 +58,17 @@ class Hook:  # pylint: disable=too-many-instance-attributes
             default_path = os.path.join(
                 pathlib.Path(__file__).parent.absolute(), "sls_core.so"
             )
-            self.rust_so_path = os.environ.get("RUNPOD_SLS_CORE_PATH", str(default_path))
+            self.rust_so_path = os.environ.get(
+                "RUNPOD_SLS_CORE_PATH", str(default_path)
+            )
         else:
             self.rust_so_path = rust_so_path
 
         rust_library = CDLL(self.rust_so_path)
         buffer = ctypes.create_string_buffer(1024)  # 1 KiB
-        num_bytes = rust_library._runpod_sls_crate_version(byref(buffer), c_int(len(buffer)))
+        num_bytes = rust_library._runpod_sls_crate_version(
+            byref(buffer), c_int(len(buffer))
+        )
 
         self.rust_crate_version = buffer.raw[:num_bytes].decode("utf-8")
 
@@ -75,24 +79,30 @@ class Hook:  # pylint: disable=too-many-instance-attributes
         # Progress Update
         self._progress_update = rust_library._runpod_sls_progress_update
         self._progress_update.argtypes = [
-            c_char_p, c_int,  # id_ptr, id_len
-            c_char_p, c_int  # json_ptr, json_len
+            c_char_p,
+            c_int,  # id_ptr, id_len
+            c_char_p,
+            c_int,  # json_ptr, json_len
         ]
         self._progress_update.restype = c_int  # 1 if success, 0 if failure
 
         # Stream Output
         self._stream_output = rust_library._runpod_sls_stream_output
         self._stream_output.argtypes = [
-            c_char_p, c_int,  # id_ptr, id_len
-            c_char_p, c_int,  # json_ptr, json_len
+            c_char_p,
+            c_int,  # id_ptr, id_len
+            c_char_p,
+            c_int,  # json_ptr, json_len
         ]
         self._stream_output.restype = c_int  # 1 if success, 0 if failure
 
         # Post Output
         self._post_output = rust_library._runpod_sls_post_output
         self._post_output.argtypes = [
-            c_char_p, c_int,  # id_ptr, id_len
-            c_char_p, c_int,  # json_ptr, json_len
+            c_char_p,
+            c_int,  # id_ptr, id_len
+            c_char_p,
+            c_int,  # json_ptr, json_len
         ]
         self._post_output.restype = c_int  # 1 if success, 0 if failure
 
@@ -114,13 +124,19 @@ class Hook:  # pylint: disable=too-many-instance-attributes
 
     def get_jobs(self, max_concurrency: int, max_jobs: int) -> List[Dict[str, Any]]:
         """Get a job or jobs from the queue. The jobs are returned as a list of Job objects."""
-        buffer = ctypes.create_string_buffer(1024 * 1024 * 20)  # 20MB buffer to store jobs in
+        buffer = ctypes.create_string_buffer(
+            1024 * 1024 * 20
+        )  # 20MB buffer to store jobs in
         destination_length = len(buffer.raw)
         result: CGetJobResult = self._get_jobs(
-            c_int(max_concurrency), c_int(max_jobs),
-            byref(buffer), c_int(destination_length)
+            c_int(max_concurrency),
+            c_int(max_jobs),
+            byref(buffer),
+            c_int(destination_length),
         )
-        if result.status_code == 1:  # success! the job was stored bytes 0..res_len of buf.raw
+        if (
+            result.status_code == 1
+        ):  # success! the job was stored bytes 0..res_len of buf.raw
             return list(json.loads(buffer.raw[: result.res_len].decode("utf-8")))
 
         if result.status_code not in [0, 1]:
@@ -133,10 +149,14 @@ class Hook:  # pylint: disable=too-many-instance-attributes
         send a progress update to AI-API.
         """
         id_bytes = job_id.encode("utf-8")
-        return bool(self._progress_update(
-            c_char_p(id_bytes), c_int(len(id_bytes)),
-            c_char_p(json_data), c_int(len(json_data))
-        ))
+        return bool(
+            self._progress_update(
+                c_char_p(id_bytes),
+                c_int(len(id_bytes)),
+                c_char_p(json_data),
+                c_int(len(json_data)),
+            )
+        )
 
     async def stream_output(self, job_id: str, job_output: bytes) -> bool:
         """
@@ -144,10 +164,14 @@ class Hook:  # pylint: disable=too-many-instance-attributes
         """
         json_data = self._json_serialize_job_data(job_output)
         id_bytes = job_id.encode("utf-8")
-        return bool(self._stream_output(
-            c_char_p(id_bytes), c_int(len(id_bytes)),
-            c_char_p(json_data), c_int(len(json_data))
-        ))
+        return bool(
+            self._stream_output(
+                c_char_p(id_bytes),
+                c_int(len(id_bytes)),
+                c_char_p(json_data),
+                c_int(len(json_data)),
+            )
+        )
 
     def post_output(self, job_id: str, job_output: bytes) -> bool:
         """
@@ -156,74 +180,78 @@ class Hook:  # pylint: disable=too-many-instance-attributes
         """
         json_data = self._json_serialize_job_data(job_output)
         id_bytes = job_id.encode("utf-8")
-        return bool(self._post_output(
-            c_char_p(id_bytes), c_int(len(id_bytes)),
-            c_char_p(json_data), c_int(len(json_data))
-        ))
+        return bool(
+            self._post_output(
+                c_char_p(id_bytes),
+                c_int(len(id_bytes)),
+                c_char_p(json_data),
+                c_int(len(json_data)),
+            )
+        )
 
     def finish_stream(self, job_id: str) -> bool:
         """
         tell the SLS queue that the result of a streaming job is complete.
         """
         id_bytes = job_id.encode("utf-8")
-        return bool(self._finish_stream(
-            c_char_p(id_bytes), c_int(len(id_bytes))
-        ))
+        return bool(self._finish_stream(c_char_p(id_bytes), c_int(len(id_bytes))))
 
 
 # -------------------------------- Process Job ------------------------------- #
-async def _process_job(config: Dict[str, Any], job: Dict[str, Any], hook) -> Dict[str, Any]:
-    """ Process a single job. """
-    handler = config['handler']
+async def _process_job(
+    config: Dict[str, Any], job: Dict[str, Any], hook
+) -> Dict[str, Any]:
+    """Process a single job."""
+    handler = config["handler"]
 
     result = {}
     try:
         if inspect.isgeneratorfunction(handler) or inspect.isasyncgenfunction(handler):
             log.debug("SLS Core | Running job as a generator.")
             generator_output = rp_job.run_job_generator(handler, job)
-            aggregated_output = {'output': []}
+            aggregated_output = {"output": []}
 
             async for part in generator_output:
-                log.debug(f"SLS Core | Streaming output: {part}", job['id'])
+                log.debug(f"SLS Core | Streaming output: {part}", job["id"])
 
-                if 'error' in part:
+                if "error" in part:
                     aggregated_output = part
                     break
-                if config.get('return_aggregate_stream', False):
-                    aggregated_output['output'].append(part['output'])
+                if config.get("return_aggregate_stream", False):
+                    aggregated_output["output"].append(part["output"])
 
-                await hook.stream_output(job['id'], part)
+                await hook.stream_output(job["id"], part)
 
-            log.debug("SLS Core | Finished streaming output.", job['id'])
-            hook.finish_stream(job['id'])
+            log.debug("SLS Core | Finished streaming output.", job["id"])
+            hook.finish_stream(job["id"])
             result = aggregated_output
 
         else:
             log.debug("SLS Core | Running job as a standard function.")
             result = await rp_job.run_job(handler, job)
-            result = result.get('output', result)
+            result = result.get("output", result)
 
     except Exception as err:  # pylint: disable=broad-except
-        log.error(f"SLS Core | Error running job: {err}", job['id'])
-        result = {'error': str(err)}
+        log.error(f"SLS Core | Error running job: {err}", job["id"])
+        result = {"error": str(err)}
 
     finally:
-        log.debug(f"SLS Core | Posting output: {result}", job['id'])
-        hook.post_output(job['id'], result)
+        log.debug(f"SLS Core | Posting output: {result}", job["id"])
+        hook.post_output(job["id"], result)
 
 
 # ---------------------------------------------------------------------------- #
 #                                  Run Worker                                  #
 # ---------------------------------------------------------------------------- #
 async def run(config: Dict[str, Any]) -> None:
-    """ Run the worker.
+    """Run the worker.
 
     Args:
         config: A dictionary containing the following keys:
             handler: A function that takes a job and returns a result.
     """
-    max_concurrency = config.get('max_concurrency', 1)
-    max_jobs = config.get('max_jobs', 1)
+    max_concurrency = config.get("max_concurrency", 1)
+    max_jobs = config.get("max_jobs", 1)
 
     serverless_hook = Hook()
 
@@ -235,7 +263,9 @@ async def run(config: Dict[str, Any]) -> None:
             continue
 
         for job in jobs:
-            asyncio.create_task(_process_job(config, job, serverless_hook), name=job['id'])
+            asyncio.create_task(
+                _process_job(config, job, serverless_hook), name=job["id"]
+            )
             await asyncio.sleep(0)
 
         await asyncio.sleep(0)
@@ -243,7 +273,7 @@ async def run(config: Dict[str, Any]) -> None:
 
 def main(config: Dict[str, Any]) -> None:
     """Run the worker in an asyncio event loop."""
-    if config.get('handler') is None:
+    if config.get("handler") is None:
         log.error("SLS Core | config must contain a handler function")
         raise ValueError("config must contain a handler function")
 

--- a/runpod/serverless/modules/__init__.py
+++ b/runpod/serverless/modules/__init__.py
@@ -1,1 +1,1 @@
-''' Allows modules to be imported from the modules directory. '''
+""" Allows modules to be imported from the modules directory. """

--- a/runpod/serverless/modules/rp_fastapi.py
+++ b/runpod/serverless/modules/rp_fastapi.py
@@ -1,25 +1,25 @@
-''' Used to launch the FastAPI web server when worker is running in API mode. '''
+""" Used to launch the FastAPI web server when worker is running in API mode. """
+
 # pylint: disable=too-few-public-methods, line-too-long
 
 import os
-import uuid
 import threading
+import uuid
 from dataclasses import dataclass
-from typing import Union, Optional, Dict, Any
+from typing import Any, Dict, Optional, Union
 
-import uvicorn
 import requests
-from fastapi import FastAPI, APIRouter
+import uvicorn
+from fastapi import APIRouter, FastAPI
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import RedirectResponse
 
+from ...http_client import SyncClientSession
+from ...version import __version__ as runpod_version
 from .rp_handler import is_generator
 from .rp_job import run_job, run_job_generator
-from .worker_state import Jobs
 from .rp_ping import Heartbeat
-from ...version import __version__ as runpod_version
-from ...http_client import SyncClientSession
-
+from .worker_state import Jobs
 
 RUNPOD_ENDPOINT_ID = os.environ.get("RUNPOD_ENDPOINT_ID", None)
 
@@ -105,16 +105,18 @@ heartbeat = Heartbeat()
 # ------------------------------- Input Objects ------------------------------ #
 @dataclass
 class Job:
-    ''' Represents a job. '''
+    """Represents a job."""
+
     id: str
     input: Union[dict, list, str, int, float, bool]
 
 
 @dataclass
 class TestJob:
-    ''' Represents a test job.
+    """Represents a test job.
     input can be any type of data.
-    '''
+    """
+
     id: Optional[str] = None
     input: Optional[Union[dict, list, str, int, float, bool]] = None
     webhook: Optional[str] = None
@@ -122,7 +124,8 @@ class TestJob:
 
 @dataclass
 class DefaultRequest:
-    """ Represents a test input. """
+    """Represents a test input."""
+
     input: Dict[str, Any]
     webhook: Optional[str] = None
 
@@ -130,7 +133,8 @@ class DefaultRequest:
 # ------------------------------ Output Objects ------------------------------ #
 @dataclass
 class JobOutput:
-    ''' Represents the output of a job. '''
+    """Represents the output of a job."""
+
     id: str
     status: str
     output: Optional[Union[dict, list, str, int, float, bool]] = None
@@ -139,7 +143,8 @@ class JobOutput:
 
 @dataclass
 class StreamOutput:
-    """ Stream representation of a job. """
+    """Stream representation of a job."""
+
     id: str
     status: str = "IN_PROGRESS"
     stream: Optional[Union[dict, list, str, int, float, bool]] = None
@@ -172,15 +177,15 @@ def _send_webhook(url: str, payload: Dict[str, Any]) -> bool:
 #                                  API Worker                                  #
 # ---------------------------------------------------------------------------- #
 class WorkerAPI:
-    ''' Used to launch the FastAPI web server when the worker is running in API mode. '''
+    """Used to launch the FastAPI web server when the worker is running in API mode."""
 
     def __init__(self, config: Dict[str, Any]):
-        '''
+        """
         Initializes the WorkerAPI class.
         1. Starts the heartbeat thread.
         2. Initializes the FastAPI web server.
         3. Sets the handler for processing jobs.
-        '''
+        """
         # Start the heartbeat thread.
         heartbeat.start_ping()
 
@@ -189,16 +194,16 @@ class WorkerAPI:
         tags_metadata = [
             {
                 "name": "Synchronously Submit Request & Get Job Results",
-                "description": "Endpoints for submitting job requests and getting the results."
+                "description": "Endpoints for submitting job requests and getting the results.",
             },
             {
                 "name": "Submit Job Requests",
-                "description": "Endpoints for submitting job requests."
+                "description": "Endpoints for submitting job requests.",
             },
             {
                 "name": "Check Job Results",
-                "description": "Endpoints for checking the status of a job and getting the results."
-            }
+                "description": "Endpoints for checking the status of a job and getting the results.",
+            },
         ]
 
         # Initialize the FastAPI web server.
@@ -207,7 +212,7 @@ class WorkerAPI:
             description=DESCRIPTION,
             version=runpod_version,
             docs_url="/",
-            openapi_tags=tags_metadata
+            openapi_tags=tags_metadata,
         )
 
         # Create an APIRouter and add the route for processing jobs.
@@ -215,63 +220,74 @@ class WorkerAPI:
 
         # Docs Redirect /docs -> /
         api_router.add_api_route(
-            "/docs", lambda: RedirectResponse(url="/"),
-            include_in_schema=False
+            "/docs", lambda: RedirectResponse(url="/"), include_in_schema=False
         )
 
         if RUNPOD_ENDPOINT_ID:
-            api_router.add_api_route(f"/{RUNPOD_ENDPOINT_ID}/realtime",
-                                     self._realtime, methods=["POST"])
+            api_router.add_api_route(
+                f"/{RUNPOD_ENDPOINT_ID}/realtime", self._realtime, methods=["POST"]
+            )
 
         # Simulation endpoints.
         api_router.add_api_route(
-            "/run", self._sim_run, methods=["POST"], response_model_exclude_none=True,
+            "/run",
+            self._sim_run,
+            methods=["POST"],
+            response_model_exclude_none=True,
             summary="Mimics the behavior of the run endpoint.",
             description=RUN_DESCRIPTION,
-            tags=["Submit Job Requests"]
+            tags=["Submit Job Requests"],
         )
         api_router.add_api_route(
-            "/runsync", self._sim_runsync, methods=["POST"],
+            "/runsync",
+            self._sim_runsync,
+            methods=["POST"],
             response_model_exclude_none=True,
             summary="Mimics the behavior of the runsync endpoint.",
             description=RUNSYNC_DESCRIPTION,
-            tags=["Synchronously Submit Request & Get Job Results"]
+            tags=["Synchronously Submit Request & Get Job Results"],
         )
         api_router.add_api_route(
-            "/stream/{job_id}", self._sim_stream, methods=["POST"],
+            "/stream/{job_id}",
+            self._sim_stream,
+            methods=["POST"],
             response_model_exclude_none=True,
             summary="Mimics the behavior of the stream endpoint.",
             description=STREAM_DESCRIPTION,
-            tags=["Check Job Results"]
+            tags=["Check Job Results"],
         )
         api_router.add_api_route(
-            "/status/{job_id}", self._sim_status, methods=["POST"],
+            "/status/{job_id}",
+            self._sim_status,
+            methods=["POST"],
             response_model_exclude_none=True,
             summary="Mimics the behavior of the status endpoint.",
             description=STATUS_DESCRIPTION,
-            tags=["Check Job Results"]
+            tags=["Check Job Results"],
         )
 
         # Include the APIRouter in the FastAPI application.
         self.rp_app.include_router(api_router)
 
-    def start_uvicorn(self, api_host='localhost', api_port=8000, api_concurrency=1):
-        '''
+    def start_uvicorn(self, api_host="localhost", api_port=8000, api_concurrency=1):
+        """
         Starts the Uvicorn server.
-        '''
+        """
         uvicorn.run(
-            self.rp_app, host=api_host,
-            port=int(api_port), workers=int(api_concurrency),
+            self.rp_app,
+            host=api_host,
+            port=int(api_port),
+            workers=int(api_concurrency),
             log_level=os.environ.get("UVICORN_LOG_LEVEL", "info"),
-            access_log=False
+            access_log=False,
         )
 
     # ----------------------------- Realtime Endpoint ---------------------------- #
     async def _realtime(self, job: Job):
-        '''
+        """
         Performs model inference on the input data using the provided handler.
         If handler is not provided, returns an error message.
-        '''
+        """
         job_list.add_job(job.id)
 
         # Process the job using the provided handler, passing in the job input.
@@ -288,14 +304,14 @@ class WorkerAPI:
 
     # ------------------------------------ run ----------------------------------- #
     async def _sim_run(self, job_request: DefaultRequest) -> JobOutput:
-        """ Development endpoint to simulate run behavior. """
+        """Development endpoint to simulate run behavior."""
         assigned_job_id = f"test-{uuid.uuid4()}"
         job_list.add_job(assigned_job_id, job_request.input, job_request.webhook)
         return jsonable_encoder({"id": assigned_job_id, "status": "IN_PROGRESS"})
 
     # ---------------------------------- runsync --------------------------------- #
     async def _sim_runsync(self, job_request: DefaultRequest) -> JobOutput:
-        """ Development endpoint to simulate runsync behavior. """
+        """Development endpoint to simulate runsync behavior."""
         assigned_job_id = f"test-{uuid.uuid4()}"
         job = TestJob(id=assigned_job_id, input=job_request.input)
 
@@ -303,39 +319,35 @@ class WorkerAPI:
             generator_output = run_job_generator(self.config["handler"], job.__dict__)
             job_output = {"output": []}
             async for stream_output in generator_output:
-                job_output['output'].append(stream_output["output"])
+                job_output["output"].append(stream_output["output"])
         else:
             job_output = await run_job(self.config["handler"], job.__dict__)
 
-        if job_output.get('error', None):
-            return jsonable_encoder({
-                "id": job.id,
-                "status": "FAILED",
-                "error": job_output['error']
-            })
+        if job_output.get("error", None):
+            return jsonable_encoder(
+                {"id": job.id, "status": "FAILED", "error": job_output["error"]}
+            )
 
         if job_request.webhook:
             thread = threading.Thread(
                 target=_send_webhook,
-                args=(job_request.webhook, job_output), daemon=True)
+                args=(job_request.webhook, job_output),
+                daemon=True,
+            )
             thread.start()
 
-        return jsonable_encoder({
-            "id": job.id,
-            "status": "COMPLETED",
-            "output": job_output['output']
-        })
+        return jsonable_encoder(
+            {"id": job.id, "status": "COMPLETED", "output": job_output["output"]}
+        )
 
     # ---------------------------------- stream ---------------------------------- #
     async def _sim_stream(self, job_id: str) -> StreamOutput:
-        """ Development endpoint to simulate stream behavior. """
+        """Development endpoint to simulate stream behavior."""
         stashed_job = job_list.get_job(job_id)
         if stashed_job is None:
-            return jsonable_encoder({
-                "id": job_id,
-                "status": "FAILED",
-                "error": "Job ID not found"
-            })
+            return jsonable_encoder(
+                {"id": job_id, "status": "FAILED", "error": "Job ID not found"}
+            )
 
         job = TestJob(id=job_id, input=stashed_job.input)
 
@@ -345,36 +357,36 @@ class WorkerAPI:
             async for stream_output in generator_output:
                 stream_accumulator.append({"output": stream_output["output"]})
         else:
-            return jsonable_encoder({
-                "id": job_id,
-                "status": "FAILED",
-                "error": "Stream not supported, handler must be a generator."
-            })
+            return jsonable_encoder(
+                {
+                    "id": job_id,
+                    "status": "FAILED",
+                    "error": "Stream not supported, handler must be a generator.",
+                }
+            )
 
         job_list.remove_job(job.id)
 
         if stashed_job.webhook:
             thread = threading.Thread(
                 target=_send_webhook,
-                args=(stashed_job.webhook, stream_accumulator), daemon=True)
+                args=(stashed_job.webhook, stream_accumulator),
+                daemon=True,
+            )
             thread.start()
 
-        return jsonable_encoder({
-            "id": job_id,
-            "status": "COMPLETED",
-            "stream": stream_accumulator
-        })
+        return jsonable_encoder(
+            {"id": job_id, "status": "COMPLETED", "stream": stream_accumulator}
+        )
 
     # ---------------------------------- status ---------------------------------- #
     async def _sim_status(self, job_id: str) -> JobOutput:
-        """ Development endpoint to simulate status behavior. """
+        """Development endpoint to simulate status behavior."""
         stashed_job = job_list.get_job(job_id)
         if stashed_job is None:
-            return jsonable_encoder({
-                "id": job_id,
-                "status": "FAILED",
-                "error": "Job ID not found"
-            })
+            return jsonable_encoder(
+                {"id": job_id, "status": "FAILED", "error": "Job ID not found"}
+            )
 
         job = TestJob(id=stashed_job.id, input=stashed_job.input)
 
@@ -382,27 +394,25 @@ class WorkerAPI:
             generator_output = run_job_generator(self.config["handler"], job.__dict__)
             job_output = {"output": []}
             async for stream_output in generator_output:
-                job_output['output'].append(stream_output["output"])
+                job_output["output"].append(stream_output["output"])
         else:
             job_output = await run_job(self.config["handler"], job.__dict__)
 
         job_list.remove_job(job.id)
 
-        if job_output.get('error', None):
-            return jsonable_encoder({
-                "id": job_id,
-                "status": "FAILED",
-                "error": job_output['error']
-            })
+        if job_output.get("error", None):
+            return jsonable_encoder(
+                {"id": job_id, "status": "FAILED", "error": job_output["error"]}
+            )
 
         if stashed_job.webhook:
             thread = threading.Thread(
                 target=_send_webhook,
-                args=(stashed_job.webhook, job_output), daemon=True)
+                args=(stashed_job.webhook, job_output),
+                daemon=True,
+            )
             thread.start()
 
-        return jsonable_encoder({
-            "id": job_id,
-            "status": "COMPLETED",
-            "output": job_output['output']
-        })
+        return jsonable_encoder(
+            {"id": job_id, "status": "COMPLETED", "output": job_output["output"]}
+        )

--- a/runpod/serverless/modules/rp_handler.py
+++ b/runpod/serverless/modules/rp_handler.py
@@ -3,6 +3,7 @@
 import inspect
 from typing import Callable
 
+
 def is_generator(handler: Callable) -> bool:
-    """Check if handler is a generator function. """
+    """Check if handler is a generator function."""
     return inspect.isgeneratorfunction(handler) or inspect.isasyncgenfunction(handler)

--- a/runpod/serverless/modules/rp_http.py
+++ b/runpod/serverless/modules/rp_http.py
@@ -2,19 +2,26 @@
     This module is used to handle HTTP requests.
 """
 
-import os
 import json
+import os
+
 from aiohttp import ClientError
-from aiohttp_retry import RetryClient, FibonacciRetry
+from aiohttp_retry import FibonacciRetry, RetryClient
+
 from runpod.http_client import ClientSession
 from runpod.serverless.modules.rp_logger import RunPodLogger
-from .worker_state import Jobs, WORKER_ID
 
-JOB_DONE_URL_TEMPLATE = str(os.environ.get('RUNPOD_WEBHOOK_POST_OUTPUT', 'JOB_DONE_URL'))
-JOB_DONE_URL = JOB_DONE_URL_TEMPLATE.replace('$RUNPOD_POD_ID', WORKER_ID)
+from .worker_state import WORKER_ID, Jobs
 
-JOB_STREAM_URL_TEMPLATE = str(os.environ.get('RUNPOD_WEBHOOK_POST_STREAM', 'JOB_STREAM_URL'))
-JOB_STREAM_URL = JOB_STREAM_URL_TEMPLATE.replace('$RUNPOD_POD_ID', WORKER_ID)
+JOB_DONE_URL_TEMPLATE = str(
+    os.environ.get("RUNPOD_WEBHOOK_POST_OUTPUT", "JOB_DONE_URL")
+)
+JOB_DONE_URL = JOB_DONE_URL_TEMPLATE.replace("$RUNPOD_POD_ID", WORKER_ID)
+
+JOB_STREAM_URL_TEMPLATE = str(
+    os.environ.get("RUNPOD_WEBHOOK_POST_STREAM", "JOB_STREAM_URL")
+)
+JOB_STREAM_URL = JOB_STREAM_URL_TEMPLATE.replace("$RUNPOD_POD_ID", WORKER_ID)
 
 log = RunPodLogger()
 job_list = Jobs()
@@ -25,12 +32,17 @@ async def _transmit(client_session: ClientSession, url, job_data):
     Wrapper for transmitting results via POST.
     """
     retry_options = FibonacciRetry(attempts=3)
-    retry_client = RetryClient(client_session=client_session, retry_options=retry_options)
+    retry_client = RetryClient(
+        client_session=client_session, retry_options=retry_options
+    )
 
     kwargs = {
         "data": job_data,
-        "headers": {"charset": "utf-8", "Content-Type": "application/x-www-form-urlencoded"},
-        "raise_for_status": True
+        "headers": {
+            "charset": "utf-8",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        "raise_for_status": True,
     }
 
     async with retry_client.post(url, **kwargs) as client_response:
@@ -38,7 +50,9 @@ async def _transmit(client_session: ClientSession, url, job_data):
 
 
 # pylint: disable=too-many-arguments, disable=line-too-long
-async def _handle_result(session: ClientSession, job_data, job, url_template, log_message, is_stream=False):
+async def _handle_result(
+    session: ClientSession, job_data, job, url_template, log_message, is_stream=False
+):
     """
     A helper function to handle the result, either for sending or streaming.
     """
@@ -48,33 +62,40 @@ async def _handle_result(session: ClientSession, job_data, job, url_template, lo
         serialized_job_data = json.dumps(job_data, ensure_ascii=False)
 
         is_stream = "true" if is_stream else "false"
-        url = url_template.replace('$ID', job['id']) + f"&isStream={is_stream}"
+        url = url_template.replace("$ID", job["id"]) + f"&isStream={is_stream}"
 
         await _transmit(session, url, serialized_job_data)
-        log.debug(f"{log_message}", job['id'])
+        log.debug(f"{log_message}", job["id"])
 
     except ClientError as err:
-        log.error(f"Failed to return job results. | {err}", job['id'])
+        log.error(f"Failed to return job results. | {err}", job["id"])
 
     except (TypeError, RuntimeError) as err:
-        log.error(f"Error while returning job result. | {err}", job['id'])
+        log.error(f"Error while returning job result. | {err}", job["id"])
 
     finally:
-        #job_data status is used for local development with FastAPI
-        if url_template == JOB_DONE_URL and job_data.get('status', None) != 'IN_PROGRESS':
+        # job_data status is used for local development with FastAPI
+        if (
+            url_template == JOB_DONE_URL
+            and job_data.get("status", None) != "IN_PROGRESS"
+        ):
             job_list.remove_job(job["id"])
-            log.info("Finished.", job['id'])
+            log.info("Finished.", job["id"])
 
 
 async def send_result(session, job_data, job, is_stream=False):
     """
     Return the job results.
     """
-    await _handle_result(session, job_data, job, JOB_DONE_URL, "Results sent.", is_stream=is_stream)
+    await _handle_result(
+        session, job_data, job, JOB_DONE_URL, "Results sent.", is_stream=is_stream
+    )
 
 
 async def stream_result(session, job_data, job):
     """
     Return the stream job results.
     """
-    await _handle_result(session, job_data, job, JOB_STREAM_URL, "Intermediate results sent.")
+    await _handle_result(
+        session, job_data, job, JOB_STREAM_URL, "Intermediate results sent."
+    )

--- a/runpod/serverless/modules/rp_job.py
+++ b/runpod/serverless/modules/rp_job.py
@@ -1,23 +1,24 @@
 """
 Job related helpers.
 """
+
 # pylint: disable=too-many-branches
 
-import inspect
-from typing import Any, Callable, Dict, Optional, Union, AsyncGenerator
-
-import os
-import json
 import asyncio
+import inspect
+import json
+import os
 import traceback
+from typing import Any, AsyncGenerator, Callable, Dict, Optional, Union
 
 from runpod.http_client import ClientSession
 from runpod.serverless.modules.rp_logger import RunPodLogger
-from .worker_state import WORKER_ID, Jobs
-from .rp_tips import check_return_size
-from ...version import __version__ as runpod_version
 
-JOB_GET_URL = str(os.environ.get('RUNPOD_WEBHOOK_GET_JOB')).replace('$ID', WORKER_ID)
+from ...version import __version__ as runpod_version
+from .rp_tips import check_return_size
+from .worker_state import WORKER_ID, Jobs
+
+JOB_GET_URL = str(os.environ.get("RUNPOD_WEBHOOK_GET_JOB")).replace("$ID", WORKER_ID)
 
 log = RunPodLogger()
 job_list = Jobs()
@@ -33,7 +34,7 @@ def _job_get_url():
     Returns:
         str: The prepared URL for the 'get' request to the serverless API.
     """
-    job_in_progress = '1' if job_list.get_job_list() else '0'
+    job_in_progress = "1" if job_list.get_job_list() else "0"
     return JOB_GET_URL + f"&job_in_progress={job_in_progress}"
 
 
@@ -58,7 +59,9 @@ async def get_job(session: ClientSession, retry=True) -> Optional[Dict[str, Any]
                     continue
 
                 if response.status == 400:
-                    log.debug("Received 400 status, expected when FlashBoot is enabled.")
+                    log.debug(
+                        "Received 400 status, expected when FlashBoot is enabled."
+                    )
                     if retry is False:
                         break
                     continue
@@ -96,7 +99,9 @@ async def get_job(session: ClientSession, retry=True) -> Optional[Dict[str, Any]
             err_type = type(err).__name__
             err_message = str(err)
             err_traceback = traceback.format_exc()
-            log.error(f"Failed to get job. | Error Type: {err_type} | Error Message: {err_message}")
+            log.error(
+                f"Failed to get job. | Error Type: {err_type} | Error Message: {err_message}"
+            )
             log.error(f"Traceback: {err_traceback}")
 
         if next_job is None:
@@ -107,7 +112,7 @@ async def get_job(session: ClientSession, retry=True) -> Optional[Dict[str, Any]
         await asyncio.sleep(1)
     else:
         job_list.add_job(next_job["id"])
-        log.debug("Request ID added.", next_job['id'])
+        log.debug("Request ID added.", next_job["id"])
 
         return next_job
 
@@ -125,19 +130,23 @@ async def run_job(handler: Callable, job: Dict[str, Any]) -> Dict[str, Any]:
     Returns:
         Dict[str, Any]: The result of running the job.
     """
-    log.info('Started.', job["id"])
+    log.info("Started.", job["id"])
     run_result = {}
 
     try:
         handler_return = handler(job)
-        job_output = await handler_return if inspect.isawaitable(handler_return) else handler_return
+        job_output = (
+            await handler_return
+            if inspect.isawaitable(handler_return)
+            else handler_return
+        )
 
-        log.debug(f'Handler output: {job_output}', job["id"])
+        log.debug(f"Handler output: {job_output}", job["id"])
 
         if isinstance(job_output, dict):
             error_msg = job_output.pop("error", None)
             refresh_worker = job_output.pop("refresh_worker", None)
-            run_result['output'] = job_output
+            run_result["output"] = job_output
 
             if error_msg:
                 run_result["error"] = error_msg
@@ -155,35 +164,38 @@ async def run_job(handler: Callable, job: Dict[str, Any]) -> Dict[str, Any]:
 
         check_return_size(run_result)  # Checks the size of the return body.
 
-    except Exception as err:    # pylint: disable=broad-except
+    except Exception as err:  # pylint: disable=broad-except
         error_info = {
             "error_type": str(type(err)),
             "error_message": str(err),
             "error_traceback": traceback.format_exc(),
             "hostname": os.environ.get("RUNPOD_POD_HOSTNAME", "unknown"),
             "worker_id": os.environ.get("RUNPOD_POD_ID", "unknown"),
-            "runpod_version": runpod_version
+            "runpod_version": runpod_version,
         }
 
-        log.error('Captured Handler Exception', job["id"])
+        log.error("Captured Handler Exception", job["id"])
         log.error(json.dumps(error_info, indent=4))
         run_result = {"error": json.dumps(error_info)}
 
     finally:
-        log.debug(f'run_job return: {run_result}', job["id"])
+        log.debug(f"run_job return: {run_result}", job["id"])
 
     return run_result
 
 
 async def run_job_generator(
-        handler: Callable,
-        job: Dict[str, Any]) -> AsyncGenerator[Dict[str, Union[str, Any]], None]:
-    '''
+    handler: Callable, job: Dict[str, Any]
+) -> AsyncGenerator[Dict[str, Union[str, Any]], None]:
+    """
     Run generator job used to stream output.
     Yields output partials from the generator.
-    '''
+    """
     is_async_gen = inspect.isasyncgenfunction(handler)
-    log.debug('Using Async Generator' if is_async_gen else 'Using Standard Generator', job["id"])
+    log.debug(
+        "Using Async Generator" if is_async_gen else "Using Standard Generator",
+        job["id"],
+    )
 
     try:
         job_output = handler(job)
@@ -197,10 +209,8 @@ async def run_job_generator(
                 log.debug(f"Generator output: {output_partial}", job["id"])
                 yield {"output": output_partial}
 
-    except Exception as err:    # pylint: disable=broad-except
+    except Exception as err:  # pylint: disable=broad-except
         log.error(err, job["id"])
-        yield {
-            "error": f"handler: {str(err)} \ntraceback: {traceback.format_exc()}"
-        }
+        yield {"error": f"handler: {str(err)} \ntraceback: {traceback.format_exc()}"}
     finally:
-        log.info('Finished running generator.', job["id"])
+        log.info("Finished running generator.", job["id"])

--- a/runpod/serverless/modules/rp_local.py
+++ b/runpod/serverless/modules/rp_local.py
@@ -1,26 +1,28 @@
-'''
+"""
 runpod | serverless | rp_local.py
 Provides the local testing functionality for runpod serverless worker.
-'''
+"""
 
+import json
 import os
 import sys
-import json
-from typing import Dict, Any
+from typing import Any, Dict
 
 from runpod.serverless.modules.rp_logger import RunPodLogger
+
 from .rp_job import run_job
 
 log = RunPodLogger()
 
+
 async def run_local(config: Dict[str, Any]) -> None:
-    '''
+    """
     Runs the worker locally.
-    '''
+    """
     # Get the local test job
-    if config['rp_args'].get('test_input', None):
+    if config["rp_args"].get("test_input", None):
         log.info("test_input set, using test_input as job input.")
-        local_job = config['rp_args']['test_input']
+        local_job = config["rp_args"]["test_input"]
     else:
         if not os.path.exists("test_input.json"):
             log.warn("test_input.json not found, exiting.")
@@ -48,9 +50,9 @@ async def run_local(config: Dict[str, Any]) -> None:
     log.info(f"Job result: {job_result}")
 
     # Compare to sample output, if provided
-    if config['rp_args'].get('test_output', None):
+    if config["rp_args"].get("test_output", None):
         log.info("test_output set, comparing output to test_output.")
-        if job_result != config['rp_args']['test_output']:
+        if job_result != config["rp_args"]["test_output"]:
             log.error("Job output does not match test_output.")
             sys.exit(1)
         log.info("Job output matches test_output.")

--- a/runpod/serverless/modules/rp_logger.py
+++ b/runpod/serverless/modules/rp_logger.py
@@ -1,4 +1,4 @@
-'''
+"""
 PodWorker | modules | logging.py
 
 Log Levels (Level - Value - Description)
@@ -8,45 +8,45 @@ DEBUG - 1 - Detailed information, typically of interest only when diagnosing pro
 INFO - 2 - Confirmation that things are working as expected.
 WARN - 3 - An indication that something unexpected happened.
 ERROR - 4 - Serious problem, the software has not been able to perform some function.
-'''
+"""
 
-import os
 import json
+import os
 from typing import Optional
 
-
 MAX_MESSAGE_LENGTH = 4096
-LOG_LEVELS = ['NOTSET', 'DEBUG', 'TRACE', 'INFO', 'WARN', 'ERROR']
+LOG_LEVELS = ["NOTSET", "DEBUG", "TRACE", "INFO", "WARN", "ERROR"]
 
 
 def _validate_log_level(log_level):
-    '''
+    """
     Checks the debug level and returns the debug level name.
-    '''
+    """
     if isinstance(log_level, str):
         log_level = log_level.upper()
 
         if log_level not in LOG_LEVELS:
-            raise ValueError(f'Invalid debug level: {log_level}')
+            raise ValueError(f"Invalid debug level: {log_level}")
 
         return log_level
 
     if isinstance(log_level, int):
         if log_level < 0 or log_level >= len(LOG_LEVELS):
-            raise ValueError(f'Invalid debug level: {log_level}')
+            raise ValueError(f"Invalid debug level: {log_level}")
 
         return LOG_LEVELS[log_level]
 
-    raise ValueError(f'Invalid debug level: {log_level}')
+    raise ValueError(f"Invalid debug level: {log_level}")
 
 
 class RunPodLogger:
-    '''Singleton class for logging.'''
+    """Singleton class for logging."""
 
     __instance = None
-    level = _validate_log_level(os.environ.get(
-        'RUNPOD_LOG_LEVEL',
-        os.environ.get('RUNPOD_DEBUG_LEVEL', 'DEBUG'))
+    level = _validate_log_level(
+        os.environ.get(
+            "RUNPOD_LOG_LEVEL", os.environ.get("RUNPOD_DEBUG_LEVEL", "DEBUG")
+        )
     )
 
     def __new__(cls):
@@ -55,22 +55,22 @@ class RunPodLogger:
         return RunPodLogger.__instance
 
     def set_level(self, new_level):
-        '''
+        """
         Set the debug level for logging.
         Can be set to the name or value of the debug level.
-        '''
+        """
         self.level = _validate_log_level(new_level)
-        self.info(f'Log level set to {self.level}')
+        self.info(f"Log level set to {self.level}")
 
-    def log(self, message, message_level='INFO', job_id=None):
-        '''
+    def log(self, message, message_level="INFO", job_id=None):
+        """
         Log message to stdout if RUNPOD_DEBUG is true.
-        '''
-        if self.level == 'NOTSET':
+        """
+        if self.level == "NOTSET":
             return
 
         level_index = LOG_LEVELS.index(self.level)
-        if level_index > LOG_LEVELS.index(message_level) and message_level != 'TIP':
+        if level_index > LOG_LEVELS.index(message_level) and message_level != "TIP":
             return
 
         message = str(message)
@@ -78,65 +78,63 @@ class RunPodLogger:
         if len(message) > MAX_MESSAGE_LENGTH:
             half_max_length = MAX_MESSAGE_LENGTH // 2
             truncated_amount = len(message) - MAX_MESSAGE_LENGTH
-            truncation_note = f'\n...TRUNCATED {truncated_amount} CHARACTERS...\n'
-            message = message[:half_max_length] + truncation_note + message[-half_max_length:]
+            truncation_note = f"\n...TRUNCATED {truncated_amount} CHARACTERS...\n"
+            message = (
+                message[:half_max_length] + truncation_note + message[-half_max_length:]
+            )
 
-        if os.environ.get('RUNPOD_ENDPOINT_ID'):
-            log_json = {
-                'requestId': job_id,
-                'message': message,
-                'level': message_level
-            }
+        if os.environ.get("RUNPOD_ENDPOINT_ID"):
+            log_json = {"requestId": job_id, "message": message, "level": message_level}
             print(json.dumps(log_json), flush=True)
             return
 
         if job_id:
-            message = f'{job_id} | {message}'
+            message = f"{job_id} | {message}"
 
-        print(f'{message_level.ljust(7)}| {message}', flush=True)
+        print(f"{message_level.ljust(7)}| {message}", flush=True)
         return
 
     def secret(self, secret_name, secret):
-        '''
+        """
         Censors secrets for logging.
         Replaces everything except the first and last characters with *
-        '''
+        """
         secret = str(secret)
-        redacted_secret = secret[0] + '*' * (len(secret)-2) + secret[-1]
+        redacted_secret = secret[0] + "*" * (len(secret) - 2) + secret[-1]
         self.info(f"{secret_name}: {redacted_secret}")
 
     def debug(self, message, request_id: Optional[str] = None):
-        '''
+        """
         debug log
-        '''
-        self.log(message, 'DEBUG', request_id)
+        """
+        self.log(message, "DEBUG", request_id)
 
     def info(self, message, request_id: Optional[str] = None):
-        '''
+        """
         info log
-        '''
-        self.log(message, 'INFO', request_id)
+        """
+        self.log(message, "INFO", request_id)
 
     def warn(self, message, request_id: Optional[str] = None):
-        '''
+        """
         warn log
-        '''
-        self.log(message, 'WARN', request_id)
+        """
+        self.log(message, "WARN", request_id)
 
     def error(self, message, request_id: Optional[str] = None):
-        '''
+        """
         error log
-        '''
-        self.log(message, 'ERROR', request_id)
+        """
+        self.log(message, "ERROR", request_id)
 
     def tip(self, message):
-        '''
+        """
         tip log
-        '''
-        self.log(message, 'TIP')
+        """
+        self.log(message, "TIP")
 
     def trace(self, message, request_id: Optional[str] = None):
-        '''
+        """
         trace log (buffered until flushed)
-        '''
-        self.log(message, 'TRACE', request_id)
+        """
+        self.log(message, "TRACE", request_id)

--- a/runpod/serverless/modules/rp_ping.py
+++ b/runpod/serverless/modules/rp_ping.py
@@ -2,63 +2,65 @@
 This module defines the Heartbeat class.
 The heartbeat is responsible for sending periodic pings to the Runpod server.
 """
+
 import os
-import time
 import threading
+import time
 
 import requests
 from urllib3.util.retry import Retry
 
 from runpod.http_client import SyncClientSession
-from runpod.version import __version__ as runpod_version
 from runpod.serverless.modules.rp_logger import RunPodLogger
-from runpod.serverless.modules.worker_state import Jobs, WORKER_ID
-
+from runpod.serverless.modules.worker_state import WORKER_ID, Jobs
+from runpod.version import __version__ as runpod_version
 
 log = RunPodLogger()
 jobs = Jobs()  # Contains the list of jobs that are currently running.
 
 
 class Heartbeat:
-    ''' Sends heartbeats to the Runpod server. '''
+    """Sends heartbeats to the Runpod server."""
 
-    PING_URL = os.environ.get('RUNPOD_WEBHOOK_PING', "PING_NOT_SET")
-    PING_URL = PING_URL.replace('$RUNPOD_POD_ID', WORKER_ID)
-    PING_INTERVAL = int(os.environ.get('RUNPOD_PING_INTERVAL', 10000))//1000
+    PING_URL = os.environ.get("RUNPOD_WEBHOOK_PING", "PING_NOT_SET")
+    PING_URL = PING_URL.replace("$RUNPOD_POD_ID", WORKER_ID)
+    PING_INTERVAL = int(os.environ.get("RUNPOD_PING_INTERVAL", 10000)) // 1000
 
     _thread_started = False
 
     def __init__(self, pool_connections=10, retries=3) -> None:
-        '''
+        """
         Initializes the Heartbeat class.
-        '''
+        """
         self._session = SyncClientSession()
-        self._session.headers.update({"Authorization": f"{os.environ.get('RUNPOD_AI_API_KEY')}"})
+        self._session.headers.update(
+            {"Authorization": f"{os.environ.get('RUNPOD_AI_API_KEY')}"}
+        )
 
         retry_strategy = Retry(
             total=retries,
             status_forcelist=[429, 500, 502, 503, 504],
             allowed_methods=["GET"],
-            backoff_factor=1
+            backoff_factor=1,
         )
 
         adapter = requests.adapters.HTTPAdapter(
             pool_connections=pool_connections,
             pool_maxsize=pool_connections,
-            max_retries=retry_strategy
+            max_retries=retry_strategy,
         )
-        self._session.mount('http://', adapter)
-        self._session.mount('https://', adapter)
+        self._session.mount("http://", adapter)
+        self._session.mount("https://", adapter)
 
     def start_ping(self, test=False):
-        '''
+        """
         Sends heartbeat pings to the Runpod server.
-        '''
-        if os.environ.get('RUNPOD_AI_API_KEY') is None:
+        """
+        if os.environ.get("RUNPOD_AI_API_KEY") is None:
             log.debug("Not deployed on RunPod serverless, pings will not be sent.")
             return
 
-        if os.environ.get('RUNPOD_POD_ID') is None:
+        if os.environ.get("RUNPOD_POD_ID") is None:
             log.info("Not running on RunPod, pings will not be sent.")
             return
 
@@ -71,9 +73,9 @@ class Heartbeat:
             Heartbeat._thread_started = True
 
     def ping_loop(self, test=False):
-        '''
+        """
         Sends heartbeat pings to the Runpod server.
-        '''
+        """
         while True:
             self._send_ping()
             time.sleep(self.PING_INTERVAL)
@@ -82,22 +84,20 @@ class Heartbeat:
                 return
 
     def _send_ping(self):
-        '''
+        """
         Sends a heartbeat to the Runpod server.
-        '''
+        """
         job_ids = jobs.get_job_list()
-        ping_params = {
-            'job_id': job_ids,
-            'runpod_version': runpod_version
-        }
+        ping_params = {"job_id": job_ids, "runpod_version": runpod_version}
 
         try:
             result = self._session.get(
-                self.PING_URL, params=ping_params,
-                timeout=self.PING_INTERVAL*2
+                self.PING_URL, params=ping_params, timeout=self.PING_INTERVAL * 2
             )
 
-            log.debug(f"Heartbeat Sent | URL: {self.PING_URL} | Status: {result.status_code}")
+            log.debug(
+                f"Heartbeat Sent | URL: {self.PING_URL} | Status: {result.status_code}"
+            )
 
         except requests.RequestException as err:
             log.error(f"Ping Request Error: {err}, attempting to restart ping.")

--- a/runpod/serverless/modules/rp_progress.py
+++ b/runpod/serverless/modules/rp_progress.py
@@ -4,10 +4,11 @@ RunPod Progress Module
 
 import asyncio
 import threading
-from typing import Dict, Any
+from typing import Any, Dict
 
 from runpod.http_client import AsyncClientSession
 from runpod.serverless.modules.rp_logger import RunPodLogger
+
 from .rp_http import send_result
 
 log = RunPodLogger()
@@ -17,10 +18,7 @@ async def _async_progress_update(session, job, progress):
     """
     The actual asynchronous function that sends the update.
     """
-    job_data = {
-        "status": "IN_PROGRESS",
-        "output": progress
-    }
+    job_data = {"status": "IN_PROGRESS", "output": progress}
 
     await send_result(session, job_data, job)
 
@@ -33,6 +31,7 @@ def _thread_target(job: Dict[str, Any], progress: Any):
     asyncio.set_event_loop(loop)
 
     try:
+
         async def main():
             session = AsyncClientSession()
             async with session:

--- a/runpod/serverless/modules/rp_scale.py
+++ b/runpod/serverless/modules/rp_scale.py
@@ -1,11 +1,13 @@
-'''
+"""
 runpod | serverless | rp_scale.py
 Provides the functionality for scaling the runpod serverless worker.
-'''
+"""
 
 import asyncio
 import warnings
+
 from runpod.serverless.modules.rp_logger import RunPodLogger
+
 from .rp_job import get_job
 from .worker_state import Jobs
 
@@ -13,19 +15,19 @@ log = RunPodLogger()
 job_list = Jobs()
 
 
-class JobScaler():
+class JobScaler:
     """
     Job Scaler. This class is responsible for scaling the number of concurrent requests.
     """
 
-    def __init__(self, concurrency_modifier = None):
+    def __init__(self, concurrency_modifier=None):
         if concurrency_modifier:
             warnings.warn(
                 "JobScaler(concurrency_modifier) is deprecated ",
                 "and will be removed in a future version. "
                 "Please remove `concurrency_modifier` parameter.",
                 DeprecationWarning,
-                stacklevel=2
+                stacklevel=2,
             )
         self._is_alive = True
 
@@ -51,9 +53,7 @@ class JobScaler():
         while self.is_alive():
             log.debug(f"Jobs in progress: {job_list.get_job_count()}")
 
-            tasks = [
-                asyncio.create_task(get_job(session, retry=False))
-            ]
+            tasks = [asyncio.create_task(get_job(session, retry=False))]
 
             for job_future in asyncio.as_completed(tasks):
                 if job := await job_future:

--- a/runpod/serverless/modules/rp_tips.py
+++ b/runpod/serverless/modules/rp_tips.py
@@ -1,21 +1,24 @@
-'''
+"""
 RunPod Tips
-'''
+"""
 
 import sys
+
 import runpod.serverless.modules.rp_logger as RunPodLogger
 
 log = RunPodLogger.RunPodLogger()
 
 
 def check_return_size(return_body):
-    '''
+    """
     Checks the size of the return body.
     If the size is above 20MB, it will recommend using storage upload.
-    '''
+    """
     size_bytes = sys.getsizeof(return_body)
     size_mb = round(size_bytes / 1_000_000, 2)
 
     if size_mb > 20:
-        log.tip(f"Your return body is {size_mb} MB which exceeds the 20 MB limit. "
-                "Consider using S3 upload and returning the object's URL instead.")
+        log.tip(
+            f"Your return body is {size_mb} MB which exceeds the 20 MB limit. "
+            "Consider using S3 upload and returning the object's URL instead."
+        )

--- a/runpod/serverless/modules/worker_state.py
+++ b/runpod/serverless/modules/worker_state.py
@@ -1,15 +1,15 @@
-'''
+"""
 Handles getting stuff from environment variables and updating the global state like job id.
-'''
+"""
 
 import os
-import uuid
 import time
-from typing import Optional, Dict, Any, Union
+import uuid
+from typing import Any, Dict, Optional, Union
 
 REF_COUNT_ZERO = time.perf_counter()  # Used for benchmarking with the debugger.
 
-WORKER_ID = os.environ.get('RUNPOD_POD_ID', str(uuid.uuid4()))
+WORKER_ID = os.environ.get("RUNPOD_POD_ID", str(uuid.uuid4()))
 
 
 # ----------------------------------- Flags ---------------------------------- #
@@ -53,7 +53,7 @@ class Job:
 #                                    Tracker                                   #
 # ---------------------------------------------------------------------------- #
 class Jobs:
-    ''' Track the state of current jobs.'''
+    """Track the state of current jobs."""
 
     _instance = None
     jobs = set()
@@ -65,22 +65,22 @@ class Jobs:
         return Jobs._instance
 
     def add_job(self, job_id, job_input=None, webhook=None):
-        '''
+        """
         Adds a job to the list of jobs.
-        '''
+        """
         self.jobs.add(Job(job_id, job_input, webhook))
 
     def remove_job(self, job_id):
-        '''
+        """
         Removes a job from the list of jobs.
-        '''
+        """
         self.jobs.remove(Job(job_id))
 
     def get_job(self, job_id) -> Optional[Union[dict, list, str, int, float, bool]]:
-        '''
+        """
         Returns the job with the given id.
         Used within rp_fastapi.py for local testing.
-        '''
+        """
         for job in self.jobs:
             if job.id == job_id:
                 return job
@@ -88,13 +88,13 @@ class Jobs:
         return None
 
     def get_job_list(self):
-        '''
+        """
         Returns the list of jobs as a string.
-        '''
-        return ','.join(str(job) for job in self.jobs) if self.jobs else None
+        """
+        return ",".join(str(job) for job in self.jobs) if self.jobs else None
 
     def get_job_count(self):
-        '''
+        """
         Returns the number of jobs.
-        '''
+        """
         return len(self.jobs)

--- a/runpod/serverless/utils/__init__.py
+++ b/runpod/serverless/utils/__init__.py
@@ -1,5 +1,4 @@
-''' Allows for the import of all modules in the utils directory. '''
+""" Allows for the import of all modules in the utils directory. """
 
 from .rp_download import download_files_from_urls
-
 from .rp_upload import upload_file_to_bucket, upload_in_memory_object

--- a/runpod/serverless/utils/rp_cleanup.py
+++ b/runpod/serverless/utils/rp_cleanup.py
@@ -1,8 +1,8 @@
-'''
+"""
 runpod | serverless | cleanup.py
 
 Called to clean up the worker pod after a job is completed.
-'''
+"""
 
 import os
 import shutil
@@ -10,16 +10,16 @@ from typing import List
 
 
 def clean(folder_list: List[str] = None):
-    '''
+    """
     Removes the downloads folder.
-    '''
+    """
     shutil.rmtree("input_objects", ignore_errors=True)
     shutil.rmtree("output_objects", ignore_errors=True)
 
     shutil.rmtree("job_files", ignore_errors=True)
 
-    if os.path.exists('output.zip'):
-        os.remove('output.zip')
+    if os.path.exists("output.zip"):
+        os.remove("output.zip")
 
     if folder_list is not None:
         for folder in folder_list:

--- a/runpod/serverless/utils/rp_cuda.py
+++ b/runpod/serverless/utils/rp_cuda.py
@@ -6,9 +6,9 @@ import subprocess
 
 
 def is_available():
-    '''
+    """
     Returns True if CUDA is available, False otherwise.
-    '''
+    """
     try:
         output = subprocess.check_output("nvidia-smi", shell=True)
         if "NVIDIA-SMI" in output.decode():

--- a/runpod/serverless/utils/rp_debugger.py
+++ b/runpod/serverless/utils/rp_debugger.py
@@ -1,14 +1,14 @@
-'''
+"""
 runpod | serverless | rp_debugger.py
 
 A collection of functions to help with debugging.
-'''
+"""
 
-import time
 import datetime
 import platform
-import cpuinfo
+import time
 
+import cpuinfo
 
 # ---------------------------------------------------------------------------- #
 #                                  System Info                                 #
@@ -16,15 +16,15 @@ import cpuinfo
 OS_INFO = f"{platform.system()} {platform.release()}"
 
 try:
-    PROCESSOR = cpuinfo.get_cpu_info()['brand_raw']
+    PROCESSOR = cpuinfo.get_cpu_info()["brand_raw"]
 except KeyError:
-    PROCESSOR = 'Unable to get processor info.'
+    PROCESSOR = "Unable to get processor info."
 
 PYTHON_VERSION = platform.python_version()
 
 
 class Checkpoints:
-    '''
+    """
     A singleton class to store checkpoint times.
 
     Format:
@@ -50,7 +50,8 @@ class Checkpoints:
 
     # Stop a checkpoint
     checkpoints.stop('checkpoint_name')
-    '''
+    """
+
     __instance = None
     checkpoints = []
     name_lookup = {}
@@ -63,78 +64,80 @@ class Checkpoints:
         return Checkpoints.__instance
 
     def add(self, name):
-        '''
+        """
         Add a checkpoint.
         Returns the index of the checkpoint.
-        '''
+        """
         if name in self.name_lookup:
             raise KeyError(f'Checkpoint name "{name}" already exists.')
 
-        self.checkpoints.append({
-            'name': name
-        })
+        self.checkpoints.append({"name": name})
 
         index = len(self.checkpoints) - 1
         self.name_lookup[name] = index
 
     def start(self, name):
-        '''
+        """
         Start a checkpoint.
-        '''
+        """
         if name not in self.name_lookup:
             raise KeyError(f"Checkpoint name '{name}' does not exist.")
 
         index = self.name_lookup[name]
-        self.checkpoints[index]['start'] = time.perf_counter()
-        self.checkpoints[index]['start_utc'] = datetime.datetime.utcnow().isoformat() + 'Z'
+        self.checkpoints[index]["start"] = time.perf_counter()
+        self.checkpoints[index]["start_utc"] = (
+            datetime.datetime.utcnow().isoformat() + "Z"
+        )
 
     def stop(self, name):
-        '''
+        """
         Stop a checkpoint.
-        '''
+        """
         if name not in self.name_lookup:
             raise KeyError(f"Checkpoint name '{name}' does not exist.")
 
         index = self.name_lookup[name]
 
-        if 'start' not in self.checkpoints[index]:
-            raise KeyError('Checkpoint has not been started.')
+        if "start" not in self.checkpoints[index]:
+            raise KeyError("Checkpoint has not been started.")
 
-        self.checkpoints[index]['end'] = time.perf_counter()
-        self.checkpoints[index]['stop_utc'] = datetime.datetime.utcnow().isoformat() + 'Z'
+        self.checkpoints[index]["end"] = time.perf_counter()
+        self.checkpoints[index]["stop_utc"] = (
+            datetime.datetime.utcnow().isoformat() + "Z"
+        )
 
     def get_checkpoints(self):
-        '''
+        """
         Get the results of the checkpoints.
-        '''
+        """
         results = []
         for checkpoint in self.checkpoints:
-            if 'start' not in checkpoint or 'end' not in checkpoint:
+            if "start" not in checkpoint or "end" not in checkpoint:
                 continue
-            start_time = checkpoint['start']
-            end_time = checkpoint['end']
-            checkpoint['duration_ms'] = (end_time - start_time) * 1000
+            start_time = checkpoint["start"]
+            end_time = checkpoint["end"]
+            checkpoint["duration_ms"] = (end_time - start_time) * 1000
 
-            checkpoint.pop('start')
-            checkpoint.pop('end')
+            checkpoint.pop("start")
+            checkpoint.pop("end")
 
             results.append(checkpoint)
 
         return results
 
     def clear(self):
-        '''
+        """
         Clear the checkpoints.
-        '''
+        """
         self.checkpoints = []
         self.name_lookup = {}
 
 
 class LineTimer:
-    '''
+    """
     A utility that can be used to time code execution using the with statement.
     When used the times should be added to the checkpoints object.
-    '''
+    """
 
     def __init__(self, name):
         self.checkpoints = Checkpoints()
@@ -149,9 +152,9 @@ class LineTimer:
 
 
 class FunctionTimer:  # pylint: disable=too-few-public-methods
-    '''
+    """
     A class-based decorator to benchmark a function.
-    '''
+    """
 
     def __init__(self, function):
         self.function = function
@@ -172,38 +175,38 @@ class FunctionTimer:  # pylint: disable=too-few-public-methods
 
 
 def get_debugger_output():
-    '''
+    """
     Return the debugger output.
-    '''
-    print('Getting debugger output...')
+    """
+    print("Getting debugger output...")
     import runpod  # pylint: disable=import-outside-toplevel, cyclic-import
 
-    print('Getting checkpoints...')
+    print("Getting checkpoints...")
 
     checkpoints = Checkpoints()
     ckpt_results = checkpoints.get_checkpoints()
     checkpoints.clear()
 
-    print('Getting system info...')
+    print("Getting system info...")
 
     system_info = {
-        'os': OS_INFO,
-        'processor': PROCESSOR,
-        'python_version': PYTHON_VERSION,
-        'runpod': runpod.__version__,
+        "os": OS_INFO,
+        "processor": PROCESSOR,
+        "python_version": PYTHON_VERSION,
+        "runpod": runpod.__version__,
     }
 
-    print('Debugger output complete.')
+    print("Debugger output complete.")
 
     return {
-        'system_info': system_info,
-        'timestamps': ckpt_results,
+        "system_info": system_info,
+        "timestamps": ckpt_results,
     }
 
 
 def clear_debugger_output():
-    '''
+    """
     Clear the debugger output.
-    '''
+    """
     checkpoints = Checkpoints()
     checkpoints.clear()

--- a/runpod/serverless/utils/rp_download.py
+++ b/runpod/serverless/utils/rp_download.py
@@ -1,38 +1,38 @@
-'''
+"""
 PodWorker | modules | download.py
 
 Called when inputs are images or zip files.
 Downloads them into a temporary directory called "input_objects".
 This directory is cleaned up after the job is complete.
-'''
+"""
 
 import os
 import re
 import uuid
 import zipfile
+from concurrent.futures import ThreadPoolExecutor
+from email import message_from_string
 from typing import List, Union
 from urllib.parse import urlparse
-from email import message_from_string
-from concurrent.futures import ThreadPoolExecutor
 
 import backoff
 from requests import RequestException
-from runpod.http_client import SyncClientSession
 
+from runpod.http_client import SyncClientSession
 
 HEADERS = {"User-Agent": "runpod-python/0.0.0 (https://runpod.io; support@runpod.io)"}
 
 
 def calculate_chunk_size(file_size: int) -> int:
-    '''
+    """
     Calculates the chunk size based on the file size.
-    '''
-    if file_size <= 1024*1024:  # 1 MB
+    """
+    if file_size <= 1024 * 1024:  # 1 MB
         return 1024  # 1 KB
-    if file_size <= 1024*1024*1024:  # 1 GB
-        return 1024*1024  # 1 MB
+    if file_size <= 1024 * 1024 * 1024:  # 1 GB
+        return 1024 * 1024  # 1 MB
 
-    return 1024*1024*10  # 10 MB
+    return 1024 * 1024 * 10  # 10 MB
 
 
 def download_files_from_urls(job_id: str, urls: Union[str, List[str]]) -> List[str]:
@@ -41,29 +41,33 @@ def download_files_from_urls(job_id: str, urls: Union[str, List[str]]) -> List[s
     Returns the list of downloaded file absolute paths.
     Saves the files in a directory called "downloaded_files" in the job directory.
     """
-    download_directory = os.path.abspath(os.path.join('jobs', job_id, 'downloaded_files'))
+    download_directory = os.path.abspath(
+        os.path.join("jobs", job_id, "downloaded_files")
+    )
     os.makedirs(download_directory, exist_ok=True)
 
     @backoff.on_exception(backoff.expo, RequestException, max_tries=3)
     def download_file(url: str, path_to_save: str) -> str:
-        with SyncClientSession().get(url, headers=HEADERS, stream=True, timeout=5) as response:
+        with SyncClientSession().get(
+            url, headers=HEADERS, stream=True, timeout=5
+        ) as response:
             response.raise_for_status()
-            content_disposition = response.headers.get('Content-Disposition')
-            file_extension = ''
+            content_disposition = response.headers.get("Content-Disposition")
+            file_extension = ""
             if content_disposition:
-                msg = message_from_string(f'Content-Disposition: {content_disposition}')
+                msg = message_from_string(f"Content-Disposition: {content_disposition}")
                 params = dict(msg.items())
-                file_extension = os.path.splitext(params.get('filename', ''))[1]
+                file_extension = os.path.splitext(params.get("filename", ""))[1]
 
             # If no extension could be determined from 'Content-Disposition', get it from the URL
             if not file_extension:
                 file_extension = os.path.splitext(urlparse(url).path)[1]
 
-            file_size = int(response.headers.get('Content-Length', 0))
+            file_size = int(response.headers.get("Content-Length", 0))
             chunk_size = calculate_chunk_size(file_size)
 
             # write the content in chunks to the file
-            with open(path_to_save + file_extension, 'wb') as file_path:
+            with open(path_to_save + file_extension, "wb") as file_path:
                 for chunk in response.iter_content(chunk_size=chunk_size):
                     if chunk:  # filter out keep-alive chunks
                         file_path.write(chunk)
@@ -74,7 +78,7 @@ def download_files_from_urls(job_id: str, urls: Union[str, List[str]]) -> List[s
         if url is None:
             return None
 
-        file_name = f'{uuid.uuid4()}'
+        file_name = f"{uuid.uuid4()}"
         output_file_path = os.path.join(download_directory, file_name)
 
         try:
@@ -95,7 +99,7 @@ def download_files_from_urls(job_id: str, urls: Union[str, List[str]]) -> List[s
 
 
 def file(file_url: str) -> dict:
-    '''
+    """
     Downloads a single file from a given URL, file is given a random name.
     First checks if the content-disposition header is set, if so, uses the file name from there.
     If the file is a zip file, it is extracted into a directory with the same name.
@@ -104,16 +108,15 @@ def file(file_url: str) -> dict:
     - The absolute path to the downloaded file
     - File type
     - Original file name
-    '''
-    os.makedirs('job_files', exist_ok=True)
+    """
+    os.makedirs("job_files", exist_ok=True)
 
     download_response = SyncClientSession().get(file_url, headers=HEADERS, timeout=30)
 
     original_file_name = []
     if "Content-Disposition" in download_response.headers.keys():
         original_file_name = re.findall(
-            "filename=(.+)",
-            download_response.headers["Content-Disposition"]
+            "filename=(.+)", download_response.headers["Content-Disposition"]
         )
 
     if len(original_file_name) > 0:
@@ -122,18 +125,18 @@ def file(file_url: str) -> dict:
         download_path = urlparse(file_url).path
         original_file_name = os.path.basename(download_path)
 
-    file_type = os.path.splitext(original_file_name)[1].replace('.', '')
+    file_type = os.path.splitext(original_file_name)[1].replace(".", "")
 
-    file_name = f'{uuid.uuid4()}'
+    file_name = f"{uuid.uuid4()}"
 
-    output_file_path = os.path.join('job_files', f'{file_name}.{file_type}')
-    with open(output_file_path, 'wb') as output_file:
+    output_file_path = os.path.join("job_files", f"{file_name}.{file_type}")
+    with open(output_file_path, "wb") as output_file:
         output_file.write(download_response.content)
 
-    if file_type == 'zip':
-        unziped_directory = os.path.join('job_files', file_name)
+    if file_type == "zip":
+        unziped_directory = os.path.join("job_files", file_name)
         os.makedirs(unziped_directory, exist_ok=True)
-        with zipfile.ZipFile(output_file_path, 'r') as zip_ref:
+        with zipfile.ZipFile(output_file_path, "r") as zip_ref:
             zip_ref.extractall(unziped_directory)
         unziped_directory = os.path.abspath(unziped_directory)
     else:
@@ -143,5 +146,5 @@ def file(file_url: str) -> dict:
         "file_path": os.path.abspath(output_file_path),
         "type": file_type,
         "original_name": original_file_name,
-        "extracted_path": unziped_directory
+        "extracted_path": unziped_directory,
     }

--- a/runpod/serverless/utils/rp_upload.py
+++ b/runpod/serverless/utils/rp_upload.py
@@ -1,23 +1,23 @@
-''' PodWorker | modules | upload.py '''
+""" PodWorker | modules | upload.py """
+
 # pylint: disable=too-many-arguments
 
-import os
 import io
+import logging
+import multiprocessing
+import os
+import shutil
+import threading
 import time
 import uuid
-import shutil
-import logging
-import threading
-import multiprocessing
-from urllib.parse import urlparse
 from typing import Optional, Tuple
+from urllib.parse import urlparse
 
 import boto3
 from boto3 import session
 from boto3.s3.transfer import TransferConfig
 from botocore.config import Config
 from tqdm_loggable.auto import tqdm
-
 
 logger = logging.getLogger("runpod upload utility")
 FMT = "%(filename)-20s:%(lineno)-4d %(asctime)s %(message)s"
@@ -30,59 +30,58 @@ def extract_region_from_url(endpoint_url):
     """
     parsed_url = urlparse(endpoint_url)
     # AWS/backblaze S3-like URL
-    if '.s3.' in endpoint_url:
-        return endpoint_url.split('.s3.')[1].split('.')[0]
+    if ".s3." in endpoint_url:
+        return endpoint_url.split(".s3.")[1].split(".")[0]
 
     # DigitalOcean Spaces-like URL
-    if parsed_url.netloc.endswith('.digitaloceanspaces.com'):
-        return endpoint_url.split('.')[1].split('.digitaloceanspaces.com')[0]
+    if parsed_url.netloc.endswith(".digitaloceanspaces.com"):
+        return endpoint_url.split(".")[1].split(".digitaloceanspaces.com")[0]
 
     return None
 
 
 # --------------------------- S3 Bucket Connection --------------------------- #
 def get_boto_client(
-        bucket_creds: Optional[dict] = None) -> Tuple[boto3.client, TransferConfig]:  # pragma: no cover # pylint: disable=line-too-long
-    '''
+    bucket_creds: Optional[dict] = None,
+) -> Tuple[
+    boto3.client, TransferConfig
+]:  # pragma: no cover # pylint: disable=line-too-long
+    """
     Returns a boto3 client and transfer config for the bucket.
-    '''
+    """
     bucket_session = session.Session()
 
     boto_config = Config(
-        signature_version='s3v4',
-        retries={
-            'max_attempts': 3,
-            'mode': 'standard'
-        }
+        signature_version="s3v4", retries={"max_attempts": 3, "mode": "standard"}
     )
 
     transfer_config = TransferConfig(
         multipart_threshold=1024 * 25,
         max_concurrency=multiprocessing.cpu_count(),
         multipart_chunksize=1024 * 25,
-        use_threads=True
+        use_threads=True,
     )
 
     if bucket_creds:
-        endpoint_url = bucket_creds['endpointUrl']
-        access_key_id = bucket_creds['accessId']
-        secret_access_key = bucket_creds['accessSecret']
+        endpoint_url = bucket_creds["endpointUrl"]
+        access_key_id = bucket_creds["accessId"]
+        secret_access_key = bucket_creds["accessSecret"]
     else:
-        endpoint_url = os.environ.get('BUCKET_ENDPOINT_URL', None)
-        access_key_id = os.environ.get('BUCKET_ACCESS_KEY_ID', None)
-        secret_access_key = os.environ.get('BUCKET_SECRET_ACCESS_KEY', None)
+        endpoint_url = os.environ.get("BUCKET_ENDPOINT_URL", None)
+        access_key_id = os.environ.get("BUCKET_ACCESS_KEY_ID", None)
+        secret_access_key = os.environ.get("BUCKET_SECRET_ACCESS_KEY", None)
 
     if endpoint_url and access_key_id and secret_access_key:
         # Extract region from the endpoint URL
         region = extract_region_from_url(endpoint_url)
 
         boto_client = bucket_session.client(
-            's3',
+            "s3",
             endpoint_url=endpoint_url,
             aws_access_key_id=access_key_id,
             aws_secret_access_key=secret_access_key,
             config=boto_config,
-            region_name=region
+            region_name=region,
         )
     else:
         boto_client = None
@@ -93,10 +92,16 @@ def get_boto_client(
 # ---------------------------------------------------------------------------- #
 #                                 Upload Image                                 #
 # ---------------------------------------------------------------------------- #
-def upload_image(job_id, image_location, result_index=0, results_list=None, bucket_name: Optional[str] = None):  # pylint: disable=line-too-long # pragma: no cover
-    '''
+def upload_image(
+    job_id,
+    image_location,
+    result_index=0,
+    results_list=None,
+    bucket_name: Optional[str] = None,
+):  # pylint: disable=line-too-long # pragma: no cover
+    """
     Upload a single file to bucket storage.
-    '''
+    """
     image_name = str(uuid.uuid4())[:8]
     boto_client, _ = get_boto_client()
     file_extension = os.path.splitext(image_location)[1]
@@ -109,7 +114,9 @@ def upload_image(job_id, image_location, result_index=0, results_list=None, buck
         # Save the output to a file
         print("No bucket endpoint set, saving to disk folder 'simulated_uploaded'")
         print("If this is a live endpoint, please reference the following:")
-        print("https://github.com/runpod/runpod-python/blob/main/docs/serverless/utils/rp_upload.md")  # pylint: disable=line-too-long
+        print(
+            "https://github.com/runpod/runpod-python/blob/main/docs/serverless/utils/rp_upload.md"
+        )  # pylint: disable=line-too-long
 
         os.makedirs("simulated_uploaded", exist_ok=True)
         sim_upload_location = f"simulated_uploaded/{image_name}{file_extension}"
@@ -122,20 +129,19 @@ def upload_image(job_id, image_location, result_index=0, results_list=None, buck
 
         return sim_upload_location
 
-    bucket = bucket_name if bucket_name else time.strftime('%m-%y')
+    bucket = bucket_name if bucket_name else time.strftime("%m-%y")
     boto_client.put_object(
-        Bucket=f'{bucket}',
-        Key=f'{job_id}/{image_name}{file_extension}',
+        Bucket=f"{bucket}",
+        Key=f"{job_id}/{image_name}{file_extension}",
         Body=output,
-        ContentType=content_type
+        ContentType=content_type,
     )
 
     presigned_url = boto_client.generate_presigned_url(
-        'get_object',
-        Params={
-            'Bucket': f'{bucket}',
-            'Key': f'{job_id}/{image_name}{file_extension}'
-        }, ExpiresIn=604800)
+        "get_object",
+        Params={"Bucket": f"{bucket}", "Key": f"{job_id}/{image_name}{file_extension}"},
+        ExpiresIn=604800,
+    )
 
     if results_list is not None:
         results_list[result_index] = presigned_url
@@ -147,17 +153,16 @@ def upload_image(job_id, image_location, result_index=0, results_list=None, buck
 #                                Files To Upload                               #
 # ---------------------------------------------------------------------------- #
 def files(job_id, file_list):  # pragma: no cover
-    '''
+    """
     Uploads a list of files in parallel.
     Once all files are uploaded, the function returns the presigned URLs list.
-    '''
+    """
     upload_progress = []  # List of threads
     file_urls = [None] * len(file_list)  # Resulting list of URLs for each file
 
     for index, selected_file in enumerate(file_list):
         new_upload = threading.Thread(
-            target=upload_image,
-            args=(job_id, selected_file, index, file_urls)
+            target=upload_image, args=(job_id, selected_file, index, file_urls)
         )
 
         new_upload.start()
@@ -172,65 +177,65 @@ def files(job_id, file_list):  # pragma: no cover
 
 # --------------------------- Custom Bucket Upload --------------------------- #
 def bucket_upload(job_id, file_list, bucket_creds):  # pragma: no cover
-    '''
+    """
     Uploads files to bucket storage.
-    '''
+    """
     temp_bucket_session = session.Session()
 
     temp_boto_config = Config(
-        signature_version='s3v4',
-        retries={
-            'max_attempts': 3,
-            'mode': 'standard'
-        }
+        signature_version="s3v4", retries={"max_attempts": 3, "mode": "standard"}
     )
 
     temp_boto_client = temp_bucket_session.client(
-        's3',
-        endpoint_url=bucket_creds['endpointUrl'],
-        aws_access_key_id=bucket_creds['accessId'],
-        aws_secret_access_key=bucket_creds['accessSecret'],
-        config=temp_boto_config
+        "s3",
+        endpoint_url=bucket_creds["endpointUrl"],
+        aws_access_key_id=bucket_creds["accessId"],
+        aws_secret_access_key=bucket_creds["accessSecret"],
+        config=temp_boto_config,
     )
 
     bucket_urls = []
 
     for selected_file in file_list:
-        with open(selected_file, 'rb') as file_data:
+        with open(selected_file, "rb") as file_data:
             temp_boto_client.put_object(
-                Bucket=str(bucket_creds['bucketName']),
-                Key=f'{job_id}/{selected_file}',
+                Bucket=str(bucket_creds["bucketName"]),
+                Key=f"{job_id}/{selected_file}",
                 Body=file_data,
             )
 
         bucket_urls.append(
-            f"{bucket_creds['endpointUrl']}/{bucket_creds['bucketName']}/{job_id}/{selected_file}")
+            f"{bucket_creds['endpointUrl']}/{bucket_creds['bucketName']}/{job_id}/{selected_file}"
+        )
 
     return bucket_urls
 
 
 # ------------------------- Single File Bucket Upload ------------------------ #
 def upload_file_to_bucket(
-        file_name: str, file_location: str,
-        bucket_creds: Optional[dict] = None,
-        bucket_name: Optional[str] = None,
-        prefix: Optional[str] = None,
-        extra_args: Optional[dict] = None
+    file_name: str,
+    file_location: str,
+    bucket_creds: Optional[dict] = None,
+    bucket_name: Optional[str] = None,
+    prefix: Optional[str] = None,
+    extra_args: Optional[dict] = None,
 ) -> str:  # pragma: no cover
-    '''
+    """
     Uploads a single file to bucket storage and returns a presigned URL.
-    '''
+    """
     boto_client, transfer_config = get_boto_client(bucket_creds)
 
     if not bucket_name:
-        bucket_name = time.strftime('%m-%y')
+        bucket_name = time.strftime("%m-%y")
 
     key = f"{prefix}/{file_name}" if prefix else file_name
 
     if boto_client is None:
         print("No bucket endpoint set, saving to disk folder 'local_upload'")
         print("If this is a live endpoint, please reference the following:")
-        print("https://github.com/runpod/runpod-python/blob/main/docs/serverless/utils/rp_upload.md")  # pylint: disable=line-too-long
+        print(
+            "https://github.com/runpod/runpod-python/blob/main/docs/serverless/utils/rp_upload.md"
+        )  # pylint: disable=line-too-long
 
         os.makedirs("local_upload", exist_ok=True)
         local_upload_location = f"local_upload/{file_name}"
@@ -239,13 +244,15 @@ def upload_file_to_bucket(
         return local_upload_location
 
     file_size = os.path.getsize(file_location)
-    with tqdm(total=file_size, unit='B', unit_scale=True, desc=file_name) as progress_bar:
+    with tqdm(
+        total=file_size, unit="B", unit_scale=True, desc=file_name
+    ) as progress_bar:
         upload_file_args = {
             "Filename": file_location,
             "Bucket": bucket_name,
             "Key": key,
             "Config": transfer_config,
-            "Callback": progress_bar.update
+            "Callback": progress_bar.update,
         }
 
         if extra_args:
@@ -254,44 +261,44 @@ def upload_file_to_bucket(
         boto_client.upload_file(**upload_file_args)
 
     presigned_url = boto_client.generate_presigned_url(
-        'get_object',
-        Params={
-            'Bucket': bucket_name,
-            'Key': key
-        }, ExpiresIn=604800)
+        "get_object", Params={"Bucket": bucket_name, "Key": key}, ExpiresIn=604800
+    )
 
     return presigned_url
 
 
 # --------------------------- Upload Memory Object --------------------------- #
 def upload_in_memory_object(
-        file_name: str, file_data: bytes,
-        bucket_creds: Optional[dict] = None,
-        bucket_name: Optional[str] = None,
-        prefix: Optional[str] = None) -> str:  # pragma: no cover
-    '''
+    file_name: str,
+    file_data: bytes,
+    bucket_creds: Optional[dict] = None,
+    bucket_name: Optional[str] = None,
+    prefix: Optional[str] = None,
+) -> str:  # pragma: no cover
+    """
     Uploads an in-memory object (bytes) to bucket storage and returns a presigned URL.
-    '''
+    """
     boto_client, transfer_config = get_boto_client(bucket_creds)
 
     if not bucket_name:
-        bucket_name = time.strftime('%m-%y')
+        bucket_name = time.strftime("%m-%y")
 
     key = f"{prefix}/{file_name}" if prefix else file_name
 
     file_size = len(file_data)
-    with tqdm(total=file_size, unit='B', unit_scale=True, desc=file_name) as progress_bar:
+    with tqdm(
+        total=file_size, unit="B", unit_scale=True, desc=file_name
+    ) as progress_bar:
         boto_client.upload_fileobj(
-            io.BytesIO(file_data), bucket_name, key,
+            io.BytesIO(file_data),
+            bucket_name,
+            key,
             Config=transfer_config,
-            Callback=progress_bar.update
+            Callback=progress_bar.update,
         )
 
     presigned_url = boto_client.generate_presigned_url(
-        'get_object',
-        Params={
-            'Bucket': bucket_name,
-            'Key': key
-        }, ExpiresIn=604800)
+        "get_object", Params={"Bucket": bucket_name, "Key": key}, ExpiresIn=604800
+    )
 
     return presigned_url

--- a/runpod/serverless/utils/rp_validator.py
+++ b/runpod/serverless/utils/rp_validator.py
@@ -1,7 +1,8 @@
-'''
+"""
 runpod | serverless | utils | validator.py
 Provides a function to validate the input to the model.
-'''
+"""
+
 # pylint: disable=too-many-branches
 
 import json
@@ -20,6 +21,7 @@ SCHEMA_ERROR = "Schema error, {} is not a dictionary."
 def _add_error(error_list: List[str], message: str) -> None:
     error_list.append(message)
 
+
 def _check_for_unexpected_inputs(raw_input, schema, error_list):
     for key in raw_input:
         if key not in schema:
@@ -35,18 +37,20 @@ def _validate_and_transform_schema_items(schema, error_list):
                 _add_error(error_list, SCHEMA_ERROR.format(key))
 
 
-def _validate_required_inputs_and_set_defaults(raw_input, schema, validated_input, error_list):
+def _validate_required_inputs_and_set_defaults(
+    raw_input, schema, validated_input, error_list
+):
     for key, rules in schema.items():
-        if 'type' not in rules:
+        if "type" not in rules:
             _add_error(error_list, MISSING_TYPE_ERROR.format(key))
 
-        if 'required' not in rules:
+        if "required" not in rules:
             _add_error(error_list, MISSING_REQUIRED_ERROR.format(key))
-        elif rules['required'] and key not in raw_input:
+        elif rules["required"] and key not in raw_input:
             _add_error(error_list, MISSING_REQUIRED_ERROR.format(key))
-        elif not rules['required'] and key not in raw_input:
+        elif not rules["required"] and key not in raw_input:
             if "default" in rules:
-                validated_input[key] = rules['default']
+                validated_input[key] = rules["default"]
             else:
                 _add_error(error_list, MISSING_DEFAULT_ERROR.format(key))
 
@@ -56,27 +60,33 @@ def _validate_input_against_schema(schema, validated_input, error_list):
         if key in validated_input:
             # Enforce floats to be floats.
             try:
-                if rules['type'] is float and type(validated_input[key]) in [int, float]:
+                if rules["type"] is float and type(validated_input[key]) in [
+                    int,
+                    float,
+                ]:
                     validated_input[key] = float(validated_input[key])
             except TypeError:
                 continue
 
             # Check for the correct type.
-            is_instance = isinstance(validated_input[key], rules['type'])
+            is_instance = isinstance(validated_input[key], rules["type"])
             if validated_input[key] is not None and not is_instance:
                 _add_error(
                     error_list,
-                    f"{key} should be {rules['type']} type, not {type(validated_input[key])}."
+                    f"{key} should be {rules['type']} type, not {type(validated_input[key])}.",
                 )
 
         # Check lambda constraints.
-        if "constraints" in rules and not rules['constraints'](validated_input.get(key)):
+        if "constraints" in rules and not rules["constraints"](
+            validated_input.get(key)
+        ):
             _add_error(error_list, CONSTRAINTS_ERROR.format(key))
+
 
 def validate(
     raw_input: Dict[str, Any], schema: Dict[str, Any]
 ) -> Dict[str, Union[Dict[str, Any], List[str]]]:
-    '''
+    """
     Validates the input.
     Checks to see if the provided inputs match the expected types.
     Checks to see if the required inputs are included.
@@ -87,14 +97,16 @@ def validate(
     {"errors": ["error1", "error2"]}
     or
     {"validated_input": {"input1": "value1", "input2": "value2"}
-    '''
+    """
     error_list = []
     validated_input = raw_input.copy()
 
     # Separate the process into functions for better readability
     _check_for_unexpected_inputs(raw_input, schema, error_list)
     _validate_and_transform_schema_items(schema, error_list)
-    _validate_required_inputs_and_set_defaults(raw_input, schema, validated_input, error_list)
+    _validate_required_inputs_and_set_defaults(
+        raw_input, schema, validated_input, error_list
+    )
     _validate_input_against_schema(schema, validated_input, error_list)
 
     validation_return = {"validated_input": validated_input}

--- a/runpod/serverless/worker.py
+++ b/runpod/serverless/worker.py
@@ -2,17 +2,16 @@
 runpod | serverless | worker_loop.py
 Called to convert a container into a worker pod for the runpod serverless platform.
 """
-import os
+
 import asyncio
-from typing import Dict, Any
+import os
+from typing import Any, Dict
 
 from runpod.http_client import AsyncClientSession
-from runpod.serverless.modules import (
-    rp_logger, rp_local, rp_handler, rp_ping,
-    rp_scale
-)
-from .modules.rp_job import run_job, run_job_generator
+from runpod.serverless.modules import rp_handler, rp_local, rp_logger, rp_ping, rp_scale
+
 from .modules.rp_http import send_result, stream_result
+from .modules.rp_job import run_job, run_job_generator
 from .modules.worker_state import REF_COUNT_ZERO, Jobs
 from .utils import rp_debugger
 
@@ -22,8 +21,8 @@ heartbeat = rp_ping.Heartbeat()
 
 
 def _is_local(config) -> bool:
-    """ Returns True if the worker is running locally, False otherwise. """
-    if config['rp_args'].get('test_input', None):
+    """Returns True if the worker is running locally, False otherwise."""
+    if config["rp_args"].get("test_input", None):
         return True
 
     if os.environ.get("RUNPOD_WEBHOOK_GET_JOB", None) is None:
@@ -36,16 +35,16 @@ async def _process_job(job, session, job_scaler, config):
     if rp_handler.is_generator(config["handler"]):
         is_stream = True
         generator_output = run_job_generator(config["handler"], job)
-        log.debug("Handler is a generator, streaming results.", job['id'])
+        log.debug("Handler is a generator, streaming results.", job["id"])
 
-        job_result = {'output': []}
+        job_result = {"output": []}
         async for stream_output in generator_output:
-            log.debug(f"Stream output: {stream_output}", job['id'])
-            if 'error' in stream_output:
+            log.debug(f"Stream output: {stream_output}", job["id"])
+            if "error" in stream_output:
                 job_result = stream_output
                 break
-            if config.get('return_aggregate_stream', False):
-                job_result['output'].append(stream_output['output'])
+            if config.get("return_aggregate_stream", False):
+                job_result["output"].append(stream_output["output"])
 
             await stream_result(session, stream_output, job)
     else:
@@ -54,20 +53,20 @@ async def _process_job(job, session, job_scaler, config):
 
     # If refresh_worker is set, pod will be reset after job is complete.
     if config.get("refresh_worker", False):
-        log.info("refresh_worker flag set, stopping pod after job.", job['id'])
+        log.info("refresh_worker flag set, stopping pod after job.", job["id"])
         job_result["stopPod"] = True
         job_scaler.kill_worker()
 
     # If rp_debugger is set, debugger output will be returned.
     if config["rp_args"].get("rp_debugger", False) and isinstance(job_result, dict):
         job_result["output"]["rp_debugger"] = rp_debugger.get_debugger_output()
-        log.debug("rp_debugger | Flag set, returning debugger output.", job['id'])
+        log.debug("rp_debugger | Flag set, returning debugger output.", job["id"])
 
         # Calculate ready delay for the debugger output.
         ready_delay = (config["reference_counter_start"] - REF_COUNT_ZERO) * 1000
         job_result["output"]["rp_debugger"]["ready_delay_ms"] = ready_delay
     else:
-        log.debug("rp_debugger | Flag not set, skipping debugger output.", job['id'])
+        log.debug("rp_debugger | Flag not set, skipping debugger output.", job["id"])
         rp_debugger.clear_debugger_output()
 
     # Send the job result to SLS

--- a/runpod/tracer.py
+++ b/runpod/tracer.py
@@ -4,30 +4,26 @@
 
 import asyncio
 import json
-from types import SimpleNamespace
 from datetime import datetime, timezone
-from time import time, monotonic
+from time import monotonic, time
+from types import SimpleNamespace
 from uuid import uuid4
-from requests import (
-    Response,
-    PreparedRequest,
-    structures,
-)
+
 from aiohttp import (
     ClientSession,
     TraceConfig,
-    TraceRequestStartParams,
-    TraceConnectionCreateStartParams,
     TraceConnectionCreateEndParams,
+    TraceConnectionCreateStartParams,
     TraceConnectionReuseconnParams,
+    TraceRequestChunkSentParams,
     TraceRequestEndParams,
     TraceRequestExceptionParams,
-    TraceRequestChunkSentParams,
+    TraceRequestStartParams,
     TraceResponseChunkReceivedParams,
 )
+from requests import PreparedRequest, Response, structures
 
 from .serverless.modules.rp_logger import RunPodLogger
-
 
 log = RunPodLogger()
 

--- a/runpod/user_agent.py
+++ b/runpod/user_agent.py
@@ -7,19 +7,19 @@ from runpod.version import __version__ as runpod_version
 
 
 def construct_user_agent():
-    """ Constructs the User-Agent string for the RunPod-Python-SDK
+    """Constructs the User-Agent string for the RunPod-Python-SDK
 
     Example:
         RunPod-Python-SDK/0.1.0 (Linux 5.4.0-54-generic; x86_64) Language/Python 3.8.5
     """
     os_info = f"{platform.system()} {platform.release()}; {platform.machine()}"
     python_version = platform.python_version()
-    integration_method = os.getenv('RUNPOD_UA_INTEGRATION')
+    integration_method = os.getenv("RUNPOD_UA_INTEGRATION")
 
     ua_components = [
         f"RunPod-Python-SDK/{runpod_version}",
         f"({os_info})",
-        f"Language/Python {python_version}"
+        f"Language/Python {python_version}",
     ]
 
     if integration_method:

--- a/runpod/version.py
+++ b/runpod/version.py
@@ -1,13 +1,14 @@
 """ runpod-python version """
 
+from importlib.metadata import PackageNotFoundError, version
 
-from importlib.metadata import version, PackageNotFoundError
 
 def get_version():
-    """ Get the version of runpod-python """""
+    """ Get the version of runpod-python """ ""
     try:
         return version("runpod")
     except PackageNotFoundError:
         return "unknown"
+
 
 __version__ = get_version()

--- a/setup.py
+++ b/setup.py
@@ -1,90 +1,73 @@
-'''
+"""
 runpod-python | setup.py
 Called to setup the runpod-python package.
-'''
+"""
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 # README.md > long_description
-with open('README.md', encoding='utf-8') as long_description_file:
+with open("README.md", encoding="utf-8") as long_description_file:
     long_description = long_description_file.read()
 
 # requirements.txt > requirements
-with open('requirements.txt', encoding="UTF-8") as requirements_file:
+with open("requirements.txt", encoding="UTF-8") as requirements_file:
     install_requires = requirements_file.read().splitlines()
 
 extras_require = {
-    'test': [
-        'asynctest',
-        'nest_asyncio',
-        'pylint==3.2.5',
-        'pytest',
-        'pytest-cov',
-        'pytest-timeout',
-        'pytest-asyncio',
+    "test": [
+        "asynctest",
+        "nest_asyncio",
+        "pylint==3.2.5",
+        "pytest",
+        "pytest-cov",
+        "pytest-timeout",
+        "pytest-asyncio",
     ]
 }
 
 if __name__ == "__main__":
 
     setup(
-        name='runpod',
-
+        name="runpod",
         use_scm_version=True,
-
-        setup_requires=[
-            'setuptools>=45',
-            'setuptools_scm',
-            'wheel'
-        ],
-
+        setup_requires=["setuptools>=45", "setuptools_scm", "wheel"],
         install_requires=install_requires,
-
         extras_require=extras_require,
-
         packages=find_packages(),
-
-        python_requires='>=3.8',
-
-        description='🐍 | Python library for RunPod API and serverless worker SDK.',
-
+        python_requires=">=3.8",
+        description="🐍 | Python library for RunPod API and serverless worker SDK.",
         long_description=long_description,
-
-        long_description_content_type='text/markdown',
-
-        author='RunPod',
-
-        author_email='engineer@runpod.io',
-
-        url='https://runpod.io',
-
+        long_description_content_type="text/markdown",
+        author="RunPod",
+        author_email="engineer@runpod.io",
+        url="https://runpod.io",
         project_urls={
-            'Documentation': 'https://docs.runpod.io',
-            'Source': 'https://github.com/runpod/runpod-python',
-            'Bug Tracker': 'https://github.com/runpod/runpod-python/issues',
-            'Changelog': 'https://github.com/runpod/runpod-python/blob/main/CHANGELOG.md'
+            "Documentation": "https://docs.runpod.io",
+            "Source": "https://github.com/runpod/runpod-python",
+            "Bug Tracker": "https://github.com/runpod/runpod-python/issues",
+            "Changelog": "https://github.com/runpod/runpod-python/blob/main/CHANGELOG.md",
         },
-
         classifiers=[
-            'Environment :: Web Environment',
-            'Intended Audience :: Developers',
-            'License :: OSI Approved :: MIT License',
-            'Operating System :: OS Independent',
-            'Programming Language :: Python',
-            'Programming Language :: Python :: 3',
-            'Topic :: Internet :: WWW/HTTP',
-            'Topic :: Internet :: WWW/HTTP :: Dynamic Content'
+            "Environment :: Web Environment",
+            "Intended Audience :: Developers",
+            "License :: OSI Approved :: MIT License",
+            "Operating System :: OS Independent",
+            "Programming Language :: Python",
+            "Programming Language :: Python :: 3",
+            "Topic :: Internet :: WWW/HTTP",
+            "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         ],
-
         include_package_data=True,
-
-        entry_points={
-            'console_scripts': [
-                'runpod = runpod.cli.entry:runpod_cli'
-            ]
-        },
-
-        keywords=['runpod', 'ai', 'gpu', 'serverless', 'SDK', 'API', 'python', 'library'],
-
-        license='MIT'
+        entry_points={"console_scripts": ["runpod = runpod.cli.entry:runpod_cli"]},
+        keywords=[
+            "runpod",
+            "ai",
+            "gpu",
+            "serverless",
+            "SDK",
+            "API",
+            "python",
+            "library",
+        ],
+        license="MIT",
     )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
-''' Allows tests to be imported as a module.'''
+""" Allows tests to be imported as a module."""
 
 import sys
 
-sys.path.append('src')
+sys.path.append("src")

--- a/tests/test_api/__init__.py
+++ b/tests/test_api/__init__.py
@@ -1,1 +1,1 @@
-''' Allows files to be imported from this directory. '''
+""" Allows files to be imported from this directory. """

--- a/tests/test_api/test_mutation_container_registry_auth.py
+++ b/tests/test_api/test_mutation_container_registry_auth.py
@@ -8,7 +8,7 @@ from runpod.api.mutations.container_register_auth import (
 
 
 class TestGenerateContainerRegistryAuth(unittest.TestCase):
-    """ Test suite for the generate_container_registry_auth function. """
+    """Test suite for the generate_container_registry_auth function."""
 
     def test_generate_container_registry_auth(self):
         """

--- a/tests/test_api/test_mutation_endpoints.py
+++ b/tests/test_api/test_mutation_endpoints.py
@@ -20,16 +20,25 @@ class TestGenerateEndpointMutation(unittest.TestCase):
     def test_all_fields(self):
         """Test all the fields."""
         result = generate_endpoint_mutation(
-            "test_name", "test_template_id", "AMPERE_20",
-            "test_volume_id", "US_WEST", 10, "WORKER_COUNT", 5, 2, 4, True
+            "test_name",
+            "test_template_id",
+            "AMPERE_20",
+            "test_volume_id",
+            "US_WEST",
+            10,
+            "WORKER_COUNT",
+            5,
+            2,
+            4,
+            True,
         )
         self.assertIn('name: "test_name-fb"', result)
         self.assertIn('templateId: "test_template_id"', result)
         self.assertIn('gpuIds: "AMPERE_20"', result)
         self.assertIn('networkVolumeId: "test_volume_id"', result)
         self.assertIn('locations: "US_WEST"', result)
-        self.assertIn('idleTimeout: 10', result)
+        self.assertIn("idleTimeout: 10", result)
         self.assertIn('scalerType: "WORKER_COUNT"', result)
-        self.assertIn('scalerValue: 5', result)
-        self.assertIn('workersMin: 2', result)
-        self.assertIn('workersMax: 4', result)
+        self.assertIn("scalerValue: 5", result)
+        self.assertIn("workersMin: 2", result)
+        self.assertIn("workersMax: 4", result)

--- a/tests/test_api/test_mutations_pods.py
+++ b/tests/test_api/test_mutations_pods.py
@@ -1,4 +1,4 @@
-''' Test API Wrapper Pod Mutations '''
+""" Test API Wrapper Pod Mutations """
 
 import unittest
 
@@ -6,12 +6,12 @@ from runpod.api.mutations import pods
 
 
 class TestPodMutations(unittest.TestCase):
-    ''' Test API Wrapper Pod Mutations '''
+    """Test API Wrapper Pod Mutations"""
 
     def test_generate_pod_deployment_mutation(self):
-        '''
+        """
         Test generate_pod_deployment_mutation
-        '''
+        """
         result = pods.generate_pod_deployment_mutation(
             name="test",
             image_name="test_image",
@@ -30,32 +30,32 @@ class TestPodMutations(unittest.TestCase):
             env={"ENV": "test"},
             support_public_ip=True,
             template_id="abcde",
-            allowed_cuda_versions=["11.8", "12.0"]
+            allowed_cuda_versions=["11.8", "12.0"],
         )
 
         # Here you should check the correct structure of the result
         self.assertIn("mutation", result)
 
     def test_generate_pod_stop_mutation(self):
-        '''
+        """
         Test generate_pod_stop_mutation
-        '''
+        """
         result = pods.generate_pod_stop_mutation("pod_id")
         # Here you should check the correct structure of the result
         self.assertIn("mutation", result)
 
     def test_generate_pod_resume_mutation(self):
-        '''
+        """
         Test generate_pod_resume_mutation
-        '''
+        """
         result = pods.generate_pod_resume_mutation("pod_id", 1)
         # Here you should check the correct structure of the result
         self.assertIn("mutation", result)
 
     def test_generate_pod_terminate_mutation(self):
-        '''
+        """
         Test generate_pod_terminate_mutation
-        '''
+        """
         result = pods.generate_pod_terminate_mutation("pod_id")
         # Here you should check the correct structure of the result
         self.assertIn("mutation", result)

--- a/tests/test_cli/__init__.py
+++ b/tests/test_cli/__init__.py
@@ -1,1 +1,1 @@
-''' Allows tests to be imported. '''
+""" Allows tests to be imported. """

--- a/tests/test_cli/test_cli_groups/__init__.py
+++ b/tests/test_cli/test_cli_groups/__init__.py
@@ -1,1 +1,1 @@
-''' Allow CLI groups to be tested. '''
+""" Allow CLI groups to be tested. """

--- a/tests/test_cli/test_cli_groups/test_config_commands.py
+++ b/tests/test_cli/test_cli_groups/test_config_commands.py
@@ -1,80 +1,108 @@
-'''
+"""
 RunPod | Tests | CLI | Commands
-'''
+"""
 
 import unittest
 from unittest.mock import patch
+
 from click.testing import CliRunner
 
 from runpod.cli.entry import runpod_cli
 
+
 class TestCommands(unittest.TestCase):
-    ''' A collection of tests for the CLI commands. '''
+    """A collection of tests for the CLI commands."""
 
     def setUp(self):
         self.runner = CliRunner()
 
     def test_config_wizard(self):
-        ''' Tests the config command. '''
-        with patch('click.echo') as mock_echo, \
-            patch('runpod.cli.groups.config.commands.set_credentials') as mock_set_credentials, \
-            patch('runpod.cli.groups.config.commands.check_credentials') as mock_check_creds, \
-            patch('click.confirm', return_value=True) as mock_confirm, \
-            patch('click.prompt', return_value='KEY') as mock_prompt:
+        """Tests the config command."""
+        with patch("click.echo") as mock_echo, patch(
+            "runpod.cli.groups.config.commands.set_credentials"
+        ) as mock_set_credentials, patch(
+            "runpod.cli.groups.config.commands.check_credentials"
+        ) as mock_check_creds, patch(
+            "click.confirm", return_value=True
+        ) as mock_confirm, patch(
+            "click.prompt", return_value="KEY"
+        ) as mock_prompt:
 
             # Assuming credentials aren't set (doesn't prompt for overwrite)
             mock_check_creds.return_value = (False, None)
 
             # Successful Call with Direct Key
-            result = self.runner.invoke(runpod_cli, ['config', '--profile', 'test', 'KEY'])
+            result = self.runner.invoke(
+                runpod_cli, ["config", "--profile", "test", "KEY"]
+            )
             assert result.exit_code == 0
-            mock_set_credentials.assert_called_with('KEY', 'test', overwrite=True)
+            mock_set_credentials.assert_called_with("KEY", "test", overwrite=True)
             assert mock_echo.call_count == 1
 
             # Successful Call with Prompted Key (since direct key isn't provided)
-            result = self.runner.invoke(runpod_cli, ['config', '--profile', 'test'])
+            result = self.runner.invoke(runpod_cli, ["config", "--profile", "test"])
             assert result.exit_code == 0
-            mock_set_credentials.assert_called_with('KEY', 'test', overwrite=True)
-            mock_prompt.assert_called_with('    > RunPod API Key', hide_input=False, confirmation_prompt=False) # pylint: disable=line-too-long
+            mock_set_credentials.assert_called_with("KEY", "test", overwrite=True)
+            mock_prompt.assert_called_with(
+                "    > RunPod API Key", hide_input=False, confirmation_prompt=False
+            )  # pylint: disable=line-too-long
 
             # Simulating existing credentials, prompting for overwrite
             mock_check_creds.return_value = (True, None)
-            result = self.runner.invoke(runpod_cli, ['config', '--profile', 'test'])
+            result = self.runner.invoke(runpod_cli, ["config", "--profile", "test"])
             mock_confirm.assert_called_with(
-                'Credentials already set for profile: test. Overwrite?', abort=True)
+                "Credentials already set for profile: test. Overwrite?", abort=True
+            )
 
             # Unsuccessful Call
             mock_set_credentials.side_effect = ValueError()
-            result = self.runner.invoke(runpod_cli, ['config', '--profile', 'test', 'KEY'])
+            result = self.runner.invoke(
+                runpod_cli, ["config", "--profile", "test", "KEY"]
+            )
             assert result.exit_code == 1
 
     def test_check_flag(self):
-        """ Tests the --check flag. """
-        with patch('runpod.cli.groups.config.commands.check_credentials') as mock_check_creds:
+        """Tests the --check flag."""
+        with patch(
+            "runpod.cli.groups.config.commands.check_credentials"
+        ) as mock_check_creds:
             # Assuming credentials are set
             mock_check_creds.return_value = (True, None)
-            result = self.runner.invoke(runpod_cli, ['config', '--check', '--profile', 'test'])
+            result = self.runner.invoke(
+                runpod_cli, ["config", "--check", "--profile", "test"]
+            )
             assert result.exit_code == 0
 
             # Assuming credentials aren't set
             mock_check_creds.return_value = (False, "Credentials not found.")
-            result = self.runner.invoke(runpod_cli, ['config', '--check', '--profile', 'test'])
+            result = self.runner.invoke(
+                runpod_cli, ["config", "--check", "--profile", "test"]
+            )
             assert result.exit_code == 1
 
     def test_output_messages(self):
-        """ Tests the output messages for the config command. """
-        with patch('click.echo') as mock_echo, \
-            patch('runpod.cli.groups.config.commands.set_credentials') as mock_set_credentials, \
-            patch('runpod.cli.groups.config.commands.check_credentials', return_value=(False, None)) as mock_check_creds: # pylint: disable=line-too-long
-            result = self.runner.invoke(runpod_cli, ['config', 'KEY', '--profile', 'test'])
-            mock_set_credentials.assert_called_with('KEY', 'test', overwrite=True)
-            mock_echo.assert_any_call('Credentials set for profile: test in ~/.runpod/config.toml')
+        """Tests the output messages for the config command."""
+        with patch("click.echo") as mock_echo, patch(
+            "runpod.cli.groups.config.commands.set_credentials"
+        ) as mock_set_credentials, patch(
+            "runpod.cli.groups.config.commands.check_credentials",
+            return_value=(False, None),
+        ) as mock_check_creds:  # pylint: disable=line-too-long
+            result = self.runner.invoke(
+                runpod_cli, ["config", "KEY", "--profile", "test"]
+            )
+            mock_set_credentials.assert_called_with("KEY", "test", overwrite=True)
+            mock_echo.assert_any_call(
+                "Credentials set for profile: test in ~/.runpod/config.toml"
+            )
             assert result.exit_code == 0
             assert mock_check_creds.call_count == 1
 
     def test_api_key_prompt(self):
-        """ Tests the API key prompt. """
-        with patch('click.prompt', return_value='KEY') as mock_prompt:
-            result = self.runner.invoke(runpod_cli, ['config', '--profile', 'test'])
-            mock_prompt.assert_called_with('    > RunPod API Key', hide_input=False, confirmation_prompt=False) # pylint: disable=line-too-long
+        """Tests the API key prompt."""
+        with patch("click.prompt", return_value="KEY") as mock_prompt:
+            result = self.runner.invoke(runpod_cli, ["config", "--profile", "test"])
+            mock_prompt.assert_called_with(
+                "    > RunPod API Key", hide_input=False, confirmation_prompt=False
+            )  # pylint: disable=line-too-long
             assert result.exit_code == 0

--- a/tests/test_cli/test_cli_groups/test_config_functions.py
+++ b/tests/test_cli/test_cli_groups/test_config_functions.py
@@ -1,48 +1,46 @@
-'''
+"""
 Unit tests for the config command.
-'''
+"""
 
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
 
 from runpod.cli.groups.config import functions
 
 
 class TestConfig(unittest.TestCase):
-    ''' Unit tests for the config function. '''
+    """Unit tests for the config function."""
 
     def setUp(self) -> None:
-        self.sample_credentials = (
-            '[default]\n'
-            'api_key = "RUNPOD_API_KEY"\n'
-        )
+        self.sample_credentials = "[default]\n" 'api_key = "RUNPOD_API_KEY"\n'
 
-    @patch('runpod.cli.groups.config.functions.toml.load')
-    @patch('builtins.open',  new_callable=mock_open())
+    @patch("runpod.cli.groups.config.functions.toml.load")
+    @patch("builtins.open", new_callable=mock_open())
     def test_set_credentials(self, mock_file, mock_toml_load):
-        '''
+        """
         Tests the set_credentials function.
-        '''
+        """
         mock_toml_load.return_value = ""
-        functions.set_credentials('RUNPOD_API_KEY')
+        functions.set_credentials("RUNPOD_API_KEY")
 
-
-        mock_file.assert_called_with(functions.CREDENTIAL_FILE, 'w', encoding="UTF-8")
+        mock_file.assert_called_with(functions.CREDENTIAL_FILE, "w", encoding="UTF-8")
 
         with self.assertRaises(ValueError) as context:
-            mock_toml_load.return_value = {'default': True}
-            functions.set_credentials('RUNPOD_API_KEY')
+            mock_toml_load.return_value = {"default": True}
+            functions.set_credentials("RUNPOD_API_KEY")
 
-        self.assertEqual(str(context.exception),
-                         'Profile already exists. Use `update_credentials` instead.')
+        self.assertEqual(
+            str(context.exception),
+            "Profile already exists. Use `update_credentials` instead.",
+        )
 
-    @patch('builtins.open',  new_callable=mock_open())
-    @patch('runpod.cli.groups.config.functions.toml.load')
-    @patch('runpod.cli.groups.config.functions.os.path.exists')
+    @patch("builtins.open", new_callable=mock_open())
+    @patch("runpod.cli.groups.config.functions.toml.load")
+    @patch("runpod.cli.groups.config.functions.os.path.exists")
     def test_check_credentials(self, mock_exists, mock_toml_load, mock_file):
-        '''mock_open_call
+        """mock_open_call
         Tests the check_credentials function.
-        '''
+        """
         mock_exists.return_value = False
         passed, _ = functions.check_credentials()
         assert passed is False
@@ -54,7 +52,7 @@ class TestConfig(unittest.TestCase):
         assert passed is False
 
         mock_exists.return_value = True
-        mock_toml_load.return_value = dict({'default': 'something'})
+        mock_toml_load.return_value = dict({"default": "something"})
         passed, _ = functions.check_credentials()
         assert passed is False
 
@@ -62,33 +60,40 @@ class TestConfig(unittest.TestCase):
         passed, _ = functions.check_credentials()
         assert passed is False
 
-        mock_toml_load.return_value = dict({'default': 'api_key'})
+        mock_toml_load.return_value = dict({"default": "api_key"})
         passed, _ = functions.check_credentials()
         assert passed is True
 
-
-    @patch('os.path.exists', return_value=True)
-    @patch('runpod.cli.groups.config.functions.toml.load')
-    @patch('builtins.open', new_callable=mock_open, read_data='[default]\nkey = "value"')
-    def test_get_credentials_existing_profile(self, mock_open_call, mock_toml_load, mock_exists):
-        '''
+    @patch("os.path.exists", return_value=True)
+    @patch("runpod.cli.groups.config.functions.toml.load")
+    @patch(
+        "builtins.open", new_callable=mock_open, read_data='[default]\nkey = "value"'
+    )
+    def test_get_credentials_existing_profile(
+        self, mock_open_call, mock_toml_load, mock_exists
+    ):
+        """
         Tests the get_credentials function.
-        '''
-        mock_toml_load.return_value = {'default': {'key': 'value'}}
-        result = functions.get_credentials('default')
-        assert result == {'key': 'value'}
+        """
+        mock_toml_load.return_value = {"default": {"key": "value"}}
+        result = functions.get_credentials("default")
+        assert result == {"key": "value"}
         assert mock_open_call.called
         assert mock_exists.called
 
-    @patch('os.path.exists', return_value=True)
-    @patch('runpod.cli.groups.config.functions.toml.load')
-    @patch('builtins.open', new_callable=mock_open, read_data='[default]\nkey = "value"')
-    def test_get_credentials_non_existent_profile(self, mock_open_call, mock_toml_load, mock_exists): # pylint: disable=line-too-long
-        '''
+    @patch("os.path.exists", return_value=True)
+    @patch("runpod.cli.groups.config.functions.toml.load")
+    @patch(
+        "builtins.open", new_callable=mock_open, read_data='[default]\nkey = "value"'
+    )
+    def test_get_credentials_non_existent_profile(
+        self, mock_open_call, mock_toml_load, mock_exists
+    ):  # pylint: disable=line-too-long
+        """
         Tests the get_credentials function.
-        '''
-        mock_toml_load.return_value = {'default': {'key': 'value'}}
-        result = functions.get_credentials('non_existent')
+        """
+        mock_toml_load.return_value = {"default": {"key": "value"}}
+        result = functions.get_credentials("non_existent")
         assert result is None
         assert mock_open_call.called
         assert mock_exists.called

--- a/tests/test_cli/test_cli_groups/test_exec_commands.py
+++ b/tests/test_cli/test_cli_groups/test_exec_commands.py
@@ -1,6 +1,7 @@
-'''
+"""
 Tests for Runpod CLI exec commands.
-'''
+"""
+
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -9,40 +10,51 @@ import click
 
 from runpod.cli.entry import runpod_cli
 
+
 class TestExecCommands(unittest.TestCase):
-    ''' Tests for Runpod CLI exec commands. '''
+    """Tests for Runpod CLI exec commands."""
 
     def setUp(self):
         self.runner = click.testing.CliRunner()
 
     def test_remote_python_with_provided_pod_id(self):
-        ''' Tests the remote_python command when pod_id is provided directly. '''
-        with tempfile.NamedTemporaryFile() as temp_file, \
-             patch('runpod.cli.groups.exec.commands.python_over_ssh') as mock_python_over_ssh:
-            result = self.runner.invoke(runpod_cli,
-                                        ['exec', 'python',
-                                         '--pod_id', 'sample_pod_id', temp_file.name])
+        """Tests the remote_python command when pod_id is provided directly."""
+        with tempfile.NamedTemporaryFile() as temp_file, patch(
+            "runpod.cli.groups.exec.commands.python_over_ssh"
+        ) as mock_python_over_ssh:
+            result = self.runner.invoke(
+                runpod_cli,
+                ["exec", "python", "--pod_id", "sample_pod_id", temp_file.name],
+            )
             assert result.exit_code == 0
-            mock_python_over_ssh.assert_called_with('sample_pod_id', temp_file.name)
+            mock_python_over_ssh.assert_called_with("sample_pod_id", temp_file.name)
 
     def test_remote_python_without_provided_pod_id_stored(self):
-        ''' Tests the remote_python command when pod_id is retrieved from storage. '''
-        with tempfile.NamedTemporaryFile() as temp_file, \
-             patch('runpod.cli.groups.exec.commands.python_over_ssh') as mock_python_over_ssh, \
-             patch('runpod.cli.groups.exec.commands.get_session_pod', return_value='stored_pod_id') as mock_get_pod_id: # pylint: disable=line-too-long
+        """Tests the remote_python command when pod_id is retrieved from storage."""
+        with tempfile.NamedTemporaryFile() as temp_file, patch(
+            "runpod.cli.groups.exec.commands.python_over_ssh"
+        ) as mock_python_over_ssh, patch(
+            "runpod.cli.groups.exec.commands.get_session_pod",
+            return_value="stored_pod_id",
+        ) as mock_get_pod_id:  # pylint: disable=line-too-long
             mock_python_over_ssh.return_value = None
-            result = self.runner.invoke(runpod_cli, ['exec', 'python', temp_file.name])
+            result = self.runner.invoke(runpod_cli, ["exec", "python", temp_file.name])
             assert result.exit_code == 0
             mock_get_pod_id.assert_called_once()
-            mock_python_over_ssh.assert_called_with('stored_pod_id', temp_file.name)
+            mock_python_over_ssh.assert_called_with("stored_pod_id", temp_file.name)
 
     def test_remote_python_without_provided_pod_id_prompt(self):
-        ''' Tests the remote_python command when pod_id is prompted to user. '''
-        with tempfile.NamedTemporaryFile() as temp_file, \
-             patch('runpod.cli.groups.exec.commands.python_over_ssh') as mock_python_over_ssh, \
-             patch('runpod.cli.groups.exec.commands.get_session_pod', side_effect=lambda: click.prompt('Please provide the pod ID', 'prompted_pod_id')) as mock_get_pod_id: # pylint: disable=line-too-long
+        """Tests the remote_python command when pod_id is prompted to user."""
+        with tempfile.NamedTemporaryFile() as temp_file, patch(
+            "runpod.cli.groups.exec.commands.python_over_ssh"
+        ) as mock_python_over_ssh, patch(
+            "runpod.cli.groups.exec.commands.get_session_pod",
+            side_effect=lambda: click.prompt(
+                "Please provide the pod ID", "prompted_pod_id"
+            ),
+        ) as mock_get_pod_id:  # pylint: disable=line-too-long
             mock_python_over_ssh.return_value = None
-            result = self.runner.invoke(runpod_cli, ['exec', 'python', temp_file.name])
+            result = self.runner.invoke(runpod_cli, ["exec", "python", temp_file.name])
             assert result.exit_code == 0
             mock_get_pod_id.assert_called_once()
-            mock_python_over_ssh.assert_called_with('prompted_pod_id', temp_file.name)
+            mock_python_over_ssh.assert_called_with("prompted_pod_id", temp_file.name)

--- a/tests/test_cli/test_cli_groups/test_exec_functions.py
+++ b/tests/test_cli/test_cli_groups/test_exec_functions.py
@@ -1,28 +1,29 @@
-''' Tests for CLI group `exec functions` '''
+""" Tests for CLI group `exec functions` """
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from runpod.cli.groups.exec import functions
 
-class TestExecFunctions(unittest.TestCase):
-    ''' Tests for CLI group `exec functions` '''
 
-    @patch('runpod.cli.groups.exec.functions.ssh_cmd.SSHConnection')
+class TestExecFunctions(unittest.TestCase):
+    """Tests for CLI group `exec functions`"""
+
+    @patch("runpod.cli.groups.exec.functions.ssh_cmd.SSHConnection")
     def test_python_over_ssh(self, mock_ssh_connection):
-        '''
+        """
         Test `python_over_ssh`
-        '''
+        """
         mock_ssh = MagicMock()
         mock_ssh_connection.return_value = mock_ssh
 
-        pod_id = 'pod_id'
-        file_name = 'file_name'
+        pod_id = "pod_id"
+        file_name = "file_name"
 
         functions.python_over_ssh(pod_id, file_name)
 
         self.assertTrue(functions.python_over_ssh)
         mock_ssh_connection.assert_called_once_with(pod_id)
-        mock_ssh.put_file.assert_called_once_with(file_name, f'/root/{file_name}')
-        mock_ssh.run_commands.assert_called_once_with([f'python3.10 /root/{file_name}'])
+        mock_ssh.put_file.assert_called_once_with(file_name, f"/root/{file_name}")
+        mock_ssh.run_commands.assert_called_once_with([f"python3.10 /root/{file_name}"])
         mock_ssh.close.assert_called_once_with()

--- a/tests/test_cli/test_cli_groups/test_exec_helpers.py
+++ b/tests/test_cli/test_cli_groups/test_exec_helpers.py
@@ -1,70 +1,74 @@
 """ Unit tests for the runpod.cli.groups.exec.helpers module. """
 
 import unittest
-from unittest.mock import patch, mock_open
-from runpod.cli.groups.exec.helpers import get_session_pod, POD_ID_FILE
+from unittest.mock import mock_open, patch
+
+from runpod.cli.groups.exec.helpers import POD_ID_FILE, get_session_pod
+
 
 class TestGetSessionPod(unittest.TestCase):
-    """ Unit tests for get_session_pod """
+    """Unit tests for get_session_pod"""
 
     def setUp(self):
         self.mocked_pod_id = "sample_pod_id"
 
-    @patch('os.path.exists')
-    @patch('runpod.cli.groups.exec.helpers.get_pod')
+    @patch("os.path.exists")
+    @patch("runpod.cli.groups.exec.helpers.get_pod")
     def test_existing_pod_id_file_and_valid_pod_id(self, mock_get_pod, mock_exists):
-        """ Test get_session_pod when the pod_id file exists and the pod_id is valid """
+        """Test get_session_pod when the pod_id file exists and the pod_id is valid"""
         mock_exists.return_value = True
         mock_get_pod.return_value = True
-        with patch('builtins.open', mock_open(read_data=self.mocked_pod_id)):
+        with patch("builtins.open", mock_open(read_data=self.mocked_pod_id)):
             result = get_session_pod()
         self.assertEqual(result, self.mocked_pod_id)
 
-    @patch('os.path.exists')
-    @patch('runpod.cli.groups.exec.helpers.get_pod')
+    @patch("os.path.exists")
+    @patch("runpod.cli.groups.exec.helpers.get_pod")
     def test_existing_pod_id_file_and_invalid_pod_id(self, mock_get_pod, mock_exists):
-        """ Test get_session_pod when the pod_id file exists and the pod_id is invalid """
+        """Test get_session_pod when the pod_id file exists and the pod_id is invalid"""
         mock_exists.return_value = True
         mock_get_pod.return_value = None
-        with patch('builtins.open', mock_open(read_data="invalid_pod_id")):
-            with patch('click.prompt', return_value=self.mocked_pod_id):
+        with patch("builtins.open", mock_open(read_data="invalid_pod_id")):
+            with patch("click.prompt", return_value=self.mocked_pod_id):
                 result = get_session_pod()
         self.assertEqual(result, self.mocked_pod_id)
 
-    @patch('os.path.exists')
-    @patch('runpod.cli.groups.exec.helpers.get_pod')
+    @patch("os.path.exists")
+    @patch("runpod.cli.groups.exec.helpers.get_pod")
     def test_no_pod_id_file(self, mock_get_pod, mock_exists):
-        """ Test get_session_pod when the pod_id file doesn't exist """
+        """Test get_session_pod when the pod_id file doesn't exist"""
         mock_exists.return_value = False
         mock_get_pod.return_value = None
-        with patch('click.prompt', return_value=self.mocked_pod_id):
+        with patch("click.prompt", return_value=self.mocked_pod_id):
             result = get_session_pod()
         self.assertEqual(result, self.mocked_pod_id)
 
-    @patch('os.path.exists')
-    @patch('runpod.cli.groups.exec.helpers.get_pod')
+    @patch("os.path.exists")
+    @patch("runpod.cli.groups.exec.helpers.get_pod")
     def test_pod_id_file_written_to_when_not_existing(self, mock_get_pod, mock_exists):
-        """ Test get_session_pod when the pod_id file doesn't exist """
+        """Test get_session_pod when the pod_id file doesn't exist"""
         mock_exists.return_value = False
         mock_get_pod.return_value = None
         mocked = mock_open()
-        with patch('builtins.open', mocked):
-            with patch('click.prompt', return_value=self.mocked_pod_id):
+        with patch("builtins.open", mocked):
+            with patch("click.prompt", return_value=self.mocked_pod_id):
                 get_session_pod()
-        mocked.assert_called_once_with(POD_ID_FILE, 'w', encoding="UTF-8")
+        mocked.assert_called_once_with(POD_ID_FILE, "w", encoding="UTF-8")
         handle = mocked()
         handle.write.assert_called_once_with(self.mocked_pod_id)
 
-    @patch('os.path.exists')
-    @patch('runpod.cli.groups.exec.helpers.get_pod')
-    def test_pod_id_file_written_to_when_invalid_pod_id_in_file(self, mock_get_pod, mock_exists):
-        """ Test get_session_pod when the pod_id file exists and the pod_id is invalid """
+    @patch("os.path.exists")
+    @patch("runpod.cli.groups.exec.helpers.get_pod")
+    def test_pod_id_file_written_to_when_invalid_pod_id_in_file(
+        self, mock_get_pod, mock_exists
+    ):
+        """Test get_session_pod when the pod_id file exists and the pod_id is invalid"""
         mock_exists.return_value = True
         mock_get_pod.return_value = None
         mocked = mock_open(read_data="invalid_pod_id")
-        with patch('builtins.open', mocked):
-            with patch('click.prompt', return_value=self.mocked_pod_id):
+        with patch("builtins.open", mocked):
+            with patch("click.prompt", return_value=self.mocked_pod_id):
                 get_session_pod()
-        mocked.assert_called_with(POD_ID_FILE, 'w', encoding="UTF-8")
+        mocked.assert_called_with(POD_ID_FILE, "w", encoding="UTF-8")
         handle = mocked()
         handle.write.assert_called_with(self.mocked_pod_id)

--- a/tests/test_cli/test_cli_groups/test_pod_commands.py
+++ b/tests/test_cli/test_cli_groups/test_pod_commands.py
@@ -1,83 +1,98 @@
-''' Test CLI pod commands '''
+""" Test CLI pod commands """
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 from prettytable import PrettyTable
 
 from runpod.cli.entry import runpod_cli
 
-class TestPodCommands(unittest.TestCase):
-    ''' Test CLI pod commands '''
 
-    @patch('runpod.cli.groups.pod.commands.get_pods')
-    @patch('runpod.cli.groups.pod.commands.click.echo')
+class TestPodCommands(unittest.TestCase):
+    """Test CLI pod commands"""
+
+    @patch("runpod.cli.groups.pod.commands.get_pods")
+    @patch("runpod.cli.groups.pod.commands.click.echo")
     def test_list_pods(self, mock_echo, mock_get_pods):
-        '''
+        """
         Test list_pods
-        '''
+        """
         # Mock data returned by get_pods
         mock_get_pods.return_value = [
-            {'id': '1', 'name': 'Pod1', 'desiredStatus': 'Running', 'imageName': 'Image1'},
-            {'id': '2', 'name': 'Pod2', 'desiredStatus': 'Stopped', 'imageName': 'Image2'}
+            {
+                "id": "1",
+                "name": "Pod1",
+                "desiredStatus": "Running",
+                "imageName": "Image1",
+            },
+            {
+                "id": "2",
+                "name": "Pod2",
+                "desiredStatus": "Stopped",
+                "imageName": "Image2",
+            },
         ]
 
         runner = CliRunner()
-        result = runner.invoke(runpod_cli, ['pod', 'list'])
+        result = runner.invoke(runpod_cli, ["pod", "list"])
 
         # Create expected table
         assert result.exit_code == 0, result.exception
-        expected_table = PrettyTable(['ID', 'Name', 'Status', 'Image'])
-        expected_table.add_row(('1', 'Pod1', 'Running', 'Image1'))
-        expected_table.add_row(('2', 'Pod2', 'Stopped', 'Image2'))
+        expected_table = PrettyTable(["ID", "Name", "Status", "Image"])
+        expected_table.add_row(("1", "Pod1", "Running", "Image1"))
+        expected_table.add_row(("2", "Pod2", "Stopped", "Image2"))
 
         # Assert that click.echo was called with the correct table
         mock_echo.assert_called()
 
-
-    @patch('runpod.cli.groups.pod.commands.click.prompt')
-    @patch('runpod.cli.groups.pod.commands.click.confirm')
-    @patch('runpod.cli.groups.pod.commands.click.echo')
-    @patch('runpod.cli.groups.pod.commands.create_pod')
-    def test_create_new_pod(self, mock_create_pod, mock_echo, mock_confirm, mock_prompt): # pylint: disable=too-many-arguments,line-too-long
-        '''
+    @patch("runpod.cli.groups.pod.commands.click.prompt")
+    @patch("runpod.cli.groups.pod.commands.click.confirm")
+    @patch("runpod.cli.groups.pod.commands.click.echo")
+    @patch("runpod.cli.groups.pod.commands.create_pod")
+    def test_create_new_pod(
+        self, mock_create_pod, mock_echo, mock_confirm, mock_prompt
+    ):  # pylint: disable=too-many-arguments,line-too-long
+        """
         Test create_new_pod
-        '''
+        """
         # Mock values
         mock_confirm.return_value = True  # for the quick_launch option
-        mock_prompt.return_value = 'RunPod-CLI-Pod'
-        mock_create_pod.return_value = {'id': 'sample_id'}
+        mock_prompt.return_value = "RunPod-CLI-Pod"
+        mock_create_pod.return_value = {"id": "sample_id"}
 
         runner = CliRunner()
-        result = runner.invoke(runpod_cli, ['pod', 'create'])
+        result = runner.invoke(runpod_cli, ["pod", "create"])
 
         # Assertions
         assert result.exit_code == 0, result.exception
-        mock_prompt.assert_called_once_with('Enter pod name', default='RunPod-CLI-Pod')
-        mock_echo.assert_called_with('Pod sample_id has been created.')
-        mock_create_pod.assert_called_with('RunPod-CLI-Pod',
-                                           'runpod/base:0.0.0',
-                                           'NVIDIA GeForce RTX 3090',
-                                           gpu_count=1, support_public_ip=True, ports='22/tcp')
-        mock_echo.assert_called_with('Pod sample_id has been created.')
+        mock_prompt.assert_called_once_with("Enter pod name", default="RunPod-CLI-Pod")
+        mock_echo.assert_called_with("Pod sample_id has been created.")
+        mock_create_pod.assert_called_with(
+            "RunPod-CLI-Pod",
+            "runpod/base:0.0.0",
+            "NVIDIA GeForce RTX 3090",
+            gpu_count=1,
+            support_public_ip=True,
+            ports="22/tcp",
+        )
+        mock_echo.assert_called_with("Pod sample_id has been created.")
 
-
-    @patch('runpod.cli.groups.pod.commands.click.echo')
-    @patch('runpod.cli.groups.pod.commands.ssh_cmd.SSHConnection')
+    @patch("runpod.cli.groups.pod.commands.click.echo")
+    @patch("runpod.cli.groups.pod.commands.ssh_cmd.SSHConnection")
     def test_connect_to_pod(self, mock_ssh_connection, mock_echo):
-        '''
+        """
         Test connect_to_pod function
-        '''
-        pod_id = 'sample_id'
+        """
+        pod_id = "sample_id"
 
         mock_ssh = MagicMock()
         mock_ssh_connection.return_value = mock_ssh
 
         runner = CliRunner()
-        result = runner.invoke(runpod_cli, ['pod', 'connect', pod_id])
+        result = runner.invoke(runpod_cli, ["pod", "connect", pod_id])
 
         assert result.exit_code == 0, result.exception
-        mock_echo.assert_called_once_with(f'Connecting to pod {pod_id}...')
+        mock_echo.assert_called_once_with(f"Connecting to pod {pod_id}...")
         mock_ssh_connection.assert_called_once_with(pod_id)
         mock_ssh.launch_terminal.assert_called_once_with()

--- a/tests/test_cli/test_cli_groups/test_project_commands.py
+++ b/tests/test_cli/test_cli_groups/test_project_commands.py
@@ -1,25 +1,31 @@
-'''
+"""
 RunPod | CLI | Groups | Project | Commands | Tests
-'''
+"""
+
 import unittest
 from unittest.mock import patch
 
 from click.testing import CliRunner
-from runpod.cli.groups.project.commands import new_project_wizard, start_project_pod, deploy_project
+
+from runpod.cli.groups.project.commands import (
+    deploy_project,
+    new_project_wizard,
+    start_project_pod,
+)
 
 
 class TestProjectCLI(unittest.TestCase):
-    ''' A collection of tests for the Project CLI commands. '''
+    """A collection of tests for the Project CLI commands."""
 
     def setUp(self):
         self.runner = CliRunner()
 
     def test_new_project_wizard_no_network_volumes(self):
-        '''
+        """
         Tests the new_project_wizard command with no network volumes.
-        '''
-        with patch('runpod.cli.groups.project.commands.get_user') as mock_get_user:
-            mock_get_user.return_value = {'networkVolumes':[]}
+        """
+        with patch("runpod.cli.groups.project.commands.get_user") as mock_get_user:
+            mock_get_user.return_value = {"networkVolumes": []}
 
             result = self.runner.invoke(new_project_wizard)
 
@@ -27,65 +33,103 @@ class TestProjectCLI(unittest.TestCase):
         self.assertIn("You do not have any network volumes.", result.output)
 
     def test_new_project_wizard_success(self):
-        '''
+        """
         Tests the new_project_wizard command.
-        '''
-        with patch('click.prompt') as mock_prompt, \
-             patch('click.confirm', return_value=True) as mock_confirm, \
-             patch('runpod.cli.groups.project.commands.create_new_project') as mock_create, \
-             patch('runpod.cli.groups.project.commands.get_user') as mock_get_user, \
-             patch('runpod.cli.groups.project.commands.cli_select') as mock_select:
-            mock_get_user.return_value = {'networkVolumes':[{ 'id': 'XYZ_VOLUME', 'name': 'XYZ_VOLUME', 'size': 100, 'dataCenterId': 'XYZ' }]} # pylint: disable=line-too-long
-            mock_prompt.side_effect = ['TestProject', '11.8.0', '3.10']
-            mock_select.return_value = {'volume-id': 'XYZ_VOLUME'}
+        """
+        with patch("click.prompt") as mock_prompt, patch(
+            "click.confirm", return_value=True
+        ) as mock_confirm, patch(
+            "runpod.cli.groups.project.commands.create_new_project"
+        ) as mock_create, patch(
+            "runpod.cli.groups.project.commands.get_user"
+        ) as mock_get_user, patch(
+            "runpod.cli.groups.project.commands.cli_select"
+        ) as mock_select:
+            mock_get_user.return_value = {
+                "networkVolumes": [
+                    {
+                        "id": "XYZ_VOLUME",
+                        "name": "XYZ_VOLUME",
+                        "size": 100,
+                        "dataCenterId": "XYZ",
+                    }
+                ]
+            }  # pylint: disable=line-too-long
+            mock_prompt.side_effect = ["TestProject", "11.8.0", "3.10"]
+            mock_select.return_value = {"volume-id": "XYZ_VOLUME"}
 
-            result = self.runner.invoke(new_project_wizard, ['--type', 'llama2', '--model', 'meta-llama/Llama-2-7b']) # pylint: disable=line-too-long
+            result = self.runner.invoke(
+                new_project_wizard,
+                ["--type", "llama2", "--model", "meta-llama/Llama-2-7b"],
+            )  # pylint: disable=line-too-long
 
         self.assertEqual(result.exit_code, 0)
         mock_confirm.assert_called_with("Do you want to continue?", abort=True)
         mock_create.assert_called()
         mock_prompt.assert_called()
-        mock_create.assert_called_with('TestProject', 'XYZ_VOLUME', '11.8.0', '3.10', 'llama2', 'meta-llama/Llama-2-7b', False) # pylint: disable=line-too-long
+        mock_create.assert_called_with(
+            "TestProject",
+            "XYZ_VOLUME",
+            "11.8.0",
+            "3.10",
+            "llama2",
+            "meta-llama/Llama-2-7b",
+            False,
+        )  # pylint: disable=line-too-long
         self.assertIn("Project TestProject created successfully!", result.output)
 
     def test_new_project_wizard_success_init_current_dir(self):
-        '''
+        """
         Tests the new_project_wizard command with the --init flag.
-        '''
-        with patch('click.prompt') as mock_prompt, \
-             patch('click.confirm', return_value=True) as mock_confirm, \
-             patch('runpod.cli.groups.project.commands.create_new_project') as mock_create, \
-             patch('runpod.cli.groups.project.commands.get_user') as mock_get_user, \
-             patch('runpod.cli.groups.project.commands.cli_select') as mock_select, \
-             patch('os.getcwd') as mock_getcwd:
-            mock_get_user.return_value = {'networkVolumes':[{ 'id': 'XYZ_VOLUME', 'name': 'XYZ_VOLUME', 'size': 100, 'dataCenterId': 'XYZ' }]} # pylint: disable=line-too-long
-            mock_select.return_value = {'volume-id': 'XYZ_VOLUME'}
-            mock_prompt.side_effect = ['XYZ_VOLUME', '11.8.0', '3.10']
+        """
+        with patch("click.prompt") as mock_prompt, patch(
+            "click.confirm", return_value=True
+        ) as mock_confirm, patch(
+            "runpod.cli.groups.project.commands.create_new_project"
+        ) as mock_create, patch(
+            "runpod.cli.groups.project.commands.get_user"
+        ) as mock_get_user, patch(
+            "runpod.cli.groups.project.commands.cli_select"
+        ) as mock_select, patch(
+            "os.getcwd"
+        ) as mock_getcwd:
+            mock_get_user.return_value = {
+                "networkVolumes": [
+                    {
+                        "id": "XYZ_VOLUME",
+                        "name": "XYZ_VOLUME",
+                        "size": 100,
+                        "dataCenterId": "XYZ",
+                    }
+                ]
+            }  # pylint: disable=line-too-long
+            mock_select.return_value = {"volume-id": "XYZ_VOLUME"}
+            mock_prompt.side_effect = ["XYZ_VOLUME", "11.8.0", "3.10"]
 
-            self.runner.invoke(new_project_wizard, ['--init'])
+            self.runner.invoke(new_project_wizard, ["--init"])
             assert mock_confirm.called
             assert mock_create.called
             assert mock_getcwd.called
 
     def test_new_project_wizard_invalid_name(self):
-        '''
+        """
         Tests the new_project_wizard command with an invalid project name.
-        '''
-        with patch('runpod.cli.groups.project.commands.get_user') as mock_get_user:
-            mock_get_user.return_value = {'networkVolumes':["XYZ_VOLUME"]}
+        """
+        with patch("runpod.cli.groups.project.commands.get_user") as mock_get_user:
+            mock_get_user.return_value = {"networkVolumes": ["XYZ_VOLUME"]}
 
-            result = self.runner.invoke(new_project_wizard, ['--name', 'Invalid/Name'])
+            result = self.runner.invoke(new_project_wizard, ["--name", "Invalid/Name"])
 
         self.assertEqual(result.exit_code, 2)
         self.assertIn("Project name contains an invalid character", result.output)
 
-
     def test_start_project_pod(self):
-        '''
+        """
         Tests the start_project_pod command.
-        '''
-        with patch('click.confirm', return_value=True) as mock_confirm, \
-             patch('runpod.cli.groups.project.commands.start_project') as mock_start:
+        """
+        with patch("click.confirm", return_value=True) as mock_confirm, patch(
+            "runpod.cli.groups.project.commands.start_project"
+        ) as mock_start:
             mock_start.return_value = None
             result = self.runner.invoke(start_project_pod)
 
@@ -93,12 +137,11 @@ class TestProjectCLI(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("Starting project development pod...", result.output)
 
-
-    @patch('runpod.cli.groups.project.commands.click.echo')
-    @patch('runpod.cli.groups.project.commands.create_project_endpoint')
+    @patch("runpod.cli.groups.project.commands.click.echo")
+    @patch("runpod.cli.groups.project.commands.create_project_endpoint")
     def test_deploy_project(self, mock_create_project_endpoint, mock_click_echo):
-        """ Test the deploy_project function. """
-        mock_create_project_endpoint.return_value = 'test_endpoint_id'
+        """Test the deploy_project function."""
+        mock_create_project_endpoint.return_value = "test_endpoint_id"
 
         result = self.runner.invoke(deploy_project)
 
@@ -106,8 +149,14 @@ class TestProjectCLI(unittest.TestCase):
 
         mock_click_echo.assert_any_call("Deploying project...")
         mock_click_echo.assert_any_call("The following urls are available:")
-        mock_click_echo.assert_any_call("    - https://api.runpod.ai/v2/test_endpoint_id/runsync")
-        mock_click_echo.assert_any_call("    - https://api.runpod.ai/v2/test_endpoint_id/run")
-        mock_click_echo.assert_any_call("    - https://api.runpod.ai/v2/test_endpoint_id/health")
+        mock_click_echo.assert_any_call(
+            "    - https://api.runpod.ai/v2/test_endpoint_id/runsync"
+        )
+        mock_click_echo.assert_any_call(
+            "    - https://api.runpod.ai/v2/test_endpoint_id/run"
+        )
+        mock_click_echo.assert_any_call(
+            "    - https://api.runpod.ai/v2/test_endpoint_id/health"
+        )
 
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_cli/test_cli_groups/test_project_functions.py
+++ b/tests/test_cli/test_cli_groups/test_project_functions.py
@@ -3,16 +3,19 @@
 import os
 import shutil
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
 
 from runpod.cli.groups.project.functions import (
-    STARTER_TEMPLATES, create_new_project,
-    start_project, create_project_endpoint
+    STARTER_TEMPLATES,
+    create_new_project,
+    create_project_endpoint,
+    start_project,
 )
 
 
 class TestCreateNewProject(unittest.TestCase):
-    """ Test the create_new_project function."""
+    """Test the create_new_project function."""
+
     def tearDown(self):
         toml_file_location = os.path.join(os.getcwd(), "test_project")
         if os.path.exists(toml_file_location):
@@ -22,8 +25,10 @@ class TestCreateNewProject(unittest.TestCase):
     @patch("os.path.exists", return_value=False)
     @patch("os.getcwd", return_value="/current/path")
     @patch("runpod.cli.groups.project.functions.copy_template_files")
-    def test_create_project_folder(self, mock_copy_template_files, mock_getcwd, mock_exists, mock_makedirs):  # pylint: disable=line-too-long
-        """ Test that a new project folder is created if init_current_dir is False. """
+    def test_create_project_folder(
+        self, mock_copy_template_files, mock_getcwd, mock_exists, mock_makedirs
+    ):  # pylint: disable=line-too-long
+        """Test that a new project folder is created if init_current_dir is False."""
         with patch("builtins.open", new_callable=mock_open):
             create_new_project("test_project", "volume_id", "11.1.1", "3.8")
         mock_makedirs.assert_called_once_with("/current/path/test_project")
@@ -31,21 +36,30 @@ class TestCreateNewProject(unittest.TestCase):
         assert mock_getcwd.called
         assert mock_exists.called
 
-    @patch('os.makedirs')
-    @patch('os.path.exists', return_value=False)
-    @patch('os.getcwd', return_value='/tmp/testdir')
-    @patch('builtins.open', new_callable=mock_open)
-    def test_create_new_project_init_current_dir(self, mock_file_open, mock_getcwd, mock_path_exists, mock_makedirs):  # pylint: disable=line-too-long
-        """ Test that a new project folder is not created if init_current_dir is True. """
+    @patch("os.makedirs")
+    @patch("os.path.exists", return_value=False)
+    @patch("os.getcwd", return_value="/tmp/testdir")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_create_new_project_init_current_dir(
+        self, mock_file_open, mock_getcwd, mock_path_exists, mock_makedirs
+    ):  # pylint: disable=line-too-long
+        """Test that a new project folder is not created if init_current_dir is True."""
         project_name = "test_project"
         runpod_volume_id = "12345"
         cuda_version = "11.1.1"
         python_version = "3.9"
 
         create_new_project(
-            project_name, runpod_volume_id, cuda_version, python_version, init_current_dir=True)
+            project_name,
+            runpod_volume_id,
+            cuda_version,
+            python_version,
+            init_current_dir=True,
+        )
         mock_makedirs.assert_not_called()
-        mock_file_open.assert_called_with('/tmp/testdir/runpod.toml', 'w', encoding="UTF-8")
+        mock_file_open.assert_called_with(
+            "/tmp/testdir/runpod.toml", "w", encoding="UTF-8"
+        )
         assert mock_getcwd.called
         assert mock_path_exists.called is False
 
@@ -53,42 +67,55 @@ class TestCreateNewProject(unittest.TestCase):
     @patch("os.path.exists", return_value=False)
     @patch("os.getcwd", return_value="/current/path")
     @patch("runpod.cli.groups.project.functions.copy_template_files")
-    def test_copy_template_files(self, mock_copy_template_files, mock_getcwd, mock_exists, mock_makedirs):  # pylint: disable=line-too-long
-        """ Test that template files are copied to the new project folder. """
+    def test_copy_template_files(
+        self, mock_copy_template_files, mock_getcwd, mock_exists, mock_makedirs
+    ):  # pylint: disable=line-too-long
+        """Test that template files are copied to the new project folder."""
         with patch("builtins.open", new_callable=mock_open):
             create_new_project("test_project", "volume_id", "11.1.1", "3.8")
         mock_copy_template_files.assert_called_once_with(
-            STARTER_TEMPLATES + "/default", "/current/path/test_project")  # pylint: disable=line-too-long
+            STARTER_TEMPLATES + "/default", "/current/path/test_project"
+        )  # pylint: disable=line-too-long
         assert mock_getcwd.called
         assert mock_exists.called
         assert mock_makedirs.called
 
     @patch("os.path.exists", return_value=True)
-    @patch("builtins.open", new_callable=mock_open, read_data="data with <<MODEL_NAME>> placeholder")  # pylint: disable=line-too-long
-    def test_replace_placeholders_in_handler(self, mock_open_file, mock_exists):  # pylint: disable=line-too-long
-        """ Test that placeholders in handler.py are replaced if model_name is given. """
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data="data with <<MODEL_NAME>> placeholder",
+    )  # pylint: disable=line-too-long
+    def test_replace_placeholders_in_handler(
+        self, mock_open_file, mock_exists
+    ):  # pylint: disable=line-too-long
+        """Test that placeholders in handler.py are replaced if model_name is given."""
         with patch("runpod.cli.groups.project.functions.copy_template_files"):
-            create_new_project("test_project", "volume_id", "11.8.0", "3.8", model_name="my_model")
+            create_new_project(
+                "test_project", "volume_id", "11.8.0", "3.8", model_name="my_model"
+            )
         assert mock_open_file.called
         assert mock_exists.called
 
     @patch("os.path.exists", return_value=False)
     @patch("builtins.open", new_callable=mock_open)
     def test_create_runpod_toml(self, mock_open_file, mock_exists):
-        """ Test that runpod.toml configuration file is created. """
+        """Test that runpod.toml configuration file is created."""
         with patch("runpod.cli.groups.project.functions.copy_template_files"):
             create_new_project("test_project", "volume_id", "11.8.0", "3.8")
         toml_file_location = os.path.join(os.getcwd(), "test_project", "runpod.toml")
         mock_open_file.assert_called_with(
-            toml_file_location, 'w', encoding="UTF-8")  # pylint: disable=line-too-long
+            toml_file_location, "w", encoding="UTF-8"
+        )  # pylint: disable=line-too-long
         assert mock_exists.called
 
     @patch("os.path.exists", return_value=True)
     @patch("builtins.open", new_callable=mock_open, read_data="<<RUNPOD>> placeholder")
     def test_update_requirements_file(self, mock_open_file, mock_exists):
-        """ Test that placeholders in requirements.txt are replaced correctly. """
-        with patch("runpod.cli.groups.project.functions.__version__", "dev"), \
-                patch("runpod.cli.groups.project.functions.copy_template_files"):
+        """Test that placeholders in requirements.txt are replaced correctly."""
+        with patch("runpod.cli.groups.project.functions.__version__", "dev"), patch(
+            "runpod.cli.groups.project.functions.copy_template_files"
+        ):
             create_new_project("test_project", "volume_id", "11.8.0", "3.8")
         assert mock_open_file.called
         assert mock_exists.called
@@ -96,107 +123,127 @@ class TestCreateNewProject(unittest.TestCase):
     @patch("os.path.exists", return_value=True)
     @patch("builtins.open", new_callable=mock_open, read_data="<<RUNPOD>> placeholder")
     def test_update_requirements_file_non_dev(self, mock_open_file, mock_exists):
-        """ Test that placeholders in requirements.txt are replaced for non-dev versions. """
-        with patch("runpod.cli.groups.project.functions.__version__", "1.0.0"), \
-                patch("runpod.cli.groups.project.functions.copy_template_files"):
+        """Test that placeholders in requirements.txt are replaced for non-dev versions."""
+        with patch("runpod.cli.groups.project.functions.__version__", "1.0.0"), patch(
+            "runpod.cli.groups.project.functions.copy_template_files"
+        ):
             create_new_project("test_project", "volume_id", "11.8.0", "3.8")
         assert mock_open_file.called
         assert mock_exists.called
 
 
 class TestStartProject(unittest.TestCase):
-    """ Test the start_project function. """
+    """Test the start_project function."""
 
-    @patch('runpod.cli.groups.project.functions.load_project_config')
-    @patch('runpod.cli.groups.project.functions.get_project_pod')
-    @patch('runpod.cli.groups.project.functions.attempt_pod_launch')
-    @patch('runpod.cli.groups.project.functions.get_pod')
-    @patch('runpod.cli.groups.project.functions.SSHConnection')
-    @patch('os.getcwd', return_value='/current/path')
-    def test_start_nonexistent_successfully(self, mock_getcwd, mock_ssh_connection, mock_get_pod, mock_attempt_pod_launch, mock_get_project_pod, mock_load_project_config):  # pylint: disable=line-too-long, too-many-arguments
-        """ Test that a project is launched successfully. """
+    @patch("runpod.cli.groups.project.functions.load_project_config")
+    @patch("runpod.cli.groups.project.functions.get_project_pod")
+    @patch("runpod.cli.groups.project.functions.attempt_pod_launch")
+    @patch("runpod.cli.groups.project.functions.get_pod")
+    @patch("runpod.cli.groups.project.functions.SSHConnection")
+    @patch("os.getcwd", return_value="/current/path")
+    def test_start_nonexistent_successfully(
+        self,
+        mock_getcwd,
+        mock_ssh_connection,
+        mock_get_pod,
+        mock_attempt_pod_launch,
+        mock_get_project_pod,
+        mock_load_project_config,
+    ):  # pylint: disable=line-too-long, too-many-arguments
+        """Test that a project is launched successfully."""
         mock_load_project_config.return_value = {
-            'project': {
-                'uuid': '123456',
-                'name': 'test_project',
-                'volume_mount_path': '/mount/path',
-                'env_vars': {'ENV_VAR': 'value'},
-                'gpu': 'NVIDIA GPU'
+            "project": {
+                "uuid": "123456",
+                "name": "test_project",
+                "volume_mount_path": "/mount/path",
+                "env_vars": {"ENV_VAR": "value"},
+                "gpu": "NVIDIA GPU",
             },
-            'runtime': {
-                'python_version': '3.8',
-                'handler_path': 'handler.py',
-                'requirements_path': 'requirements.txt'
-            }
+            "runtime": {
+                "python_version": "3.8",
+                "handler_path": "handler.py",
+                "requirements_path": "requirements.txt",
+            },
         }
 
         mock_get_project_pod.return_value = False
 
         mock_attempt_pod_launch.return_value = {
-            'id': 'new_pod_id',
-            'desiredStatus': 'PENDING',
-            'runtime': None
+            "id": "new_pod_id",
+            "desiredStatus": "PENDING",
+            "runtime": None,
         }
 
         mock_get_pod.return_value = {
-            'id': 'new_pod_id',
-            'desiredStatus': 'RUNNING',
-            'runtime': 'ONLINE'
+            "id": "new_pod_id",
+            "desiredStatus": "RUNNING",
+            "runtime": "ONLINE",
         }
 
         mock_ssh_instance = mock_ssh_connection.return_value
         mock_ssh_instance.__enter__.return_value = mock_ssh_instance
         mock_ssh_instance.run_commands.return_value = None
 
-        with patch('runpod.cli.groups.project.functions.sync_directory') as mock_sync_directory:
+        with patch(
+            "runpod.cli.groups.project.functions.sync_directory"
+        ) as mock_sync_directory:
             start_project()
 
         mock_attempt_pod_launch.assert_called()
-        mock_get_pod.assert_called_with('new_pod_id')
-        mock_ssh_connection.assert_called_with('new_pod_id')
+        mock_get_pod.assert_called_with("new_pod_id")
+        mock_ssh_connection.assert_called_with("new_pod_id")
         mock_ssh_instance.run_commands.assert_called()
         assert mock_getcwd.called
         assert mock_sync_directory.called
 
-    @patch('runpod.cli.groups.project.functions.get_project_pod')
-    @patch('runpod.cli.groups.project.functions.attempt_pod_launch')
+    @patch("runpod.cli.groups.project.functions.get_project_pod")
+    @patch("runpod.cli.groups.project.functions.attempt_pod_launch")
     def test_failed_pod_launch(self, mock_attempt_pod, mock_get_pod):
-        """ Test that a project is not launched if pod launch fails. """
+        """Test that a project is not launched if pod launch fails."""
         mock_attempt_pod.return_value = None
         mock_get_pod.return_value = None
 
-        with patch('builtins.print') as mock_print, \
-                patch('runpod.cli.groups.project.functions.load_project_config'):
+        with patch("builtins.print") as mock_print, patch(
+            "runpod.cli.groups.project.functions.load_project_config"
+        ):
 
             start_project()
             mock_print.assert_called_with(
-                "Selected GPU types unavailable, try again later or use a different type.")  # pylint: disable=line-too-long
+                "Selected GPU types unavailable, try again later or use a different type."
+            )  # pylint: disable=line-too-long
 
 
 class TestStartProjectAPI(unittest.TestCase):
-    """ Test the start_project_api function. """
+    """Test the start_project_api function."""
 
-    @patch('runpod.cli.groups.project.functions.load_project_config')
-    @patch('runpod.cli.groups.project.functions.get_project_pod')
-    @patch('runpod.cli.groups.project.functions.SSHConnection')
-    @patch('os.getcwd', return_value='/current/path')
-    @patch('runpod.cli.groups.project.functions.sync_directory')
-    def test_start_project_api_successfully(self, mock_sync_directory, mock_getcwd, mock_ssh_connection, mock_get_project_pod, mock_load_project_config):  # pylint: disable=line-too-long, too-many-arguments
-        """ Test that a project API is started successfully. """
+    @patch("runpod.cli.groups.project.functions.load_project_config")
+    @patch("runpod.cli.groups.project.functions.get_project_pod")
+    @patch("runpod.cli.groups.project.functions.SSHConnection")
+    @patch("os.getcwd", return_value="/current/path")
+    @patch("runpod.cli.groups.project.functions.sync_directory")
+    def test_start_project_api_successfully(
+        self,
+        mock_sync_directory,
+        mock_getcwd,
+        mock_ssh_connection,
+        mock_get_project_pod,
+        mock_load_project_config,
+    ):  # pylint: disable=line-too-long, too-many-arguments
+        """Test that a project API is started successfully."""
         mock_load_project_config.return_value = {
-            'project': {
-                'uuid': '123456',
-                'name': 'test_project',
-                'volume_mount_path': '/mount/path'
+            "project": {
+                "uuid": "123456",
+                "name": "test_project",
+                "volume_mount_path": "/mount/path",
             },
-            'runtime': {
-                'python_version': '3.8',
-                'handler_path': 'handler.py',
-                'requirements_path': 'requirements.txt'
-            }
+            "runtime": {
+                "python_version": "3.8",
+                "handler_path": "handler.py",
+                "requirements_path": "requirements.txt",
+            },
         }
 
-        mock_get_project_pod.return_value = {'id': 'pod_id'}
+        mock_get_project_pod.return_value = {"id": "pod_id"}
 
         mock_ssh_instance = mock_ssh_connection.return_value
         mock_ssh_instance.__enter__.return_value = mock_ssh_instance
@@ -204,77 +251,88 @@ class TestStartProjectAPI(unittest.TestCase):
 
         start_project()
 
-        mock_get_project_pod.assert_called_with('123456')
-        mock_ssh_connection.assert_called_with({'id': 'pod_id'})
-        mock_sync_directory.assert_called_with(mock_ssh_instance,
-                                               '/current/path', '/mount/path/123456/dev')
+        mock_get_project_pod.assert_called_with("123456")
+        mock_ssh_connection.assert_called_with({"id": "pod_id"})
+        mock_sync_directory.assert_called_with(
+            mock_ssh_instance, "/current/path", "/mount/path/123456/dev"
+        )
         mock_ssh_instance.run_commands.assert_called()
         assert mock_getcwd.called
 
 
 class TestCreateProjectEndpoint(unittest.TestCase):
-    """ Test the create_project_endpoint function. """
+    """Test the create_project_endpoint function."""
 
-    @patch('runpod.cli.groups.project.functions.SSHConnection')
-    @patch('runpod.cli.groups.project.functions.load_project_config')
-    @patch('runpod.cli.groups.project.functions.create_template')
-    @patch('runpod.cli.groups.project.functions.create_endpoint')
-    @patch('runpod.cli.groups.project.functions.update_endpoint_template')
-    @patch('runpod.cli.groups.project.functions.get_project_pod')
-    @patch('runpod.cli.groups.project.functions.get_project_endpoint')
-    def test_create_project_endpoint(self, mock_get_project_endpoint, mock_get_project_pod, mock_update_endpoint, mock_create_endpoint,  # pylint: disable=too-many-arguments,line-too-long
-                                     mock_create_template, mock_load_project_config, mock_ssh_connection):  # pylint: disable=line-too-long
-        """ Test that a project endpoint is created successfully. """
+    @patch("runpod.cli.groups.project.functions.SSHConnection")
+    @patch("runpod.cli.groups.project.functions.load_project_config")
+    @patch("runpod.cli.groups.project.functions.create_template")
+    @patch("runpod.cli.groups.project.functions.create_endpoint")
+    @patch("runpod.cli.groups.project.functions.update_endpoint_template")
+    @patch("runpod.cli.groups.project.functions.get_project_pod")
+    @patch("runpod.cli.groups.project.functions.get_project_endpoint")
+    def test_create_project_endpoint(
+        self,
+        mock_get_project_endpoint,
+        mock_get_project_pod,
+        mock_update_endpoint,
+        mock_create_endpoint,  # pylint: disable=too-many-arguments,line-too-long
+        mock_create_template,
+        mock_load_project_config,
+        mock_ssh_connection,
+    ):  # pylint: disable=line-too-long
+        """Test that a project endpoint is created successfully."""
         mock_get_project_endpoint.return_value = False
 
         mock_get_project_pod.return_value = None
-        with patch('runpod.cli.groups.project.functions._launch_dev_pod') as mock_launch_dev_pod:
+        with patch(
+            "runpod.cli.groups.project.functions._launch_dev_pod"
+        ) as mock_launch_dev_pod:
             mock_launch_dev_pod.return_value = None
             assert create_project_endpoint() is None
 
-        mock_get_project_pod.return_value = {'id': 'test_pod_id'}
+        mock_get_project_pod.return_value = {"id": "test_pod_id"}
         mock_load_project_config.return_value = {
-            'project': {
-                'name': 'test_project',
-                'volume_mount_path': '/runpod-volume/123456',
-                'uuid': '123456',
-                'env_vars': {'TEST_VAR': 'value'},
-                'base_image': 'test_image',
-                'container_disk_size_gb': 10,
-                'storage_id': 'test_storage_id',
+            "project": {
+                "name": "test_project",
+                "volume_mount_path": "/runpod-volume/123456",
+                "uuid": "123456",
+                "env_vars": {"TEST_VAR": "value"},
+                "base_image": "test_image",
+                "container_disk_size_gb": 10,
+                "storage_id": "test_storage_id",
             },
-            'runtime': {
-                'python_version': '3.8',
-                'handler_path': 'handler.py',
-                'requirements_path': 'requirements.txt'
-            }
+            "runtime": {
+                "python_version": "3.8",
+                "handler_path": "handler.py",
+                "requirements_path": "requirements.txt",
+            },
         }
-        mock_create_template.return_value = {'id': 'test_template_id'}
-        mock_create_endpoint.return_value = {'id': 'test_endpoint_id'}
+        mock_create_template.return_value = {"id": "test_template_id"}
+        mock_create_endpoint.return_value = {"id": "test_endpoint_id"}
 
         mock_ssh_instance = mock_ssh_connection.return_value
         mock_ssh_instance.__enter__.return_value = mock_ssh_instance
         mock_ssh_instance.run_commands.return_value = None
 
-        with patch('runpod.cli.groups.project.functions.datetime') as mock_datetime:
-            mock_datetime.now.return_value = '123456'
+        with patch("runpod.cli.groups.project.functions.datetime") as mock_datetime:
+            mock_datetime.now.return_value = "123456"
             result = create_project_endpoint()
 
-        self.assertEqual(result, 'test_endpoint_id')
+        self.assertEqual(result, "test_endpoint_id")
         mock_create_template.assert_called_with(
-            name='test_project-endpoint | 123456 | 123456',
-            image_name='test_image',
+            name="test_project-endpoint | 123456 | 123456",
+            image_name="test_image",
             container_disk_in_gb=10,
             docker_start_cmd='bash -c ". /runpod-volume/123456/prod/venv/bin/activate && python -u /runpod-volume/123456/prod/test_project/handler.py"',  # pylint: disable=line-too-long
-            env={'TEST_VAR': 'value'},
-            is_serverless=True
+            env={"TEST_VAR": "value"},
+            is_serverless=True,
         )
         mock_create_endpoint.assert_called_with(
-            name='test_project-endpoint | 123456',
-            template_id='test_template_id',
-            network_volume_id='test_storage_id'
+            name="test_project-endpoint | 123456",
+            template_id="test_template_id",
+            network_volume_id="test_storage_id",
         )
 
-        mock_update_endpoint.return_value = {'id': 'test_endpoint_id'}
-        mock_get_project_endpoint.return_value = {'id': 'test_endpoint_id'}
-        self.assertEqual(create_project_endpoint(), 'test_endpoint_id')
+        mock_update_endpoint.return_value = {"id": "test_endpoint_id"}
+        mock_get_project_endpoint.return_value = {"id": "test_endpoint_id"}
+        self.assertEqual(create_project_endpoint(), "test_endpoint_id")

--- a/tests/test_cli/test_cli_groups/test_project_helpers.py
+++ b/tests/test_cli/test_cli_groups/test_project_helpers.py
@@ -1,18 +1,18 @@
 """Tests for the project helpers."""
 
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
 
 import click
 
 from runpod import error as rp_error
 from runpod.cli.groups.project.helpers import (
-    validate_project_name,
-    get_project_pod,
-    get_project_endpoint,
-    copy_template_files,
     attempt_pod_launch,
-    load_project_config
+    copy_template_files,
+    get_project_endpoint,
+    get_project_pod,
+    load_project_config,
+    validate_project_name,
 )
 
 
@@ -89,7 +89,7 @@ class TestHelpers(unittest.TestCase):
                 "ports": "ports",
                 "storage_id": "storage_id",
                 "volume_mount_path": "volume_mount_path",
-                "container_disk_size_gb": "1"
+                "container_disk_size_gb": "1",
             }
         }
         environment_variables = {"key": "value"}
@@ -108,6 +108,7 @@ class TestHelpers(unittest.TestCase):
         assert mock_exists.called
         assert mock_file.called
 
-        with patch("os.path.exists", return_value=False), \
-                self.assertRaises(FileNotFoundError):
+        with patch("os.path.exists", return_value=False), self.assertRaises(
+            FileNotFoundError
+        ):
             load_project_config()

--- a/tests/test_cli/test_cli_groups/test_ssh_commands.py
+++ b/tests/test_cli/test_cli_groups/test_ssh_commands.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 
-from runpod.cli.groups.ssh.commands import list_keys, add_key
+from runpod.cli.groups.ssh.commands import add_key, list_keys
+
 
 class TestSSHCommands(unittest.TestCase):
     """Tests for the SSH commands of the CLI."""
@@ -13,28 +14,35 @@ class TestSSHCommands(unittest.TestCase):
     def test_list_keys(self):
         """Test the list_keys command."""
         runner = CliRunner()
-        with patch('runpod.cli.groups.ssh.commands.get_user_pub_keys', return_value=[
-            {'name': 'key1', 'type': 'RSA', 'fingerprint': 'fp1'},
-            {'name': 'key2', 'type': 'DSA', 'fingerprint': 'fp2'}
-        ]) as mock_get_keys:
+        with patch(
+            "runpod.cli.groups.ssh.commands.get_user_pub_keys",
+            return_value=[
+                {"name": "key1", "type": "RSA", "fingerprint": "fp1"},
+                {"name": "key2", "type": "DSA", "fingerprint": "fp2"},
+            ],
+        ) as mock_get_keys:
 
             result = runner.invoke(list_keys)
 
-            self.assertIn('key1', result.output)
-            self.assertIn('key2', result.output)
+            self.assertIn("key1", result.output)
+            self.assertIn("key2", result.output)
 
             assert mock_get_keys.called
 
     def test_add_key_without_params(self):
         """Test the add_key command without parameters."""
         runner = CliRunner()
-        with patch('runpod.cli.groups.ssh.commands.generate_ssh_key_pair') as mock_gen_key, \
-             patch('runpod.cli.groups.ssh.commands.click.prompt', return_value='TestKey') as mock_prompt, \
-             patch('runpod.cli.groups.ssh.commands.click.confirm', return_value=True) as mock_confirm: # pylint: disable=line-too-long
+        with patch(
+            "runpod.cli.groups.ssh.commands.generate_ssh_key_pair"
+        ) as mock_gen_key, patch(
+            "runpod.cli.groups.ssh.commands.click.prompt", return_value="TestKey"
+        ) as mock_prompt, patch(
+            "runpod.cli.groups.ssh.commands.click.confirm", return_value=True
+        ) as mock_confirm:  # pylint: disable=line-too-long
 
             result = runner.invoke(add_key, [])
 
-            self.assertIn('The key has been added to your account.', result.output)
-            mock_gen_key.assert_called_once_with('TestKey')
+            self.assertIn("The key has been added to your account.", result.output)
+            mock_gen_key.assert_called_once_with("TestKey")
             assert mock_prompt.called
             assert mock_confirm.called

--- a/tests/test_cli/test_cli_groups/test_ssh_functions.py
+++ b/tests/test_cli/test_cli_groups/test_ssh_functions.py
@@ -2,51 +2,56 @@
 
 import base64
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
+
 from runpod.cli.groups.ssh.functions import (
-    get_ssh_key_fingerprint, get_user_pub_keys,
-    generate_ssh_key_pair, add_ssh_key
+    add_ssh_key,
+    generate_ssh_key_pair,
+    get_ssh_key_fingerprint,
+    get_user_pub_keys,
 )
 
 
 class TestSSHFunctions(unittest.TestCase):
-    """ Tests for the SSH functions """
+    """Tests for the SSH functions"""
 
     def test_get_ssh_key_fingerprint(self):
-        """ Test the get_ssh_key_fingerprint function """
+        """Test the get_ssh_key_fingerprint function"""
         key = "ssh-rsa AAAAB3Nza...base64data...Q== user@host"
         fingerprint = get_ssh_key_fingerprint(key)
         expected_start = "SHA256:"
         self.assertTrue(fingerprint.startswith(expected_start))
 
     def test_get_ssh_key_fingerprint_invalid(self):
-        """ Test the get_ssh_key_fingerprint function with an invalid key """
+        """Test the get_ssh_key_fingerprint function with an invalid key"""
         with self.assertRaises(ValueError):
             get_ssh_key_fingerprint("invalidkey")
 
     @patch("runpod.cli.groups.ssh.functions.get_user")
     def test_get_user_pub_keys(self, mock_get_user):
-        """ Test the get_user_pub_keys function """
+        """Test the get_user_pub_keys function"""
 
         # Create dummy base64 data for our mock SSH keys
-        dummy_data1 = base64.b64encode("test data 1".encode('utf-8')).decode('utf-8')
-        dummy_data2 = base64.b64encode("test data 2".encode('utf-8')).decode('utf-8')
+        dummy_data1 = base64.b64encode("test data 1".encode("utf-8")).decode("utf-8")
+        dummy_data2 = base64.b64encode("test data 2".encode("utf-8")).decode("utf-8")
 
         mock_get_user.return_value = {
-            'pubKey': f'ssh-rsa {dummy_data1} key1\nssh-rsa {dummy_data2} key2\n1'
+            "pubKey": f"ssh-rsa {dummy_data1} key1\nssh-rsa {dummy_data2} key2\n1"
         }
 
         keys = get_user_pub_keys()
 
         self.assertEqual(len(keys), 2)
-        self.assertEqual(keys[0]['fingerprint'].startswith("SHA256:"), True)
+        self.assertEqual(keys[0]["fingerprint"].startswith("SHA256:"), True)
 
     @patch("runpod.cli.groups.ssh.functions.get_user")
     def test_add_ssh_key_already_exists(self, mock_get_user):
-        """ Test the add_ssh_key function when the key already exists """
-        mock_get_user.return_value = {'pubKey': 'ssh-rsa ABCDE12345 key1'}
+        """Test the add_ssh_key function when the key already exists"""
+        mock_get_user.return_value = {"pubKey": "ssh-rsa ABCDE12345 key1"}
         key = "ssh-rsa AAAAB3Nza...base64data...Q== user@host"
-        with patch("runpod.cli.groups.ssh.functions.update_user_settings") as mock_update_settings:
+        with patch(
+            "runpod.cli.groups.ssh.functions.update_user_settings"
+        ) as mock_update_settings:
             mock_update_settings.return_value = None
             self.assertIsNone(add_ssh_key(key))
             assert mock_update_settings.called
@@ -54,15 +59,18 @@ class TestSSHFunctions(unittest.TestCase):
     @patch("runpod.cli.groups.ssh.functions.os.path.join")
     @patch("runpod.cli.groups.ssh.functions.paramiko.RSAKey.generate")
     def test_generate_ssh_key_pair(self, mock_generate, mock_path_join):
-        """ Test the generate_ssh_key_pair function """
+        """Test the generate_ssh_key_pair function"""
         mock_generate.return_value.get_name.return_value = "ssh-rsa"
         mock_generate.return_value.get_base64.return_value = "ABCDE12345"
         mock_path_join.return_value = "/path/to/private_key"
 
-        with patch("os.mkdir") as mock_mkdir, \
-                patch("builtins.open", mock_open()) as mock_file, \
-                patch("runpod.cli.groups.ssh.functions.os.chmod") as mock_chmod, \
-                patch("runpod.cli.groups.ssh.functions.add_ssh_key") as mock_add_key:
+        with patch("os.mkdir") as mock_mkdir, patch(
+            "builtins.open", mock_open()
+        ) as mock_file, patch(
+            "runpod.cli.groups.ssh.functions.os.chmod"
+        ) as mock_chmod, patch(
+            "runpod.cli.groups.ssh.functions.add_ssh_key"
+        ) as mock_add_key:
             mock_mkdir.return_value = None
             mock_file.return_value.write.return_value = None
             private_key, public_key = generate_ssh_key_pair("test_key")
@@ -75,11 +83,11 @@ class TestSSHFunctions(unittest.TestCase):
     @patch("runpod.cli.groups.ssh.functions.get_user")
     @patch("runpod.cli.groups.ssh.functions.update_user_settings")
     def test_add_ssh_key_new(self, mock_update_settings, mock_get_user):
-        """ Test the add_ssh_key function when the key is new """
-        mock_get_user.return_value = {'pubKey': ''}
+        """Test the add_ssh_key function when the key is new"""
+        mock_get_user.return_value = {"pubKey": ""}
         key = "ssh-rsa ABCDE12345 somecomment"
         add_ssh_key(key)
         mock_update_settings.assert_called_once_with(key)
 
-        mock_get_user.return_value = {'pubKey': 'ssh-rsa ABCDE12345 key1'}
-        assert add_ssh_key('ssh-rsa ABCDE12345 key1') is None
+        mock_get_user.return_value = {"pubKey": "ssh-rsa ABCDE12345 key1"}
+        assert add_ssh_key("ssh-rsa ABCDE12345 key1") is None

--- a/tests/test_cli/test_cli_utils/__init__.py
+++ b/tests/test_cli/test_cli_utils/__init__.py
@@ -1,1 +1,1 @@
-''' Import util tests '''
+""" Import util tests """

--- a/tests/test_cli/test_cli_utils/test_info.py
+++ b/tests/test_cli/test_cli_utils/test_info.py
@@ -1,51 +1,45 @@
 """ Unit testing for runpod.cli.utils.rp_info.py """
 
 from unittest.mock import patch
+
 import pytest
 
 from runpod.cli.utils.rp_info import get_pod_ssh_ip_port
 
 
 class TestGetPodSSHIpPort:
-    """ Unit testing for get_pod_ssh_ip_port """
+    """Unit testing for get_pod_ssh_ip_port"""
 
     def test_get_pod_ssh_ip_port_normal(self):
-        """ Test get_pod_ssh_ip_port normal """
-        with patch('runpod.cli.utils.rp_info.get_pod') as mock_get_pod:
+        """Test get_pod_ssh_ip_port normal"""
+        with patch("runpod.cli.utils.rp_info.get_pod") as mock_get_pod:
             mock_get_pod.return_value = {
-                'desiredStatus': 'RUNNING',
-                'runtime': {
-                    'ports': [
-                        {
-                            'privatePort': 22,
-                            'ip': '127.0.0.1',
-                            'publicPort': 2222
-                        }
+                "desiredStatus": "RUNNING",
+                "runtime": {
+                    "ports": [
+                        {"privatePort": 22, "ip": "127.0.0.1", "publicPort": 2222}
                     ]
-                }
+                },
             }
 
-            ip, port = get_pod_ssh_ip_port('pod_id')
-            assert ip == '127.0.0.1'
+            ip, port = get_pod_ssh_ip_port("pod_id")
+            assert ip == "127.0.0.1"
             assert port == 2222
 
     def test_get_pod_ssh_ip_port_timeout(self):
-        """ Test get_pod_ssh_ip_port timeout """
-        with patch('runpod.cli.utils.rp_info.get_pod') as mock_get_pod:
-            mock_get_pod.return_value = {
-                'desiredStatus': 'RUNNING',
-                'runtime': None
-            }
+        """Test get_pod_ssh_ip_port timeout"""
+        with patch("runpod.cli.utils.rp_info.get_pod") as mock_get_pod:
+            mock_get_pod.return_value = {"desiredStatus": "RUNNING", "runtime": None}
 
             with pytest.raises(TimeoutError):
-                get_pod_ssh_ip_port('pod_id', timeout=0.1)
+                get_pod_ssh_ip_port("pod_id", timeout=0.1)
 
-            mock_get_pod.return_value = {'desiredStatus': 'NOT_RUNNING'}
+            mock_get_pod.return_value = {"desiredStatus": "NOT_RUNNING"}
 
             with pytest.raises(TimeoutError):
-                get_pod_ssh_ip_port('pod_id', timeout=0.1)
+                get_pod_ssh_ip_port("pod_id", timeout=0.1)
 
             mock_get_pod.return_value = {}
 
             with pytest.raises(TimeoutError):
-                get_pod_ssh_ip_port('pod_id', timeout=0.1)
+                get_pod_ssh_ip_port("pod_id", timeout=0.1)

--- a/tests/test_cli/test_cli_utils/test_runpodignore.py
+++ b/tests/test_cli/test_cli_utils/test_runpodignore.py
@@ -4,32 +4,31 @@
 
 import os
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
 
 from runpod.cli.utils.rp_runpodignore import get_ignore_list, should_ignore
 
 
 class TestGetIgnoreList(unittest.TestCase):
-    """ Unit tests for the get_ignore_list function. """
+    """Unit tests for the get_ignore_list function."""
 
-    @patch('os.path.isfile', return_value=False)
+    @patch("os.path.isfile", return_value=False)
     def test_no_ignore_file(self, mock_isfile):
-        """ Test that the default ignore list is returned when no ignore file is present. """
+        """Test that the default ignore list is returned when no ignore file is present."""
         result = get_ignore_list()
-        self.assertEqual(result, [
-            "__pycache__/",
-            "*.pyc",
-            ".*.swp",
-            ".git/",
-            "*.tmp",
-            "*.log"
-        ])
+        self.assertEqual(
+            result, ["__pycache__/", "*.pyc", ".*.swp", ".git/", "*.tmp", "*.log"]
+        )
         assert mock_isfile.called
 
-    @patch('os.path.isfile', return_value=True)
-    @patch('builtins.open', new_callable=mock_open, read_data="*.hello\n# This is a comment\n\n.world\n") # pylint: disable=line-too-long
+    @patch("os.path.isfile", return_value=True)
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data="*.hello\n# This is a comment\n\n.world\n",
+    )  # pylint: disable=line-too-long
     def test_with_ignore_file(self, mock_file, mock_isfile):
-        """ Test that the default ignore list is returned when no ignore file is present. """
+        """Test that the default ignore list is returned when no ignore file is present."""
         result = get_ignore_list()
         expected_patterns = [
             "__pycache__/",
@@ -39,45 +38,45 @@ class TestGetIgnoreList(unittest.TestCase):
             "*.tmp",
             "*.log",
             "*.hello",
-            ".world"
+            ".world",
         ]
         self.assertEqual(result, expected_patterns)
         assert mock_file.called
         assert mock_isfile.called
 
-    @patch('os.path.isfile', return_value=True)
-    @patch('builtins.open', new_callable=mock_open, read_data="# Only comments and empty lines\n\n\n") # pylint: disable=line-too-long
+    @patch("os.path.isfile", return_value=True)
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data="# Only comments and empty lines\n\n\n",
+    )  # pylint: disable=line-too-long
     def test_empty_ignore_file(self, mock_file, mock_isfile):
-        """ Test that the default ignore list is returned when no ignore file is present. """
+        """Test that the default ignore list is returned when no ignore file is present."""
         result = get_ignore_list()
-        self.assertEqual(result, [
-            "__pycache__/",
-            "*.pyc",
-            ".*.swp",
-            ".git/",
-            "*.tmp",
-            "*.log"
-        ])
+        self.assertEqual(
+            result, ["__pycache__/", "*.pyc", ".*.swp", ".git/", "*.tmp", "*.log"]
+        )
         assert mock_file.called
         assert mock_isfile.called
 
+
 class TestShouldIgnoreFunction(unittest.TestCase):
-    """ Unit tests for the should_ignore function. """
+    """Unit tests for the should_ignore function."""
 
     def test_should_ignore_with_relative_path(self):
-        """ Test that the should_ignore function returns True when the file should be ignored. """
+        """Test that the should_ignore function returns True when the file should be ignored."""
         patterns = ["/test/"]
         file_path = os.path.join(os.getcwd(), "test", "example.txt")
         self.assertTrue(should_ignore(file_path, patterns))
 
     def test_should_ignore_with_absolute_path(self):
-        """ Test that the should_ignore function returns True when the file should be ignored. """
+        """Test that the should_ignore function returns True when the file should be ignored."""
         patterns = ["*.txt"]
         file_path = os.path.join(os.getcwd(), "test", "example.txt")
         self.assertTrue(should_ignore(file_path, patterns))
 
     def test_should_not_ignore(self):
-        """ Test that the should_ignore
+        """Test that the should_ignore
         Function returns False when the file should not be ignored
         """
         patterns = ["*.md"]
@@ -86,14 +85,14 @@ class TestShouldIgnoreFunction(unittest.TestCase):
 
     @patch("runpod.cli.utils.rp_runpodignore.get_ignore_list")
     def test_should_ignore_with_mocked_ignore_list(self, mock_get_ignore_list):
-        """ Test that the should_ignore function returns True when the file should be ignored. """
+        """Test that the should_ignore function returns True when the file should be ignored."""
         mock_get_ignore_list.return_value = ["*.txt"]
         file_path = "example.txt"
         self.assertTrue(should_ignore(file_path))
 
     @patch("runpod.cli.utils.rp_runpodignore.get_ignore_list")
     def test_should_not_ignore_with_mocked_ignore_list(self, mock_get_ignore_list):
-        """ Test that the should_ignore
+        """Test that the should_ignore
         Function returns False when the file should not be ignored
         """
         mock_get_ignore_list.return_value = ["*.md"]
@@ -102,7 +101,7 @@ class TestShouldIgnoreFunction(unittest.TestCase):
 
     @patch("runpod.cli.utils.rp_runpodignore.os.getcwd")
     def test_should_ignore_with_mocked_cwd(self, mock_getcwd):
-        """ Test that the should_ignore function returns True when the file should be ignored. """
+        """Test that the should_ignore function returns True when the file should be ignored."""
         mock_getcwd.return_value = "/fake/directory"
         patterns = ["/test/"]
         file_path = "/fake/directory/test/example.txt"

--- a/tests/test_cli/test_cli_utils/test_ssh_cmd.py
+++ b/tests/test_cli/test_cli_utils/test_ssh_cmd.py
@@ -1,8 +1,9 @@
-'''
+"""
 RunPod | CLI | Utils | SSH Command
-'''
+"""
+
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import paramiko
 
@@ -10,57 +11,67 @@ from runpod.cli.utils.ssh_cmd import SSHConnection
 
 
 class TestSSHConnection(unittest.TestCase):
-    """ Test the SSHConnection class. """
+    """Test the SSHConnection class."""
 
     def setUp(self):
 
-        self.patch_get_pod_ssh_ip_port = patch('runpod.cli.utils.ssh_cmd.get_pod_ssh_ip_port',
-                                               return_value=('127.0.0.1', 22)).start()
+        self.patch_get_pod_ssh_ip_port = patch(
+            "runpod.cli.utils.ssh_cmd.get_pod_ssh_ip_port",
+            return_value=("127.0.0.1", 22),
+        ).start()
 
-        self.patch_find_ssh_key_file = patch('runpod.cli.utils.ssh_cmd.find_ssh_key_file',
-                                             return_value='key_file').start()
+        self.patch_find_ssh_key_file = patch(
+            "runpod.cli.utils.ssh_cmd.find_ssh_key_file", return_value="key_file"
+        ).start()
 
         self.mock_ssh_client = MagicMock()
-        patch_paramiko = patch('runpod.cli.utils.ssh_cmd.paramiko.SSHClient',
-                               return_value=self.mock_ssh_client).start()
+        patch_paramiko = patch(
+            "runpod.cli.utils.ssh_cmd.paramiko.SSHClient",
+            return_value=self.mock_ssh_client,
+        ).start()
 
         self.addCleanup(self.patch_get_pod_ssh_ip_port.stop)
         self.addCleanup(self.patch_find_ssh_key_file.stop)
         self.addCleanup(patch_paramiko.stop)
 
-        self.ssh_connection = SSHConnection('pod_id_mock')
+        self.ssh_connection = SSHConnection("pod_id_mock")
 
     def test_enter(self):
-        ''' Test entering the context manager. '''
+        """Test entering the context manager."""
         self.assertEqual(
-            self.ssh_connection, self.ssh_connection.__enter__())  # pylint: disable=unnecessary-dunder-call
+            self.ssh_connection, self.ssh_connection.__enter__()
+        )  # pylint: disable=unnecessary-dunder-call
 
     def test_enter_exception(self):
-        """ Test entering the context manager with an exception. """
+        """Test entering the context manager with an exception."""
         self.mock_ssh_client.connect.side_effect = paramiko.SSHException
         with self.assertRaises(SystemExit):
-            SSHConnection('pod_id_mock')
+            SSHConnection("pod_id_mock")
 
     def test_exit(self):
-        ''' Test exiting the context manager. '''
+        """Test exiting the context manager."""
         self.ssh_connection.__exit__(None, None, None)
 
         self.mock_ssh_client.close.assert_called_once()
 
     def test_run_commands(self):
-        ''' Test that run_commands() calls exec_command() on the SSH object. '''
-        commands = ['command1', 'command2']
+        """Test that run_commands() calls exec_command() on the SSH object."""
+        commands = ["command1", "command2"]
 
         mock_exec_command = self.mock_ssh_client.exec_command
-        mock_exec_command.return_value = (None, ['stdout1', 'stdout2'], ['stderr1', 'stderr2'])
+        mock_exec_command.return_value = (
+            None,
+            ["stdout1", "stdout2"],
+            ["stderr1", "stderr2"],
+        )
         self.ssh_connection.run_commands(commands)
 
         assert mock_exec_command.call_count == 2
 
     def test_put_file(self):
-        ''' Test that put_file() calls put() on the SFTP object. '''
-        local_path = '/local/file.txt'
-        remote_path = '/remote/file.txt'
+        """Test that put_file() calls put() on the SFTP object."""
+        local_path = "/local/file.txt"
+        remote_path = "/remote/file.txt"
 
         mock_sftp = self.mock_ssh_client.open_sftp.return_value.__enter__.return_value
         self.ssh_connection.put_file(local_path, remote_path)
@@ -68,32 +79,34 @@ class TestSSHConnection(unittest.TestCase):
         mock_sftp.put.assert_called_once_with(local_path, remote_path)
 
     def test_get_file(self):
-        ''' Test that get_file() calls get() on the SFTP object. '''
-        local_path = '/local/file.txt'
-        remote_path = '/remote/file.txt'
+        """Test that get_file() calls get() on the SFTP object."""
+        local_path = "/local/file.txt"
+        remote_path = "/remote/file.txt"
 
         mock_sftp = self.mock_ssh_client.open_sftp.return_value.__enter__.return_value
         self.ssh_connection.get_file(remote_path, local_path)
 
         mock_sftp.get.assert_called_once_with(remote_path, local_path)
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_launch_terminal(self, mock_subprocess):
-        ''' Test that launch_terminal() calls subprocess.run(). '''
+        """Test that launch_terminal() calls subprocess.run()."""
         self.ssh_connection.launch_terminal()
         mock_subprocess.assert_called_once()
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_rsync(self, mock_subprocess):
-        ''' Test that rsync() calls subprocess.run(). '''
-        self.ssh_connection.rsync('local_path', 'remote_path', quiet=True)
+        """Test that rsync() calls subprocess.run()."""
+        self.ssh_connection.rsync("local_path", "remote_path", quiet=True)
         mock_subprocess.assert_called_once()
 
     # Test that the signal handler closes the connection.
-    @patch('runpod.cli.utils.ssh_cmd.SSHConnection.close')
+    @patch("runpod.cli.utils.ssh_cmd.SSHConnection.close")
     def test_signal_handler(self, mock_close):
-        ''' Test that the signal handler closes the connection. '''
-        with patch('sys.exit') as mock_exit:
-            self.ssh_connection._signal_handler(None, None)  # pylint: disable=protected-access
+        """Test that the signal handler closes the connection."""
+        with patch("sys.exit") as mock_exit:
+            self.ssh_connection._signal_handler(
+                None, None
+            )  # pylint: disable=protected-access
         mock_close.assert_called_once()
         assert mock_exit.called

--- a/tests/test_cli/test_cli_utils/test_sync.py
+++ b/tests/test_cli/test_cli_utils/test_sync.py
@@ -2,10 +2,11 @@
 
 import time
 import unittest
-from unittest.mock import patch, MagicMock, ANY
+from unittest.mock import ANY, MagicMock, patch
 
 from runpod.cli import STOP_EVENT
 from runpod.cli.utils.rp_sync import WatcherHandler, start_watcher, sync_directory
+
 
 class TestWatcherHandler(unittest.TestCase):
     """Tests for the WatcherHandler class."""
@@ -36,7 +37,7 @@ class TestWatcherHandler(unittest.TestCase):
         event_mock.src_path = "some_path/not_ignored_file.txt"
 
         handler.on_any_event(event_mock)
-        handler.on_any_event(event_mock) # Call it twice to test the debouncer
+        handler.on_any_event(event_mock)  # Call it twice to test the debouncer
         time.sleep(2)
         mock_action_function.assert_called_once()
 
@@ -52,6 +53,7 @@ class TestWatcherHandler(unittest.TestCase):
         time.sleep(2)
         mock_action_function.assert_not_called()
 
+
 class TestSyncDirectory(unittest.TestCase):
     """Tests for the sync_directory function."""
 
@@ -66,7 +68,7 @@ class TestSyncDirectory(unittest.TestCase):
 
         sync_directory(mock_ssh_client, local_path, remote_path)
 
-        target_function = mock_thread_class.call_args[1]['target']
+        target_function = mock_thread_class.call_args[1]["target"]
         target_function()
 
         mock_start_watcher.assert_called_once()
@@ -83,28 +85,33 @@ class TestSyncDirectory(unittest.TestCase):
         sync_function = sync_directory(mock_ssh_client, local_path, remote_path)
         sync_function()
 
-        mock_ssh_client.rsync.assert_called_once_with(local_path, remote_path, quiet=True)
+        mock_ssh_client.rsync.assert_called_once_with(
+            local_path, remote_path, quiet=True
+        )
 
         mock_thread_class.assert_called_once()
         mock_thread_class.assert_called_with(
-            target=mock_start_watcher, daemon=True, args=(ANY, local_path))
+            target=mock_start_watcher, daemon=True, args=(ANY, local_path)
+        )
 
         assert mock_start_watcher.called is False
+
 
 class TestStartWatcher(unittest.TestCase):
     """Tests for the start_watcher function."""
 
-    @patch('runpod.cli.utils.rp_sync.Observer')
-    @patch('runpod.cli.utils.rp_sync.WatcherHandler')
+    @patch("runpod.cli.utils.rp_sync.Observer")
+    @patch("runpod.cli.utils.rp_sync.WatcherHandler")
     def test_start_watcher(self, mock_watch_handler, mock_observer_class):
         """Test that the start_watcher function starts the watcher correctly."""
         fake_action = MagicMock()
-        local_path = '/path/to/watch'
+        local_path = "/path/to/watch"
 
         mock_observer_instance = mock_observer_class.return_value
 
         STOP_EVENT.clear()
-        with patch('runpod.cli.utils.rp_sync.time.sleep') as mock_sleep:
+        with patch("runpod.cli.utils.rp_sync.time.sleep") as mock_sleep:
+
             def side_effect(*args, **kwargs):
                 del args, kwargs
                 STOP_EVENT.set()
@@ -115,9 +122,7 @@ class TestStartWatcher(unittest.TestCase):
         mock_watch_handler.assert_called_once_with(fake_action, local_path)
 
         mock_observer_instance.schedule.assert_called_once_with(
-            mock_watch_handler.return_value,
-            local_path,
-            recursive=True
+            mock_watch_handler.return_value, local_path, recursive=True
         )
 
         mock_observer_instance.start.assert_called_once()

--- a/tests/test_cli/test_cli_utils/test_userspace.py
+++ b/tests/test_cli/test_cli_utils/test_userspace.py
@@ -4,38 +4,37 @@ import os
 import unittest
 from unittest.mock import patch
 
-
 from runpod.cli.utils.rp_userspace import find_ssh_key_file
 
 
 class TestFindSSHKeyFile(unittest.TestCase):
-    """ Unit testing for find_ssh_key_file """
+    """Unit testing for find_ssh_key_file"""
 
     def setUp(self):
         self.pod_ip = "127.0.0.1"
         self.pod_port = 22
 
-    @patch('os.listdir')
+    @patch("os.listdir")
     def test_no_keys_in_directory(self, mock_listdir):
-        """ Test find_ssh_key_file when there are no keys in the directory """
+        """Test find_ssh_key_file when there are no keys in the directory"""
         mock_listdir.return_value = []
         result = find_ssh_key_file(self.pod_ip, self.pod_port)
         self.assertIsNone(result)
 
-    @patch('os.path.isfile')
-    @patch('os.listdir')
+    @patch("os.path.isfile")
+    @patch("os.listdir")
     def test_all_keys_end_with_pub(self, mock_listdir, mock_isfile):
-        """ Test find_ssh_key_file when all keys in the directory end with .pub """
+        """Test find_ssh_key_file when all keys in the directory end with .pub"""
         mock_listdir.return_value = ["key1.pub", "key2.pub"]
         mock_isfile.return_value = True
         result = find_ssh_key_file(self.pod_ip, self.pod_port)
         self.assertIsNone(result)
 
-    @patch('paramiko.SSHClient')
-    @patch('os.path.isfile')
-    @patch('os.listdir')
+    @patch("paramiko.SSHClient")
+    @patch("os.path.isfile")
+    @patch("os.listdir")
     def test_valid_key_found(self, mock_listdir, mock_isfile, mock_ssh_client):
-        """ Test find_ssh_key_file when a valid key is found """
+        """Test find_ssh_key_file when a valid key is found"""
         mock_listdir.return_value = ["key1", "key2"]
         mock_isfile.return_value = True
         mock_ssh_instance = mock_ssh_client.return_value
@@ -43,16 +42,17 @@ class TestFindSSHKeyFile(unittest.TestCase):
         result = find_ssh_key_file(self.pod_ip, self.pod_port)
         self.assertEqual(result, os.path.expanduser("~/.runpod/ssh/key1"))
 
-    @patch('paramiko.SSHClient')
-    @patch('os.path.isfile')
-    @patch('os.listdir')
+    @patch("paramiko.SSHClient")
+    @patch("os.path.isfile")
+    @patch("os.listdir")
     def test_no_valid_key_found(self, mock_listdir, mock_isfile, mock_ssh_client):
-        """ Test find_ssh_key_file when no valid key is found """
+        """Test find_ssh_key_file when no valid key is found"""
         mock_listdir.return_value = ["key1", "key2"]
         mock_isfile.return_value = True
         mock_ssh_instance = mock_ssh_client.return_value
         mock_ssh_instance.connect.side_effect = [
-            Exception("Error with key1"), Exception("Error with key2")
+            Exception("Error with key1"),
+            Exception("Error with key2"),
         ]
         result = find_ssh_key_file(self.pod_ip, self.pod_port)
         self.assertIsNone(result)

--- a/tests/test_endpoint/__init__.py
+++ b/tests/test_endpoint/__init__.py
@@ -1,1 +1,1 @@
-''' Allows for the testing of the endpoint module. '''
+""" Allows for the testing of the endpoint module. """

--- a/tests/test_endpoint/test_asyncio_runner.py
+++ b/tests/test_endpoint/test_asyncio_runner.py
@@ -1,25 +1,28 @@
-''' Unit tests for the asyncio_runner module. '''
+""" Unit tests for the asyncio_runner module. """
+
 # pylint: disable=too-few-public-methods
 
-import tracemalloc
 import asyncio
+import tracemalloc
 import unittest
-from unittest.mock import patch, MagicMock, AsyncMock
 from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from runpod.endpoint.asyncio.asyncio_runner import Job, Endpoint
+from runpod.endpoint.asyncio.asyncio_runner import Endpoint, Job
 
 tracemalloc.start()
 
 
 class TestJob(IsolatedAsyncioTestCase):
-    ''' Tests the Job class. '''
+    """Tests the Job class."""
 
     async def test_status(self):
-        '''
+        """
         Tests Job.status
-        '''
-        with patch("aiohttp.ClientSession", new_callable=AsyncMock) as mock_session_class:
+        """
+        with patch(
+            "aiohttp.ClientSession", new_callable=AsyncMock
+        ) as mock_session_class:
             mock_session = mock_session_class.return_value
             mock_get = mock_session.get
             mock_resp = AsyncMock()
@@ -33,11 +36,14 @@ class TestJob(IsolatedAsyncioTestCase):
             assert await job.status() == "COMPLETED"
 
     async def test_output(self):
-        '''
+        """
         Tests Job.output
-        '''
-        with patch("runpod.endpoint.asyncio.asyncio_runner.asyncio.sleep") as mock_sleep, \
-             patch("aiohttp.ClientSession", new_callable=AsyncMock) as mock_session_class:
+        """
+        with patch(
+            "runpod.endpoint.asyncio.asyncio_runner.asyncio.sleep"
+        ) as mock_sleep, patch(
+            "aiohttp.ClientSession", new_callable=AsyncMock
+        ) as mock_session_class:
             mock_session = mock_session_class.return_value
             mock_get = mock_session.get
             mock_resp = AsyncMock()
@@ -58,10 +64,12 @@ class TestJob(IsolatedAsyncioTestCase):
             assert await job.output() == "OUTPUT"
 
     async def test_output_timeout(self):
-        '''
+        """
         Tests Job.output with a timeout
-        '''
-        with patch("aiohttp.ClientSession", new_callable=AsyncMock) as mock_session_class:
+        """
+        with patch(
+            "aiohttp.ClientSession", new_callable=AsyncMock
+        ) as mock_session_class:
             mock_session = mock_session_class.return_value
             mock_get = mock_session.get
             mock_resp = AsyncMock()
@@ -76,10 +84,12 @@ class TestJob(IsolatedAsyncioTestCase):
                 await output_task
 
     async def test_stream(self):
-        '''
+        """
         Tests Job.stream
-        '''
-        with patch("aiohttp.ClientSession", new_callable=AsyncMock) as mock_session_class:
+        """
+        with patch(
+            "aiohttp.ClientSession", new_callable=AsyncMock
+        ) as mock_session_class:
             mock_session = mock_session_class.return_value
             mock_get = mock_session.get
             mock_resp = AsyncMock()
@@ -90,7 +100,11 @@ class TestJob(IsolatedAsyncioTestCase):
             ]
 
             async def json_side_effect():
-                return responses.pop(0) if responses else {"stream": [], "status": "COMPLETED"}
+                return (
+                    responses.pop(0)
+                    if responses
+                    else {"stream": [], "status": "COMPLETED"}
+                )
 
             mock_resp.json.side_effect = json_side_effect
             mock_get.return_value = mock_resp
@@ -106,9 +120,9 @@ class TestJob(IsolatedAsyncioTestCase):
             assert outputs == ["OUTPUT1", "OUTPUT2"]
 
     async def test_cancel(self):
-        '''
+        """
         Tests Job.cancel
-        '''
+        """
         with patch("aiohttp.ClientSession") as mock_session:
             mock_resp = MagicMock()
             mock_resp.json = MagicMock(return_value=asyncio.Future())
@@ -120,19 +134,25 @@ class TestJob(IsolatedAsyncioTestCase):
             assert cancel_result == {"result": "CANCELLED"}
 
     async def test_output_in_progress_then_completed(self):
-        '''Tests Job.output when status is initially IN_PROGRESS and then changes to COMPLETED'''
-        with patch("aiohttp.ClientSession", new_callable=AsyncMock) as mock_session_class:
+        """Tests Job.output when status is initially IN_PROGRESS and then changes to COMPLETED"""
+        with patch(
+            "aiohttp.ClientSession", new_callable=AsyncMock
+        ) as mock_session_class:
             mock_session = mock_session_class.return_value
             mock_get = mock_session.get
             mock_resp = AsyncMock()
 
             responses = [
                 {"status": "IN_PROGRESS"},
-                {"status": "COMPLETED", "output": "OUTPUT"}
+                {"status": "COMPLETED", "output": "OUTPUT"},
             ]
 
             async def json_side_effect():
-                return responses.pop(0) if responses else {"status": "COMPLETED", "output": "OUTPUT"} # pylint: disable=line-too-long
+                return (
+                    responses.pop(0)
+                    if responses
+                    else {"status": "COMPLETED", "output": "OUTPUT"}
+                )  # pylint: disable=line-too-long
 
             mock_resp.json.side_effect = json_side_effect
             mock_get.return_value = mock_resp
@@ -141,13 +161,14 @@ class TestJob(IsolatedAsyncioTestCase):
             output = await job.output(timeout=3)
             assert output == "OUTPUT"
 
+
 class TestEndpoint(IsolatedAsyncioTestCase):
-    ''' Unit tests for the Endpoint class. '''
+    """Unit tests for the Endpoint class."""
 
     async def test_run(self):
-        '''
+        """
         Tests Endpoint.run
-        '''
+        """
         with patch("aiohttp.ClientSession") as mock_session:
             mock_resp = MagicMock()
             mock_resp.json = MagicMock(return_value=asyncio.Future())
@@ -159,9 +180,9 @@ class TestEndpoint(IsolatedAsyncioTestCase):
             assert job.job_id == "job_id"
 
     async def test_health(self):
-        '''
+        """
         Tests Endpoint.health
-        '''
+        """
         with patch("aiohttp.ClientSession") as mock_session:
             mock_resp = MagicMock()
             mock_resp.json = MagicMock(return_value=asyncio.Future())
@@ -173,9 +194,9 @@ class TestEndpoint(IsolatedAsyncioTestCase):
             assert health == {"status": "HEALTHY"}
 
     async def test_purge_queue(self):
-        '''
+        """
         Tests Endpoint.purge_queue
-        '''
+        """
         with patch("aiohttp.ClientSession") as mock_session:
             mock_resp = MagicMock()
             mock_resp.json = MagicMock(return_value=asyncio.Future())
@@ -186,22 +207,26 @@ class TestEndpoint(IsolatedAsyncioTestCase):
             purge_result = await endpoint.purge_queue()
             assert purge_result == {"result": "PURGED"}
 
+
 class TestEndpointInitialization(unittest.TestCase):
-    '''Tests for the Endpoint class initialization.'''
+    """Tests for the Endpoint class initialization."""
 
     def test_endpoint_initialization(self):
-        '''Tests initialization of Endpoint class.'''
+        """Tests initialization of Endpoint class."""
         with patch("aiohttp.ClientSession"):
             endpoint = Endpoint("endpoint_id", MagicMock())
-            self.assertEqual(endpoint.endpoint_url, "https://api.runpod.ai/v2/endpoint_id/run")
+            self.assertEqual(
+                endpoint.endpoint_url, "https://api.runpod.ai/v2/endpoint_id/run"
+            )
             self.assertIn("Content-Type", endpoint.headers)
             self.assertIn("Authorization", endpoint.headers)
+
 
 if __name__ == "__main__":
     unittest.main()
 
     snapshot = tracemalloc.take_snapshot()
-    top_stats = snapshot.statistics('lineno')
+    top_stats = snapshot.statistics("lineno")
 
     print("[ Top 10 ]")
     for stat in top_stats[:10]:

--- a/tests/test_endpoint/test_runner.py
+++ b/tests/test_endpoint/test_runner.py
@@ -1,32 +1,33 @@
-'''
+"""
 Tests for runpod | endpoint | modules | endpoint.py
-'''
+"""
 
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
+
 import requests
 
 import runpod
 from runpod.endpoint import runner
-from runpod.endpoint.runner import RunPodClient, Job, Endpoint
+from runpod.endpoint.runner import Endpoint, Job, RunPodClient
 
 
 class TestRunPodClient(unittest.TestCase):
-    """ Tests for RunPodClient """
+    """Tests for RunPodClient"""
 
     def test_no_api_key(self):
-        '''
+        """
         Tests RunPodClient with no api_key
-        '''
+        """
         with self.assertRaises(RuntimeError):
             runpod.api_key = None
             RunPodClient()
 
-    @patch.object(requests.Session, 'post')
+    @patch.object(requests.Session, "post")
     def test_post_with_401(self, mock_post):
-        '''
+        """
         Tests RunPodClient.post with 401 status code
-        '''
+        """
         mock_response = Mock()
         mock_response.status_code = 401
         mock_post.return_value = mock_response
@@ -36,11 +37,11 @@ class TestRunPodClient(unittest.TestCase):
             client = RunPodClient()
             client.post("ENDPOINT_ID/run", {"input": {}})
 
-    @patch.object(requests.Session, 'request')
+    @patch.object(requests.Session, "request")
     def test_post(self, mock_post):
-        '''
+        """
         Tests RunPodClient.post
-        '''
+        """
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"id": "123"}
@@ -52,11 +53,11 @@ class TestRunPodClient(unittest.TestCase):
 
         self.assertEqual(response, {"id": "123"})
 
-    @patch.object(requests.Session, 'get')
+    @patch.object(requests.Session, "get")
     def test_get_with_401(self, mock_get):
-        '''
+        """
         Tests RunPodClient.get with 401 status code
-        '''
+        """
         mock_response = Mock()
         mock_response.status_code = 401
         mock_get.return_value = mock_response
@@ -66,11 +67,11 @@ class TestRunPodClient(unittest.TestCase):
             client = RunPodClient()
             client.get("ENDPOINT_ID/status/123")
 
-    @patch.object(requests.Session, 'request')
+    @patch.object(requests.Session, "request")
     def test_get(self, mock_get):
-        '''
+        """
         Tests RunPodClient.get
-        '''
+        """
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"status": "COMPLETED"}
@@ -84,7 +85,7 @@ class TestRunPodClient(unittest.TestCase):
 
 
 class TestEndpoint(unittest.TestCase):
-    ''' Tests for Endpoint '''
+    """Tests for Endpoint"""
 
     ENDPOINT_ID = "ENDPOINT_ID"
     MOCK_API_KEY = "MOCK_API_KEY"
@@ -92,21 +93,23 @@ class TestEndpoint(unittest.TestCase):
     MODEL_OUTPUT = {"result": "YOUR_MODEL_OUTPUT_VALUE"}
 
     def setUp(self):
-        ''' Common setup for the tests. '''
+        """Common setup for the tests."""
         runpod.api_key = self.MOCK_API_KEY
         self.endpoint = Endpoint(self.ENDPOINT_ID)
 
-    @patch('runpod.endpoint.runner.RunPodClient._request')
+    @patch("runpod.endpoint.runner.RunPodClient._request")
     def test_endpoint_run(self, mock_client_request):
-        ''' Test the run method of Endpoint with a successful job initiation. '''
+        """Test the run method of Endpoint with a successful job initiation."""
         mock_client_request.return_value = {"id": "123", "status": "IN_PROGRESS"}
 
         run_request = self.endpoint.run(self.MODEL_INPUT)
 
         # Tests
         mock_client_request.assert_called_once_with(
-            'POST', f"{self.ENDPOINT_ID}/run",
-            {'input': {'YOUR_MODEL_INPUT_JSON': 'YOUR_MODEL_INPUT_VALUE'}}, 10
+            "POST",
+            f"{self.ENDPOINT_ID}/run",
+            {"input": {"YOUR_MODEL_INPUT_JSON": "YOUR_MODEL_INPUT_VALUE"}},
+            10,
         )
 
         self.assertIsInstance(run_request, Job)
@@ -114,13 +117,17 @@ class TestEndpoint(unittest.TestCase):
         self.assertEqual(run_request.status(), "IN_PROGRESS")
 
         mock_client_request.assert_called_with(
-            'GET', f"{self.ENDPOINT_ID}/status/123", timeout=10)
+            "GET", f"{self.ENDPOINT_ID}/status/123", timeout=10
+        )
 
-    @patch('runpod.endpoint.runner.RunPodClient._request')
+    @patch("runpod.endpoint.runner.RunPodClient._request")
     def test_endpoint_run_sync(self, mock_client_request):
-        ''' Test the run_sync method of Endpoint with a successful job initiation. '''
+        """Test the run_sync method of Endpoint with a successful job initiation."""
         mock_client_request.return_value = {
-            "id": "123", "status": "COMPLETED", "output": self.MODEL_OUTPUT}
+            "id": "123",
+            "status": "COMPLETED",
+            "output": self.MODEL_OUTPUT,
+        }
 
         run_request = self.endpoint.run_sync(self.MODEL_INPUT)
 
@@ -128,40 +135,43 @@ class TestEndpoint(unittest.TestCase):
         self.assertEqual(run_request, self.MODEL_OUTPUT)
 
         mock_client_request.assert_called_once_with(
-            'POST', f"{self.ENDPOINT_ID}/runsync",
-            {'input': {'YOUR_MODEL_INPUT_JSON': 'YOUR_MODEL_INPUT_VALUE'}}, 86400
+            "POST",
+            f"{self.ENDPOINT_ID}/runsync",
+            {"input": {"YOUR_MODEL_INPUT_JSON": "YOUR_MODEL_INPUT_VALUE"}},
+            86400,
         )
 
-    @patch('runpod.endpoint.runner.RunPodClient._request')
+    @patch("runpod.endpoint.runner.RunPodClient._request")
     def test_endpoint_health(self, mock_client_request):
-        ''' Test the health method of Endpoint '''
+        """Test the health method of Endpoint"""
         self.endpoint.health()
 
-        mock_client_request.assert_called_once_with('GET', f"{self.ENDPOINT_ID}/health", timeout=3)
+        mock_client_request.assert_called_once_with(
+            "GET", f"{self.ENDPOINT_ID}/health", timeout=3
+        )
 
-    @patch('runpod.endpoint.runner.RunPodClient._request')
+    @patch("runpod.endpoint.runner.RunPodClient._request")
     def test_endpoint_purge_queue(self, mock_client_request):
-        ''' Test the health method of Endpoint '''
+        """Test the health method of Endpoint"""
         self.endpoint.purge_queue()
 
         mock_client_request.assert_called_once_with(
-            'POST', f"{self.ENDPOINT_ID}/purge-queue",
-            None, 3
+            "POST", f"{self.ENDPOINT_ID}/purge-queue", None, 3
         )
 
     def test_missing_api_key(self):
-        '''
+        """
         Tests Endpoint.run without api_key
-        '''
+        """
         with self.assertRaises(RuntimeError):
             runpod.api_key = None
             self.endpoint.run(self.MODEL_INPUT)
 
-    @patch.object(requests.Session, 'post')
+    @patch.object(requests.Session, "post")
     def test_run_with_401(self, mock_post):
-        '''
+        """
         Tests Endpoint.run with 401 status code
-        '''
+        """
         mock_response = Mock()
         mock_response.status_code = 401
         mock_post.return_value = mock_response
@@ -172,15 +182,12 @@ class TestEndpoint(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             endpoint.run(request_data)
 
-    @patch.object(runpod.endpoint.runner.RunPodClient, '_request')
+    @patch.object(runpod.endpoint.runner.RunPodClient, "_request")
     def test_run(self, mock_client_request):
-        '''
+        """
         Tests Endpoint.run
-        '''
-        mock_client_request.return_value = {
-            "id": "123",
-            "status": "IN_PROGRESS"
-        }
+        """
+        mock_client_request.return_value = {"id": "123", "status": "IN_PROGRESS"}
 
         runpod.api_key = "MOCK_API_KEY"
         endpoint = runpod.Endpoint("ENDPOINT_ID")
@@ -191,15 +198,15 @@ class TestEndpoint(unittest.TestCase):
         self.assertEqual(run_request.job_id, "123")
         self.assertEqual(run_request.status(), "IN_PROGRESS")
 
-    @patch.object(runpod.endpoint.runner.RunPodClient, '_request')
+    @patch.object(runpod.endpoint.runner.RunPodClient, "_request")
     def test_run_sync(self, mock_client_request):
-        '''
+        """
         Tests Endpoint.run_sync
-        '''
+        """
         mock_client_request.return_value = {
             "id": "123",
             "status": "COMPLETED",
-            "output": {"result": "YOUR_MODEL_OUTPUT_VALUE"}
+            "output": {"result": "YOUR_MODEL_OUTPUT_VALUE"},
         }
 
         runpod.api_key = "MOCK_API_KEY"
@@ -210,15 +217,12 @@ class TestEndpoint(unittest.TestCase):
 
         self.assertEqual(run_request, {"result": "YOUR_MODEL_OUTPUT_VALUE"})
 
-    @patch.object(runpod.endpoint.runner.RunPodClient, '_request')
+    @patch.object(runpod.endpoint.runner.RunPodClient, "_request")
     def test_run_sync_with_timeout(self, mock_client_request):
-        '''
+        """
         Tests Endpoint.run_sync with timeout
-        '''
-        mock_client_request.return_value = {
-            "id": "123",
-            "status": "IN_PROGRESS"
-        }
+        """
+        mock_client_request.return_value = {"id": "123", "status": "IN_PROGRESS"}
 
         runpod.api_key = "MOCK_API_KEY"
         endpoint = runpod.Endpoint("ENDPOINT_ID")
@@ -229,49 +233,40 @@ class TestEndpoint(unittest.TestCase):
 
 
 class TestJob(unittest.TestCase):
-    ''' Tests for Job '''
+    """Tests for Job"""
+
     MODEL_OUTPUT = {"result": "YOUR_MODEL_OUTPUT_VALUE"}
 
-    @patch('runpod.endpoint.runner.RunPodClient')
+    @patch("runpod.endpoint.runner.RunPodClient")
     def test_status(self, mock_client):
-        '''
+        """
         Tests Job.status
-        '''
-        mock_client.get.return_value = {
-            "status": "COMPLETED"
-        }
+        """
+        mock_client.get.return_value = {"status": "COMPLETED"}
 
         job = runner.Job("endpoint_id", "job_id", mock_client)
         status = job.status()
         self.assertEqual(status, "COMPLETED")
 
-    @patch('runpod.endpoint.runner.RunPodClient')
+    @patch("runpod.endpoint.runner.RunPodClient")
     def test_output(self, mock_client):
-        '''
+        """
         Tests Job.output
-        '''
-        mock_client.get.return_value = {
-            "status": "COMPLETED",
-            "output": "Job output"
-        }
+        """
+        mock_client.get.return_value = {"status": "COMPLETED", "output": "Job output"}
 
         job = runner.Job("endpoint_id", "job_id", mock_client)
         output = job.output()
         self.assertEqual(output, "Job output")
 
-    @patch('runpod.endpoint.runner.RunPodClient')
+    @patch("runpod.endpoint.runner.RunPodClient")
     def test_output_with_sleep(self, mock_client):
-        '''
+        """
         Tests Job.output with sleep
-        '''
+        """
         mock_client.get.side_effect = [
-            {
-                "status": "IN_PROGRESS"
-            },
-            {
-                "status": "COMPLETED",
-                "output": "Job output"
-            }
+            {"status": "IN_PROGRESS"},
+            {"status": "COMPLETED", "output": "Job output"},
         ]
 
         job = runner.Job("endpoint_id", "job_id", mock_client)
@@ -279,41 +274,36 @@ class TestJob(unittest.TestCase):
 
         self.assertEqual(output, "Job output")
 
-    @patch('runpod.endpoint.runner.RunPodClient')
+    @patch("runpod.endpoint.runner.RunPodClient")
     def test_output_timeout(self, mock_client):
-        '''
+        """
         Tests Job.output with timeout
-        '''
-        mock_client.get.return_value = {
-            "status": "IN_PROGRESS"
-        }
+        """
+        mock_client.get.return_value = {"status": "IN_PROGRESS"}
 
         job = runner.Job("endpoint_id", "job_id", mock_client)
         with self.assertRaises(TimeoutError):
             job.output(timeout=1)
 
-    @patch('runpod.endpoint.runner.RunPodClient')
+    @patch("runpod.endpoint.runner.RunPodClient")
     def test_cancel(self, mock_client):
-        ''' Test the cancel method of Job with a successful job initiation. '''
+        """Test the cancel method of Job with a successful job initiation."""
         job = runner.Job("endpoint_id", "job_id", mock_client)
 
         job.cancel()
 
-        mock_client.post.assert_called_with("endpoint_id/cancel/job_id",
-                                            data=None, timeout=3)
+        mock_client.post.assert_called_with(
+            "endpoint_id/cancel/job_id", data=None, timeout=3
+        )
 
-    @patch('runpod.endpoint.runner.RunPodClient')
+    @patch("runpod.endpoint.runner.RunPodClient")
     def test_job_status(self, mock_client):
-        '''
+        """
         Tests Job.status
-        '''
+        """
         mock_client.get.side_effect = [
-            {
-                "status": "IN_PROGRESS"
-            },
-            {
-                "status": "COMPLETED"
-            }
+            {"status": "IN_PROGRESS"},
+            {"status": "COMPLETED"},
         ]
 
         job = runner.Job("endpoint_id", "job_id", mock_client)
@@ -321,25 +311,19 @@ class TestJob(unittest.TestCase):
         self.assertEqual(job.status(), "COMPLETED")
         self.assertEqual(job.status(), "COMPLETED")
 
-    @patch('runpod.endpoint.runner.RunPodClient')
+    @patch("runpod.endpoint.runner.RunPodClient")
     def test_job_stream(self, mock_client):
-        '''
+        """
         Tests Job.stream
-        '''
+        """
         mock_client.get.side_effect = [
             {
                 "status": "IN_PROGRESS",
-                "stream": [
-                    {"output": "Job output 1"},
-                    {"output": "Job output 2"}
-                ]
+                "stream": [{"output": "Job output 1"}, {"output": "Job output 2"}],
             },
-            {
-                "status": "COMPLETED",
-                "stream": []
-            }
+            {"status": "COMPLETED", "stream": []},
         ]
 
         job = runner.Job("endpoint_id", "job_id", mock_client)
         output = list(job.stream())
-        self.assertEqual(output, ['Job output 1', 'Job output 2'])
+        self.assertEqual(output, ["Job output 1", "Job output 2"])

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -3,7 +3,8 @@
 import unittest
 
 # Assuming the error classes are in a file named 'error.py'
-from runpod.error import RunPodError, AuthenticationError, QueryError
+from runpod.error import AuthenticationError, QueryError, RunPodError
+
 
 class TestErrorClasses(unittest.TestCase):
     """Unit tests for the error classes in the runpod.error module."""
@@ -17,7 +18,7 @@ class TestErrorClasses(unittest.TestCase):
     def test_run_pod_error_without_message(self):
         """Test the RunPodError class without a message."""
         err = RunPodError()
-        self.assertEqual(str(err), 'None')
+        self.assertEqual(str(err), "None")
 
     def test_authentication_error(self):
         """Test the AuthenticationError class."""
@@ -36,5 +37,5 @@ class TestErrorClasses(unittest.TestCase):
     def test_query_error_without_message_and_query(self):
         """Test the QueryError class without a message or query."""
         err = QueryError()
-        self.assertEqual(str(err), 'None')
+        self.assertEqual(str(err), "None")
         self.assertIsNone(err.query)

--- a/tests/test_serverless/__init__.py
+++ b/tests/test_serverless/__init__.py
@@ -1,1 +1,1 @@
-''' Alow serverless tests to be run from the command line.'''
+""" Alow serverless tests to be run from the command line."""

--- a/tests/test_serverless/test_modules/__init__.py
+++ b/tests/test_serverless/test_modules/__init__.py
@@ -1,1 +1,1 @@
-''' Serverless Module Tests '''
+""" Serverless Module Tests """

--- a/tests/test_serverless/test_modules/test_fastapi.py
+++ b/tests/test_serverless/test_modules/test_fastapi.py
@@ -1,20 +1,21 @@
-''' Tests for runpod.serverless.modules.rp_fastapi.py '''
+""" Tests for runpod.serverless.modules.rp_fastapi.py """
+
 # pylint: disable=protected-access
 
-import os
 import asyncio
-
+import os
 import unittest
-from unittest.mock import patch, Mock, MagicMock
-import pytest
+from unittest.mock import MagicMock, Mock, patch
 
+import pytest
 import requests
+
 import runpod
 from runpod.serverless.modules import rp_fastapi
 
 
 class TestFastAPI(unittest.TestCase):
-    ''' Tests the FastAPI '''
+    """Tests the FastAPI"""
 
     def setUp(self) -> None:
         self.handler = Mock()
@@ -24,20 +25,25 @@ class TestFastAPI(unittest.TestCase):
         self.error_handler.side_effect = Exception("test error")
 
     def test_start_serverless_with_realtime(self):
-        '''
+        """
         Tests the start_serverless() method with the realtime option.
-        '''
+        """
         module_location = "runpod.serverless.modules.rp_fastapi"
-        with patch(f"{module_location}.Heartbeat.start_ping", Mock()) as mock_ping, \
-                patch(f"{module_location}.FastAPI", Mock()) as mock_fastapi, \
-                patch(f"{module_location}.APIRouter", return_value=Mock()) as mock_router, \
-                patch(f"{module_location}.uvicorn", Mock()) as mock_uvicorn:
+        with patch(
+            f"{module_location}.Heartbeat.start_ping", Mock()
+        ) as mock_ping, patch(
+            f"{module_location}.FastAPI", Mock()
+        ) as mock_fastapi, patch(
+            f"{module_location}.APIRouter", return_value=Mock()
+        ) as mock_router, patch(
+            f"{module_location}.uvicorn", Mock()
+        ) as mock_uvicorn:
 
-            rp_fastapi.RUNPOD_REALTIME_PORT = '1111'
-            rp_fastapi.RUNPOD_ENDPOINT_ID = 'test_endpoint_id'
+            rp_fastapi.RUNPOD_REALTIME_PORT = "1111"
+            rp_fastapi.RUNPOD_ENDPOINT_ID = "test_endpoint_id"
 
-            os.environ["RUNPOD_REALTIME_PORT"] = '1111'
-            os.environ["RUNPOD_ENDPOINT_ID"] = 'test_endpoint_id'
+            os.environ["RUNPOD_REALTIME_PORT"] = "1111"
+            os.environ["RUNPOD_ENDPOINT_ID"] = "test_endpoint_id"
 
             runpod.serverless.start({"handler": self.handler})
 
@@ -46,7 +52,7 @@ class TestFastAPI(unittest.TestCase):
             self.assertTrue(mock_fastapi.called)
             self.assertTrue(mock_router.called)
 
-            self.assertTrue(rp_fastapi.RUNPOD_ENDPOINT_ID == 'test_endpoint_id')
+            self.assertTrue(rp_fastapi.RUNPOD_ENDPOINT_ID == "test_endpoint_id")
             self.assertTrue(mock_router.return_value.add_api_route.called)
 
             self.assertTrue(mock_uvicorn.run.called)
@@ -81,21 +87,24 @@ class TestFastAPI(unittest.TestCase):
 
     @pytest.mark.asyncio
     def test_run(self):
-        '''
+        """
         Tests the _run() method.
-        '''
+        """
         loop = asyncio.get_event_loop()
 
         module_location = "runpod.serverless.modules.rp_fastapi"
-        with patch(f"{module_location}.Heartbeat.start_ping", Mock()) as mock_ping, \
-                patch(f"{module_location}.FastAPI", Mock()), \
-                patch(f"{module_location}.APIRouter", return_value=Mock()), \
-                patch(f"{module_location}.uvicorn", Mock()), \
-                patch(f"{module_location}.uuid.uuid4", return_value="123"):
+        with patch(
+            f"{module_location}.Heartbeat.start_ping", Mock()
+        ) as mock_ping, patch(f"{module_location}.FastAPI", Mock()), patch(
+            f"{module_location}.APIRouter", return_value=Mock()
+        ), patch(
+            f"{module_location}.uvicorn", Mock()
+        ), patch(
+            f"{module_location}.uuid.uuid4", return_value="123"
+        ):
 
             job_object = rp_fastapi.Job(
-                id="test_job_id",
-                input={"test_input": "test_input"}
+                id="test_job_id", input={"test_input": "test_input"}
             )
 
             default_input_object = rp_fastapi.DefaultRequest(
@@ -109,10 +118,7 @@ class TestFastAPI(unittest.TestCase):
             assert run_return == {"output": {"result": "success"}}
 
             debug_run_return = asyncio.run(worker_api._sim_run(default_input_object))
-            assert debug_run_return == {
-                "id": "test-123",
-                "status": "IN_PROGRESS"
-            }
+            assert debug_run_return == {"id": "test-123", "status": "IN_PROGRESS"}
 
             self.assertTrue(mock_ping.called)
 
@@ -122,35 +128,35 @@ class TestFastAPI(unittest.TestCase):
                 yield {"result": "success"}
 
             generator_worker_api = rp_fastapi.WorkerAPI({"handler": generator_handler})
-            generator_run_return = asyncio.run(generator_worker_api._sim_run(default_input_object))
-            assert generator_run_return == {
-                "id": "test-123",
-                "status": "IN_PROGRESS"
-            }
+            generator_run_return = asyncio.run(
+                generator_worker_api._sim_run(default_input_object)
+            )
+            assert generator_run_return == {"id": "test-123", "status": "IN_PROGRESS"}
 
         loop.close()
 
     @pytest.mark.asyncio
     def test_runsync(self):
-        '''
+        """
         Tests the _runsync() method.
-        '''
+        """
         loop = asyncio.get_event_loop()
 
         module_location = "runpod.serverless.modules.rp_fastapi"
-        with patch(f"{module_location}.FastAPI", Mock()), \
-                patch(f"{module_location}.APIRouter", return_value=Mock()), \
-                patch(f"{module_location}.uvicorn", Mock()), \
-                patch(f"{module_location}.uuid.uuid4", return_value="123"), \
-                patch(f"{module_location}.threading") as mock_threading:
+        with patch(f"{module_location}.FastAPI", Mock()), patch(
+            f"{module_location}.APIRouter", return_value=Mock()
+        ), patch(f"{module_location}.uvicorn", Mock()), patch(
+            f"{module_location}.uuid.uuid4", return_value="123"
+        ), patch(
+            f"{module_location}.threading"
+        ) as mock_threading:
 
             default_input_object = rp_fastapi.DefaultRequest(
                 input={"test_input": "test_input"}
             )
 
             input_object_with_webhook = rp_fastapi.DefaultRequest(
-                input={"test_input": "test_input"},
-                webhook="test_webhook"
+                input={"test_input": "test_input"}, webhook="test_webhook"
             )
 
             # Test with handler
@@ -160,7 +166,7 @@ class TestFastAPI(unittest.TestCase):
             assert runsync_return == {
                 "id": "test-123",
                 "status": "COMPLETED",
-                "output": {"result": "success"}
+                "output": {"result": "success"},
             }
 
             # Test with generator handler
@@ -170,17 +176,19 @@ class TestFastAPI(unittest.TestCase):
 
             generator_worker_api = rp_fastapi.WorkerAPI({"handler": generator_handler})
             generator_runsync_return = asyncio.run(
-                generator_worker_api._sim_runsync(default_input_object))
+                generator_worker_api._sim_runsync(default_input_object)
+            )
             assert generator_runsync_return == {
                 "id": "test-123",
                 "status": "COMPLETED",
-                "output": [{"result": "success"}]
+                "output": [{"result": "success"}],
             }
 
             # Test with error handler
             error_worker_api = rp_fastapi.WorkerAPI({"handler": self.error_handler})
             error_runsync_return = asyncio.run(
-                error_worker_api._sim_runsync(default_input_object))
+                error_worker_api._sim_runsync(default_input_object)
+            )
             assert "error" in error_runsync_return
 
             # Test webhook caller sent
@@ -191,25 +199,26 @@ class TestFastAPI(unittest.TestCase):
 
     @pytest.mark.asyncio
     def test_stream(self):
-        '''
+        """
         Tests the _stream() method.
-        '''
+        """
         loop = asyncio.get_event_loop()
 
         module_location = "runpod.serverless.modules.rp_fastapi"
-        with patch(f"{module_location}.FastAPI", Mock()), \
-                patch(f"{module_location}.APIRouter", return_value=Mock()), \
-                patch(f"{module_location}.uvicorn", Mock()), \
-                patch(f"{module_location}.uuid.uuid4", return_value="123"), \
-                patch(f"{module_location}.threading") as mock_threading:
+        with patch(f"{module_location}.FastAPI", Mock()), patch(
+            f"{module_location}.APIRouter", return_value=Mock()
+        ), patch(f"{module_location}.uvicorn", Mock()), patch(
+            f"{module_location}.uuid.uuid4", return_value="123"
+        ), patch(
+            f"{module_location}.threading"
+        ) as mock_threading:
 
             default_input_object = rp_fastapi.DefaultRequest(
                 input={"test_input": "test_input"}
             )
 
             input_object_with_webhook = rp_fastapi.DefaultRequest(
-                input={"test_input": "test_input"},
-                webhook="test_webhook"
+                input={"test_input": "test_input"}, webhook="test_webhook"
             )
 
             worker_api = rp_fastapi.WorkerAPI({"handler": self.handler})
@@ -221,14 +230,14 @@ class TestFastAPI(unittest.TestCase):
             assert stream_return == {
                 "id": "test_job_id",
                 "status": "FAILED",
-                "error": "Job ID not found"
+                "error": "Job ID not found",
             }
 
             stream_return = asyncio.run(worker_api._sim_stream("test-123"))
             assert stream_return == {
                 "id": "test-123",
                 "status": "FAILED",
-                "error": "Stream not supported, handler must be a generator."
+                "error": "Stream not supported, handler must be a generator.",
             }
 
             # Test with generator handler
@@ -238,11 +247,12 @@ class TestFastAPI(unittest.TestCase):
 
             generator_worker_api = rp_fastapi.WorkerAPI({"handler": generator_handler})
             generator_stream_return = asyncio.run(
-                generator_worker_api._sim_stream("test-123"))
+                generator_worker_api._sim_stream("test-123")
+            )
             assert generator_stream_return == {
                 "id": "test-123",
                 "status": "COMPLETED",
-                "stream": [{"output": {"result": "success"}}]
+                "stream": [{"output": {"result": "success"}}],
             }
 
             # Test webhook caller sent
@@ -254,17 +264,19 @@ class TestFastAPI(unittest.TestCase):
 
     @pytest.mark.asyncio
     def test_status(self):
-        '''
+        """
         Tests the _status() method.
-        '''
+        """
         loop = asyncio.get_event_loop()
 
         module_location = "runpod.serverless.modules.rp_fastapi"
-        with patch(f"{module_location}.FastAPI", Mock()), \
-                patch(f"{module_location}.APIRouter", return_value=Mock()), \
-                patch(f"{module_location}.uvicorn", Mock()), \
-                patch(f"{module_location}.uuid.uuid4", return_value="123"), \
-                patch(f"{module_location}.threading") as mock_threading:
+        with patch(f"{module_location}.FastAPI", Mock()), patch(
+            f"{module_location}.APIRouter", return_value=Mock()
+        ), patch(f"{module_location}.uvicorn", Mock()), patch(
+            f"{module_location}.uuid.uuid4", return_value="123"
+        ), patch(
+            f"{module_location}.threading"
+        ) as mock_threading:
 
             worker_api = rp_fastapi.WorkerAPI({"handler": self.handler})
 
@@ -273,8 +285,7 @@ class TestFastAPI(unittest.TestCase):
             )
 
             input_object_with_webhook = rp_fastapi.DefaultRequest(
-                input={"test_input": "test_input"},
-                webhook="test_webhook"
+                input={"test_input": "test_input"}, webhook="test_webhook"
             )
 
             # Add job to job_list
@@ -284,14 +295,14 @@ class TestFastAPI(unittest.TestCase):
             assert status_return == {
                 "id": "test_job_id",
                 "status": "FAILED",
-                "error": "Job ID not found"
+                "error": "Job ID not found",
             }
 
             status_return = asyncio.run(worker_api._sim_status("test-123"))
             assert status_return == {
                 "id": "test-123",
                 "status": "COMPLETED",
-                "output": {"result": "success"}
+                "output": {"result": "success"},
             }
 
             # Test webhook caller sent
@@ -303,21 +314,22 @@ class TestFastAPI(unittest.TestCase):
             def generator_handler(job):
                 del job
                 yield {"result": "success"}
+
             generator_worker_api = rp_fastapi.WorkerAPI({"handler": generator_handler})
             asyncio.run(generator_worker_api._sim_run(default_input_object))
             generator_stream_return = asyncio.run(
-                generator_worker_api._sim_status("test-123"))
+                generator_worker_api._sim_status("test-123")
+            )
             assert generator_stream_return == {
                 "id": "test-123",
                 "status": "COMPLETED",
-                "output": [{"result": "success"}]
+                "output": [{"result": "success"}],
             }
 
             # Test with error handler
             error_worker_api = rp_fastapi.WorkerAPI({"handler": self.error_handler})
             asyncio.run(error_worker_api._sim_run(default_input_object))
-            error_status_return = asyncio.run(
-                error_worker_api._sim_status("test-123"))
+            error_status_return = asyncio.run(error_worker_api._sim_status("test-123"))
             assert "error" in error_status_return
 
         loop.close()

--- a/tests/test_serverless/test_modules/test_handler.py
+++ b/tests/test_serverless/test_modules/test_handler.py
@@ -1,5 +1,6 @@
 """ Unit tests for the handler module.
 """
+
 import unittest
 
 from runpod.serverless.modules.rp_handler import is_generator
@@ -10,24 +11,32 @@ class TestIsGenerator(unittest.TestCase):
 
     def test_regular_function(self):
         """Test that a regular function is not a generator."""
+
         def regular_func():
             return "I'm a regular function!"
+
         self.assertFalse(is_generator(regular_func))
 
     def test_generator_function(self):
         """Test that a generator function is a generator."""
+
         def generator_func():
             yield "I'm a generator function!"
+
         self.assertTrue(is_generator(generator_func))
 
     def test_async_function(self):
         """Test that an async function is not a generator."""
+
         async def async_func():
             return "I'm an async function!"
+
         self.assertFalse(is_generator(async_func))
 
     def test_async_generator_function(self):
         """Test that an async generator function is a generator."""
+
         async def async_gen_func():
             yield "I'm an async generator function!"
+
         self.assertTrue(is_generator(async_gen_func))

--- a/tests/test_serverless/test_modules/test_http.py
+++ b/tests/test_serverless/test_modules/test_http.py
@@ -1,19 +1,21 @@
-'''
+"""
 Test rp_http.py module.
-'''
+"""
+
 # pylint: disable=too-few-public-methods
 
 import gc
 import json
 import unittest
-from unittest.mock import patch, AsyncMock
+from unittest.mock import AsyncMock, patch
+
 import aiohttp
 
 from runpod.serverless.modules import rp_http
 
 
 class MockRequestInfo:
-    ''' Mock aiohttp.RequestInfo class. '''
+    """Mock aiohttp.RequestInfo class."""
 
     def __init__(self, *args, **kwargs):
         del args, kwargs
@@ -26,7 +28,7 @@ class MockRequestInfo:
 
 
 class TestHTTP(unittest.IsolatedAsyncioTestCase):
-    ''' Test HTTP module. '''
+    """Test HTTP module."""
 
     def setUp(self) -> None:
         self.job = {"id": "test_id"}
@@ -36,18 +38,24 @@ class TestHTTP(unittest.IsolatedAsyncioTestCase):
         gc.collect()
 
     async def test_send_result(self):
-        '''
+        """
         Test send_result function.
-        '''
-        with patch('runpod.serverless.modules.rp_http.log') as mock_log, \
-                patch('runpod.serverless.modules.rp_http.job_list.jobs') as mock_jobs, \
-                patch('runpod.serverless.modules.rp_http.RetryClient') as mock_retry:
+        """
+        with patch("runpod.serverless.modules.rp_http.log") as mock_log, patch(
+            "runpod.serverless.modules.rp_http.job_list.jobs"
+        ) as mock_jobs, patch(
+            "runpod.serverless.modules.rp_http.RetryClient"
+        ) as mock_retry:
 
             mock_retry.return_value.post.return_value = AsyncMock()
-            mock_retry.return_value.post.return_value.__aenter__.return_value.text.return_value = "response text"  # pylint: disable=line-too-long
+            mock_retry.return_value.post.return_value.__aenter__.return_value.text.return_value = (
+                "response text"  # pylint: disable=line-too-long
+            )
 
-            mock_jobs.return_value = set(['test_id'])
-            send_return_local = await rp_http.send_result(AsyncMock(), self.job_data, self.job)
+            mock_jobs.return_value = set(["test_id"])
+            send_return_local = await rp_http.send_result(
+                AsyncMock(), self.job_data, self.job
+            )
 
             assert send_return_local is None
             assert mock_log.debug.call_count == 1
@@ -55,44 +63,49 @@ class TestHTTP(unittest.IsolatedAsyncioTestCase):
             assert mock_log.info.call_count == 1
 
             mock_retry.return_value.post.assert_called_with(
-                'JOB_DONE_URL' + "&isStream=false",
+                "JOB_DONE_URL" + "&isStream=false",
                 data=str(json.dumps(self.job_data, ensure_ascii=False)),
                 headers={
                     "charset": "utf-8",
-                    "Content-Type": "application/x-www-form-urlencoded"
+                    "Content-Type": "application/x-www-form-urlencoded",
                 },
-                raise_for_status=True
+                raise_for_status=True,
             )
 
     async def test_send_result_client_response_error(self):
-        '''
+        """
         Test send_result function with ClientResponseError.
-        '''
+        """
 
         def mock_request_info_init(self, *args, **kwargs):
-            '''
+            """
             Mock aiohttp.RequestInfo.__init__ method.
-            '''
+            """
             del args, kwargs
             self.url = "http://test_url"
             self.method = "POST"
             self.headers = {"Content-Type": "application/json"}
             self.real_url = "http://test_url"
 
-        with patch('runpod.serverless.modules.rp_http.log') as mock_log, \
-                patch('runpod.serverless.modules.rp_http.job_list.jobs') as mock_jobs, \
-                patch('runpod.serverless.modules.rp_http.RetryClient') as mock_retry, \
-                patch.object(aiohttp.RequestInfo, "__init__", mock_request_info_init):
+        with patch("runpod.serverless.modules.rp_http.log") as mock_log, patch(
+            "runpod.serverless.modules.rp_http.job_list.jobs"
+        ) as mock_jobs, patch(
+            "runpod.serverless.modules.rp_http.RetryClient"
+        ) as mock_retry, patch.object(
+            aiohttp.RequestInfo, "__init__", mock_request_info_init
+        ):
 
             mock_retry.side_effect = aiohttp.ClientResponseError(
                 request_info=MockRequestInfo,
                 history=None,
                 status=500,
-                message="Error message"
+                message="Error message",
             )
 
-            mock_jobs.return_value = set(['test_id'])
-            send_return_local = await rp_http.send_result(AsyncMock(), self.job_data, self.job)
+            mock_jobs.return_value = set(["test_id"])
+            send_return_local = await rp_http.send_result(
+                AsyncMock(), self.job_data, self.job
+            )
 
             assert send_return_local is None
             assert mock_log.debug.call_count == 0
@@ -100,17 +113,20 @@ class TestHTTP(unittest.IsolatedAsyncioTestCase):
             assert mock_log.info.call_count == 1
 
     async def test_send_result_type_error(self):
-        '''
+        """
         Test send_result function with TypeError.
-        '''
-        with patch('runpod.serverless.modules.rp_http.log') as mock_log, \
-                patch('runpod.serverless.modules.rp_http.job_list.jobs') as mock_jobs, \
-                patch('runpod.serverless.modules.rp_http.json.dumps') as mock_dumps, \
-                patch('runpod.serverless.modules.rp_http.RetryClient') as mock_retry:
+        """
+        with patch("runpod.serverless.modules.rp_http.log") as mock_log, patch(
+            "runpod.serverless.modules.rp_http.job_list.jobs"
+        ) as mock_jobs, patch(
+            "runpod.serverless.modules.rp_http.json.dumps"
+        ) as mock_dumps, patch(
+            "runpod.serverless.modules.rp_http.RetryClient"
+        ) as mock_retry:
 
             mock_dumps.side_effect = TypeError("Forced exception")
 
-            mock_jobs.return_value = set(['test_id'])
+            mock_jobs.return_value = set(["test_id"])
             send_return_local = await rp_http.send_result(
                 aiohttp.ClientSession(), self.job_data, self.job
             )
@@ -121,21 +137,28 @@ class TestHTTP(unittest.IsolatedAsyncioTestCase):
             assert mock_log.info.call_count == 1
             assert mock_retry.return_value.post.call_count == 0
             mock_log.error.assert_called_with(
-                'Error while returning job result. | Forced exception', 'test_id')  # pylint: disable=line-too-long
+                "Error while returning job result. | Forced exception", "test_id"
+            )  # pylint: disable=line-too-long
 
     async def test_stream_result(self):
-        '''
+        """
         Test stream_result function.
-        '''
-        with patch('runpod.serverless.modules.rp_http.log') as mock_log, \
-                patch('runpod.serverless.modules.rp_http.job_list.jobs') as mock_jobs, \
-                patch('runpod.serverless.modules.rp_http.RetryClient') as mock_retry:
+        """
+        with patch("runpod.serverless.modules.rp_http.log") as mock_log, patch(
+            "runpod.serverless.modules.rp_http.job_list.jobs"
+        ) as mock_jobs, patch(
+            "runpod.serverless.modules.rp_http.RetryClient"
+        ) as mock_retry:
 
             mock_retry.return_value.post.return_value = AsyncMock()
-            mock_retry.return_value.post.return_value.__aenter__.return_value.text.return_value = "response text"  # pylint: disable=line-too-long
+            mock_retry.return_value.post.return_value.__aenter__.return_value.text.return_value = (
+                "response text"  # pylint: disable=line-too-long
+            )
 
-            mock_jobs.return_value = set(['test_id'])
-            send_return_local = await rp_http.stream_result(AsyncMock(), self.job_data, self.job)
+            mock_jobs.return_value = set(["test_id"])
+            send_return_local = await rp_http.stream_result(
+                AsyncMock(), self.job_data, self.job
+            )
 
             assert send_return_local is None
             assert mock_log.debug.call_count == 1
@@ -143,15 +166,15 @@ class TestHTTP(unittest.IsolatedAsyncioTestCase):
             assert mock_log.info.call_count == 0
 
             mock_retry.return_value.post.assert_called_with(
-                'JOB_STREAM_URL' + "&isStream=false",
+                "JOB_STREAM_URL" + "&isStream=false",
                 data=str(json.dumps(self.job_data, ensure_ascii=False)),
                 headers={
                     "charset": "utf-8",
-                    "Content-Type": "application/x-www-form-urlencoded"
+                    "Content-Type": "application/x-www-form-urlencoded",
                 },
-                raise_for_status=True
+                raise_for_status=True,
             )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_serverless/test_modules/test_job.py
+++ b/tests/test_serverless/test_modules/test_job.py
@@ -1,12 +1,12 @@
-'''
+"""
 Test Serverless Job Module
-'''
+"""
 
 import asyncio
 import time
+from unittest import IsolatedAsyncioTestCase
 from unittest.mock import Mock, patch
 
-from unittest import IsolatedAsyncioTestCase
 from aiohttp import ClientResponse
 from aiohttp.test_utils import make_mocked_coro
 
@@ -14,12 +14,12 @@ from runpod.serverless.modules import rp_job
 
 
 class TestJob(IsolatedAsyncioTestCase):
-    ''' Tests the Job class. '''
+    """Tests the Job class."""
 
     async def test_get_job_retries(self):
-        '''
+        """
         Tests the get_job function with a 204, 400, and 200 response with retries
-        '''
+        """
         # Mocked responses
         response_204 = Mock()
         response_204.status = 204
@@ -31,13 +31,16 @@ class TestJob(IsolatedAsyncioTestCase):
 
         response_200 = Mock()
         response_200.status = 200
-        response_200.json = make_mocked_coro(return_value={"id": "123", "input": {"number": 1}})
+        response_200.json = make_mocked_coro(
+            return_value={"id": "123", "input": {"number": 1}}
+        )
 
         # Create a list of responses: 204, 400, then a 200
         responses = [response_204] * 98 + [response_400] + [response_200]
 
-        with patch("aiohttp.ClientSession") as mock_session, \
-                patch("runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"):
+        with patch("aiohttp.ClientSession") as mock_session, patch(
+            "runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"
+        ):
 
             mock_session.get.return_value.__aenter__.side_effect = responses
 
@@ -57,9 +60,9 @@ class TestJob(IsolatedAsyncioTestCase):
             assert total_time_taken >= 1
 
     async def test_get_job_200(self):
-        '''
+        """
         Tests the get_job function
-        '''
+        """
         # Mock the non-200 response
         response1 = Mock()
         response1.status = 500
@@ -78,14 +81,20 @@ class TestJob(IsolatedAsyncioTestCase):
         # Mock the 200 response
         response4 = Mock()
         response4.status = 200
-        response4.json = make_mocked_coro(return_value={"id": "123", "input": {"number": 1}})
+        response4.json = make_mocked_coro(
+            return_value={"id": "123", "input": {"number": 1}}
+        )
 
-        with patch("aiohttp.ClientSession") as mock_session, \
-                patch("runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"):
+        with patch("aiohttp.ClientSession") as mock_session, patch(
+            "runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"
+        ):
 
             # Set side_effect to a list of mock responses
             mock_session.get.return_value.__aenter__.side_effect = [
-                response1, response2, response3, response4
+                response1,
+                response2,
+                response3,
+                response4,
             ]
 
             job = await rp_job.get_job(mock_session, retry=True)
@@ -94,16 +103,17 @@ class TestJob(IsolatedAsyncioTestCase):
             assert job == {"id": "123", "input": {"number": 1}}
 
     async def test_get_job_204(self):
-        '''
+        """
         Tests the get_job function with a 204 response
-        '''
+        """
         # 204 Mock
         response_204 = Mock()
         response_204.status = 204
         response_204.json = make_mocked_coro(return_value=None)
 
-        with patch("aiohttp.ClientSession") as mock_session_204, \
-                patch("runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"):
+        with patch("aiohttp.ClientSession") as mock_session_204, patch(
+            "runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"
+        ):
 
             mock_session_204.get.return_value.__aenter__.return_value = response_204
             job = await rp_job.get_job(mock_session_204, retry=False)
@@ -112,15 +122,16 @@ class TestJob(IsolatedAsyncioTestCase):
             assert mock_session_204.get.call_count == 1
 
     async def test_get_job_400(self):
-        '''
+        """
         Test the get_job function with a 400 response
-        '''
+        """
         # 400 Mock
         response_400 = Mock(ClientResponse)
         response_400.status = 400
 
-        with patch("aiohttp.ClientSession") as mock_session_400, \
-                patch("runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"):
+        with patch("aiohttp.ClientSession") as mock_session_400, patch(
+            "runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"
+        ):
 
             mock_session_400.get.return_value.__aenter__.return_value = response_400
             job = await rp_job.get_job(mock_session_400, retry=False)
@@ -128,15 +139,16 @@ class TestJob(IsolatedAsyncioTestCase):
             assert job is None
 
     async def test_get_job_500(self):
-        '''
+        """
         Tests the get_job function with a 500 response
-        '''
+        """
         # 500 Mock
         response_500 = Mock(ClientResponse)
         response_500.status = 500
 
-        with patch("aiohttp.ClientSession") as mock_session_500, \
-                patch("runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"):
+        with patch("aiohttp.ClientSession") as mock_session_500, patch(
+            "runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"
+        ):
 
             mock_session_500.get.return_value.__aenter__.return_value = response_500
             job = await rp_job.get_job(mock_session_500, retry=False)
@@ -144,16 +156,18 @@ class TestJob(IsolatedAsyncioTestCase):
             assert job is None
 
     async def test_get_job_no_id(self):
-        '''
+        """
         Tests the get_job function with a 200 response but no id
-        '''
+        """
         response = Mock(ClientResponse)
         response.status = 200
         response.json = make_mocked_coro(return_value={})
 
-        with patch("aiohttp.ClientSession") as mock_session, \
-                patch("runpod.serverless.modules.rp_job.log", new_callable=Mock) as mock_log, \
-                patch("runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"):
+        with patch("aiohttp.ClientSession") as mock_session, patch(
+            "runpod.serverless.modules.rp_job.log", new_callable=Mock
+        ) as mock_log, patch(
+            "runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"
+        ):
 
             mock_session.get.return_value.__aenter__.return_value = response
 
@@ -163,16 +177,18 @@ class TestJob(IsolatedAsyncioTestCase):
             assert mock_log.error.call_count == 1
 
     async def test_get_job_no_input(self):
-        '''
+        """
         Tests the get_job function with a 200 response but no input
-        '''
+        """
         response = Mock(ClientResponse)
         response.status = 200
         response.json = make_mocked_coro(return_value={"id": "123"})
 
-        with patch("aiohttp.ClientSession") as mock_session, \
-                patch("runpod.serverless.modules.rp_job.log", new_callable=Mock) as mock_log, \
-                patch("runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"):
+        with patch("aiohttp.ClientSession") as mock_session, patch(
+            "runpod.serverless.modules.rp_job.log", new_callable=Mock
+        ) as mock_log, patch(
+            "runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"
+        ):
 
             mock_session.get.return_value.__aenter__.return_value = response
 
@@ -182,32 +198,38 @@ class TestJob(IsolatedAsyncioTestCase):
             assert mock_log.error.call_count == 1
 
     async def test_get_job_no_timeout(self):
-        """ Tests the get_job function with a timeout """
+        """Tests the get_job function with a timeout"""
         # Timeout Mock
         response_timeout = Mock(ClientResponse)
         response_timeout.status = 200
 
-        with patch("aiohttp.ClientSession") as mock_session_timeout, \
-                patch("runpod.serverless.modules.rp_job.log", new_callable=Mock) as mock_log, \
-                patch("runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"):
+        with patch("aiohttp.ClientSession") as mock_session_timeout, patch(
+            "runpod.serverless.modules.rp_job.log", new_callable=Mock
+        ) as mock_log, patch(
+            "runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"
+        ):
 
-            mock_session_timeout.get.return_value.__aenter__.side_effect = asyncio.TimeoutError
+            mock_session_timeout.get.return_value.__aenter__.side_effect = (
+                asyncio.TimeoutError
+            )
             job = await rp_job.get_job(mock_session_timeout, retry=False)
 
             assert job is None
             assert mock_log.error.call_count == 0
 
     async def test_get_job_exception(self):
-        '''
+        """
         Tests the get_job function with an exception
-        '''
+        """
         # Exception Mock
         response_exception = Mock(ClientResponse)
         response_exception.status = 200
 
-        with patch("aiohttp.ClientSession") as mock_session_exception, \
-                patch("runpod.serverless.modules.rp_job.log", new_callable=Mock) as mock_log, \
-                patch("runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"):
+        with patch("aiohttp.ClientSession") as mock_session_exception, patch(
+            "runpod.serverless.modules.rp_job.log", new_callable=Mock
+        ) as mock_log, patch(
+            "runpod.serverless.modules.rp_job.JOB_GET_URL", "http://mock.url"
+        ):
 
             mock_session_exception.get.return_value.__aenter__.side_effect = Exception
             job = await rp_job.get_job(mock_session_exception, retry=False)
@@ -217,27 +239,27 @@ class TestJob(IsolatedAsyncioTestCase):
 
 
 class TestRunJob(IsolatedAsyncioTestCase):
-    ''' Tests the run_job function '''
+    """Tests the run_job function"""
 
     def setUp(self) -> None:
         self.sample_job = {
             "id": "123",
             "input": {
                 "test_input": None,
-            }
+            },
         }
 
     async def test_simple_job(self):
-        '''
+        """
         Tests the run_job function
-        '''
+        """
         mock_handler = Mock()
 
         mock_handler.return_value = "test"
         job_result = await rp_job.run_job(mock_handler, self.sample_job)
         assert job_result == {"output": "test"}
 
-        mock_handler.return_value = ['test1', 'test2']
+        mock_handler.return_value = ["test1", "test2"]
         job_result_list = await rp_job.run_job(mock_handler, self.sample_job)
         assert job_result_list == {"output": ["test1", "test2"]}
 
@@ -246,9 +268,9 @@ class TestRunJob(IsolatedAsyncioTestCase):
         assert job_result_int == {"output": 123}
 
     async def test_job_with_errors(self):
-        '''
+        """
         Tests the run_job function with errors
-        '''
+        """
         mock_handler = Mock()
         mock_handler.return_value = {"error": "test"}
 
@@ -257,9 +279,9 @@ class TestRunJob(IsolatedAsyncioTestCase):
         assert job_result == {"error": "test"}
 
     async def test_job_with_raised_exception(self):
-        '''
+        """
         Tests the run_job function with a raised exception
-        '''
+        """
         mock_handler = Mock()
         mock_handler.side_effect = Exception
 
@@ -268,9 +290,9 @@ class TestRunJob(IsolatedAsyncioTestCase):
         assert "error" in job_result
 
     async def test_job_with_refresh_worker(self):
-        '''
+        """
         Tests the run_job function with refresh_worker
-        '''
+        """
         mock_handler = Mock()
         mock_handler.return_value = {"refresh_worker": True}
 
@@ -279,9 +301,9 @@ class TestRunJob(IsolatedAsyncioTestCase):
         assert job_result["stopPod"] is True
 
     async def test_job_bool_output(self):
-        '''
+        """
         Tests the run_job function with a boolean output
-        '''
+        """
         mock_handler = Mock()
         mock_handler.return_value = True
 
@@ -290,9 +312,9 @@ class TestRunJob(IsolatedAsyncioTestCase):
         assert job_result == {"output": True}
 
     async def test_job_with_exception(self):
-        '''
+        """
         Tests the run_job function with an exception
-        '''
+        """
         mock_handler = Mock()
         mock_handler.side_effect = Exception
 
@@ -302,70 +324,82 @@ class TestRunJob(IsolatedAsyncioTestCase):
 
 
 class TestRunJobGenerator(IsolatedAsyncioTestCase):
-    ''' Tests the run_job_generator function '''
+    """Tests the run_job_generator function"""
 
     def handler_gen_success(self, job):  # pylint: disable=unused-argument
-        '''
+        """
         Test handler that returns a generator.
-        '''
+        """
         yield "partial_output_1"
         yield "partial_output_2"
 
     async def handler_async_gen_success(self, job):  # pylint: disable=unused-argument
-        '''
+        """
         Test handler that returns an async generator.
-        '''
+        """
         yield "partial_output_1"
         yield "partial_output_2"
 
     def handler_fail(self, job):
-        '''
+        """
         Test handler that raises an exception.
-        '''
+        """
         raise Exception("Test Exception")  # pylint: disable=broad-exception-raised
 
     async def test_run_job_generator_success(self):
-        '''
+        """
         Tests the run_job_generator function with a successful generator
-        '''
+        """
         handler = self.handler_gen_success
         job = {"id": "123"}
 
-        with patch("runpod.serverless.modules.rp_job.log", new_callable=Mock) as mock_log:
+        with patch(
+            "runpod.serverless.modules.rp_job.log", new_callable=Mock
+        ) as mock_log:
             result = [i async for i in rp_job.run_job_generator(handler, job)]
 
-        assert result == [{"output": "partial_output_1"}, {"output": "partial_output_2"}]
+        assert result == [
+            {"output": "partial_output_1"},
+            {"output": "partial_output_2"},
+        ]
         assert mock_log.error.call_count == 0
         assert mock_log.info.call_count == 1
-        mock_log.info.assert_called_with('Finished running generator.', '123')
+        mock_log.info.assert_called_with("Finished running generator.", "123")
 
     async def test_run_job_generator_success_async(self):
-        '''
+        """
         Tests the run_job_generator function with a successful generator
-        '''
+        """
         handler = self.handler_async_gen_success
         job = {"id": "123"}
 
-        with patch("runpod.serverless.modules.rp_job.log", new_callable=Mock) as mock_log:
+        with patch(
+            "runpod.serverless.modules.rp_job.log", new_callable=Mock
+        ) as mock_log:
             result = [i async for i in rp_job.run_job_generator(handler, job)]
 
-        assert result == [{"output": "partial_output_1"}, {"output": "partial_output_2"}]
+        assert result == [
+            {"output": "partial_output_1"},
+            {"output": "partial_output_2"},
+        ]
         assert mock_log.error.call_count == 0
         assert mock_log.info.call_count == 1
-        mock_log.info.assert_called_with('Finished running generator.', '123')
+        mock_log.info.assert_called_with("Finished running generator.", "123")
 
     async def test_run_job_generator_exception(self):
-        '''
+        """
         Tests the run_job_generator function with an exception
-        '''
+        """
         handler = self.handler_fail
         job = {"id": "123"}
 
-        with patch("runpod.serverless.modules.rp_job.log", new_callable=Mock) as mock_log:
+        with patch(
+            "runpod.serverless.modules.rp_job.log", new_callable=Mock
+        ) as mock_log:
             result = [i async for i in rp_job.run_job_generator(handler, job)]
 
         assert len(result) == 1
         assert "error" in result[0]
         assert mock_log.error.call_count == 1
         assert mock_log.info.call_count == 1
-        mock_log.info.assert_called_with('Finished running generator.', '123')
+        mock_log.info.assert_called_with("Finished running generator.", "123")

--- a/tests/test_serverless/test_modules/test_local.py
+++ b/tests/test_serverless/test_modules/test_local.py
@@ -1,31 +1,28 @@
-''' Tests for rp_local.py '''
+""" Tests for rp_local.py """
 
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
 
 from runpod.serverless.modules import rp_local
 
 
 class TestRunLocal(IsolatedAsyncioTestCase):
-    ''' Tests for run_local function '''
+    """Tests for run_local function"""
 
-    @patch("runpod.serverless.modules.rp_local.run_job", return_value={"result": "success"})
+    @patch(
+        "runpod.serverless.modules.rp_local.run_job", return_value={"result": "success"}
+    )
     @patch("builtins.open", new_callable=mock_open, read_data='{"input": "test"}')
     async def test_run_local_with_test_input(self, mock_file, mock_run):
-        '''
+        """
         Test run_local function with test_input in rp_args
-        '''
+        """
         config = {
             "handler": "handler",
             "rp_args": {
-                "test_input": {
-                    "input": "test",
-                    "id": "test_id"
-                },
-                "test_output": {
-                    "result": "success"
-                }
-            }
+                "test_input": {"input": "test", "id": "test_id"},
+                "test_output": {"result": "success"},
+            },
         }
         with self.assertRaises(SystemExit) as sys_exit:
             await rp_local.run_local(config)
@@ -42,13 +39,10 @@ class TestRunLocal(IsolatedAsyncioTestCase):
     @patch("runpod.serverless.modules.rp_local.run_job", return_value={})
     @patch("builtins.open", new_callable=mock_open, read_data='{"input": "test"}')
     async def test_run_local_with_test_input_json(self, mock_file, mock_run):
-        '''
+        """
         Test run_local function with test_input.json
-        '''
-        config = {
-            "handler": "handler",
-            "rp_args": {}
-        }
+        """
+        config = {"handler": "handler", "rp_args": {}}
         with patch("os.path.exists", return_value=True):
             with self.assertRaises(SystemExit) as sys_exit:
                 await rp_local.run_local(config)
@@ -57,20 +51,18 @@ class TestRunLocal(IsolatedAsyncioTestCase):
         assert mock_file.called
         assert mock_run.called
 
-    @patch("runpod.serverless.modules.rp_local.run_job", return_value={"error": "test_error"})
+    @patch(
+        "runpod.serverless.modules.rp_local.run_job",
+        return_value={"error": "test_error"},
+    )
     @patch("builtins.open", new_callable=mock_open, read_data='{"input": "test"}')
     async def test_run_local_with_error(self, mock_file, mock_run):
-        '''
+        """
         Test run_local function when run_job returns an error
-        '''
+        """
         config = {
             "handler": "handler",
-            "rp_args": {
-                "test_input": {
-                    "input": "test",
-                    "id": "test_id"
-                }
-            }
+            "rp_args": {"test_input": {"input": "test", "id": "test_id"}},
         }
         with self.assertRaises(SystemExit) as sys_exit:
             await rp_local.run_local(config)
@@ -80,13 +72,10 @@ class TestRunLocal(IsolatedAsyncioTestCase):
         assert mock_run.called
 
     async def test_run_local_without_test_input_json(self):
-        '''
+        """
         Test run_local function without test_input.json
-        '''
-        config = {
-            "handler": "handler",
-            "rp_args": {}
-        }
+        """
+        config = {"handler": "handler", "rp_args": {}}
         with patch("os.path.exists", return_value=False):
             with self.assertRaises(SystemExit) as sys_exit:
                 await rp_local.run_local(config)
@@ -95,13 +84,10 @@ class TestRunLocal(IsolatedAsyncioTestCase):
     @patch("runpod.serverless.modules.rp_local.run_job", return_value={})
     @patch("builtins.open", new_callable=mock_open, read_data='{"not_input": "test"}')
     async def test_run_local_without_input(self, mock_file, mock_run):
-        '''
+        """
         Test run_local function without input in test_input.json
-        '''
-        config = {
-            "handler": "handler",
-            "rp_args": {}
-        }
+        """
+        config = {"handler": "handler", "rp_args": {}}
         with patch("os.path.exists", return_value=True):
             with self.assertRaises(SystemExit) as sys_exit:
                 await rp_local.run_local(config)

--- a/tests/test_serverless/test_modules/test_logger.py
+++ b/tests/test_serverless/test_modules/test_logger.py
@@ -1,4 +1,4 @@
-''' Tests for runpod.serverless.modules.rp_logger '''
+""" Tests for runpod.serverless.modules.rp_logger """
 
 import os
 import unittest
@@ -8,35 +8,35 @@ from runpod.serverless.modules import rp_logger
 
 
 class TestLogger(unittest.TestCase):
-    ''' Tests for rp_logger '''
+    """Tests for rp_logger"""
 
     def setUp(self) -> None:
-        '''
+        """
         Set up the logger for each test
-        '''
+        """
         self.logger = rp_logger.RunPodLogger()
 
     def test_default_log_level(self):
-        '''
+        """
         Tests that the default log level is DEBUG
-        '''
+        """
         defult_logger = rp_logger.RunPodLogger()
 
         self.assertEqual(defult_logger.level, "DEBUG")
 
     def test_singleton(self):
-        '''
+        """
         Tests that the logger is a singleton
-        '''
+        """
         logger1 = rp_logger.RunPodLogger()
         logger2 = rp_logger.RunPodLogger()
 
         self.assertIs(logger1, logger2)
 
     def test_set_log_level(self):
-        '''
+        """
         Tests that the log level can be set
-        '''
+        """
         logger = rp_logger.RunPodLogger()
 
         logger.set_level("TRACE")
@@ -52,9 +52,9 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(logger.level, "INFO")
 
     def test_call_log(self):
-        '''
+        """
         Tests that the logger can be called and logs the message to stdout if the log level is set.
-        '''
+        """
         log = rp_logger.RunPodLogger()
 
         with patch("runpod.serverless.modules.rp_logger.RunPodLogger.log") as mock_log:
@@ -64,8 +64,9 @@ class TestLogger(unittest.TestCase):
             mock_log.assert_called_once_with("Test log message", "WARN", None)
 
         log.set_level(0)
-        with patch("runpod.serverless.modules.rp_logger.RunPodLogger.log") as mock_log, \
-                patch("builtins.print") as mock_print:
+        with patch(
+            "runpod.serverless.modules.rp_logger.RunPodLogger.log"
+        ) as mock_log, patch("builtins.print") as mock_print:
 
             log.debug("Test log message")
 
@@ -76,9 +77,9 @@ class TestLogger(unittest.TestCase):
         log.set_level("DEBUG")
 
     def test_invalid_debug_level(self):
-        '''
+        """
         Tests that an invalid debug level raises an exception
-        '''
+        """
         logger = rp_logger.RunPodLogger()
 
         with self.assertRaises(ValueError):
@@ -88,44 +89,48 @@ class TestLogger(unittest.TestCase):
             logger.set_level([])
 
     def test_debug_level_int(self):
-        '''
+        """
         Tests that the debug level can be set using an int
-        '''
+        """
         int_logger = rp_logger.RunPodLogger()
 
         with self.assertRaises(ValueError):
             int_logger.set_level(69)
 
     def test_log_secret(self):
-        '''
+        """
         Tests that the secret method censors secrets.
         Captures stdout and checks that the secret is censored.
-        '''
+        """
         with patch("runpod.serverless.modules.rp_logger.RunPodLogger.log") as mock_log:
             self.logger.secret("test_secret", "test_secret_value")
-            mock_log.assert_called_once_with("test_secret: t***************e", "INFO", None)
+            mock_log.assert_called_once_with(
+                "test_secret: t***************e", "INFO", None
+            )
 
     def test_log_tip(self):
-        '''
+        """
         Tests that the tip method logs a tip.
-        '''
+        """
         with patch("runpod.serverless.modules.rp_logger.RunPodLogger.log") as mock_log:
             self.logger.tip("test_tip")
             mock_log.assert_called_once_with("test_tip", "TIP")
 
     def test_log_trace(self):
-        '''
+        """
         Tests that the trace method logs a trace.
-        '''
+        """
         with patch("runpod.serverless.modules.rp_logger.RunPodLogger.log") as mock_log:
             self.logger.trace("This is a trace message")
             mock_log.assert_called_once_with("This is a trace message", "TRACE", None)
 
             self.logger.trace("This is another trace message", "test-request-id")
-            mock_log.assert_called_with("This is another trace message", "TRACE", "test-request-id")
+            mock_log.assert_called_with(
+                "This is another trace message", "TRACE", "test-request-id"
+            )
 
     def test_log_job_id(self):
-        """ Tests that the log method logs a job id """
+        """Tests that the log method logs a job id"""
         logger = rp_logger.RunPodLogger()
         job_id = "test_job_id"
 
@@ -134,8 +139,7 @@ class TestLogger(unittest.TestCase):
             logger.log("test_message", "INFO", job_id)
 
             mock_print.assert_called_once_with(
-                'INFO   | test_job_id | test_message',
-                flush=True
+                "INFO   | test_job_id | test_message", flush=True
             )
 
             # Test with endpoint id set
@@ -145,23 +149,23 @@ class TestLogger(unittest.TestCase):
 
             mock_print.assert_called_with(
                 '{"requestId": "test_job_id", "message": "test_message", "level": "INFO"}',
-                flush=True
+                flush=True,
             )
 
     def test_log_truncate(self):
-        """Tests that the log method truncates """
+        """Tests that the log method truncates"""
         logger = rp_logger.RunPodLogger()
         job_id = "test_job_id"
         long_message = "a" * (rp_logger.MAX_MESSAGE_LENGTH + 100)
         expected_start = "a" * (rp_logger.MAX_MESSAGE_LENGTH // 2)
         expected_end = "a" * (rp_logger.MAX_MESSAGE_LENGTH // 2)
         truncated_amount = len(long_message) - rp_logger.MAX_MESSAGE_LENGTH
-        truncation_note = f'\n...TRUNCATED {truncated_amount} CHARACTERS...\n'
+        truncation_note = f"\n...TRUNCATED {truncated_amount} CHARACTERS...\n"
         truncated_message = expected_start + truncation_note + expected_end
 
         with patch("builtins.print") as mock_print:
             logger.log(long_message, "INFO", job_id)
 
-            expected_log_output = f'INFO   | {job_id} | {truncated_message}'
+            expected_log_output = f"INFO   | {job_id} | {truncated_message}"
 
             mock_print.assert_called_once_with(expected_log_output, flush=True)

--- a/tests/test_serverless/test_modules/test_ping.py
+++ b/tests/test_serverless/test_modules/test_ping.py
@@ -1,31 +1,35 @@
-''' Tests for runpod.serverless.modules.rp_ping '''
+""" Tests for runpod.serverless.modules.rp_ping """
 
-import os
 import importlib
-
+import os
 import unittest
 from unittest.mock import patch
 
 import requests
+
 from runpod.serverless.modules import rp_ping
 
-class MockResponse: # pylint: disable=too-few-public-methods
-    ''' Mock response for aiohttp '''
+
+class MockResponse:  # pylint: disable=too-few-public-methods
+    """Mock response for aiohttp"""
+
     status_code = 200
 
-def mock_get(*args, **kwargs): # pylint: disable=unused-argument
-    '''
+
+def mock_get(*args, **kwargs):  # pylint: disable=unused-argument
+    """
     Mock get function for aiohttp
-    '''
+    """
     return MockResponse()
 
+
 class TestPing(unittest.TestCase):
-    ''' Tests for rp_ping '''
+    """Tests for rp_ping"""
 
     def test_variables(self):
-        '''
+        """
         Tests that the variables are set correctly
-        '''
+        """
         os.environ["RUNPOD_WEBHOOK_PING"] = "PING_NOT_SET"
 
         importlib.reload(rp_ping)
@@ -41,11 +45,13 @@ class TestPing(unittest.TestCase):
         self.assertEqual(rp_ping.Heartbeat.PING_URL, "https://test.com/ping")
         self.assertEqual(rp_ping.Heartbeat.PING_INTERVAL, 20)
 
-    @patch("runpod.serverless.modules.rp_ping.SyncClientSession.get", side_effect=mock_get)
+    @patch(
+        "runpod.serverless.modules.rp_ping.SyncClientSession.get", side_effect=mock_get
+    )
     def test_start_ping(self, mock_get_return):
-        '''
+        """
         Tests that the start_ping function works correctly
-        '''
+        """
         # No RUNPOD_AI_API_KEY case
         with patch("threading.Thread.start") as mock_thread_start:
             rp_ping.Heartbeat().start_ping(test=True)

--- a/tests/test_serverless/test_modules/test_progress.py
+++ b/tests/test_serverless/test_modules/test_progress.py
@@ -3,13 +3,14 @@ Tests for the rp_progress.py module.
 """
 
 import unittest
-from unittest.mock import ANY, patch
 from threading import Event
+from unittest.mock import ANY, patch
 
-from runpod.serverless.modules.rp_progress import progress_update, _thread_target
+from runpod.serverless.modules.rp_progress import _thread_target, progress_update
+
 
 class TestProgressUpdate(unittest.TestCase):
-    """ Tests for the progress_update function. """
+    """Tests for the progress_update function."""
 
     @patch("runpod.serverless.modules.rp_progress.send_result")
     @patch("runpod.serverless.modules.rp_progress._thread_target")
@@ -24,7 +25,7 @@ class TestProgressUpdate(unittest.TestCase):
             try:
                 assert job == "fake_job", "Job ID was not passed correctly"
                 assert progress == "50%", "Progress was not passed correctly"
-            except Exception as err: # pylint: disable=broad-except
+            except Exception as err:  # pylint: disable=broad-except
                 print(f"Exception in mocked function: {err}")
             finally:
                 thread_event.set()
@@ -37,14 +38,12 @@ class TestProgressUpdate(unittest.TestCase):
         progress_update(job, progress)
         _thread_target(job, progress)
 
-
         assert mock_thread_target.called, "Thread function was not started"
         mock_thread_target.assert_called_once_with(job, progress)
-        assert thread_event.wait(timeout=30), "Thread did not complete within expected time"
+        assert thread_event.wait(
+            timeout=30
+        ), "Thread did not complete within expected time"
 
         # Assertions
-        expected_job_data = {
-            "status": "IN_PROGRESS",
-            "output": progress
-        }
+        expected_job_data = {"status": "IN_PROGRESS", "output": progress}
         mock_result.assert_called_once_with(ANY, expected_job_data, job)

--- a/tests/test_serverless/test_modules/test_state.py
+++ b/tests/test_serverless/test_modules/test_state.py
@@ -1,75 +1,73 @@
-''' Tests for environment variables module '''
+""" Tests for environment variables module """
 
 import os
 import unittest
 
-from runpod.serverless.modules.worker_state import (
-    Job, Jobs, IS_LOCAL_TEST, WORKER_ID
-)
+from runpod.serverless.modules.worker_state import IS_LOCAL_TEST, WORKER_ID, Job, Jobs
 
 
 class TestEnvVars(unittest.TestCase):
-    ''' Tests for environment variables module '''
+    """Tests for environment variables module"""
 
     def setUp(self):
-        '''
+        """
         Set up test variables
-        '''
-        self.test_api_key = 'test_api_key'
-        os.environ['RUNPOD_AI_API_KEY'] = self.test_api_key
+        """
+        self.test_api_key = "test_api_key"
+        os.environ["RUNPOD_AI_API_KEY"] = self.test_api_key
 
     def test_is_local_test(self):
-        '''
+        """
         Tests if IS_LOCAL_TEST flag is properly set
-        '''
-        os.environ.pop('RUNPOD_WEBHOOK_GET_JOB', None)
+        """
+        os.environ.pop("RUNPOD_WEBHOOK_GET_JOB", None)
         self.assertEqual(IS_LOCAL_TEST, True)
 
     def test_worker_id(self):
-        '''
+        """
         Tests if WORKER_ID is properly set
-        '''
+        """
         os.environ["RUNPOD_POD_ID"] = WORKER_ID
 
-        self.assertEqual(WORKER_ID, os.environ.get('RUNPOD_POD_ID'))
+        self.assertEqual(WORKER_ID, os.environ.get("RUNPOD_POD_ID"))
 
 
 class TestJobs(unittest.TestCase):
-    ''' Tests for Jobs class '''
+    """Tests for Jobs class"""
 
     def setUp(self):
-        '''
+        """
         Set up test variables
-        '''
+        """
         self.jobs = Jobs()
         self.jobs.jobs.clear()  # clear jobs before each test
 
     def test_singleton(self):
-        '''
+        """
         Tests if Jobs is a singleton class
-        '''
+        """
         jobs2 = Jobs()
         self.assertEqual(self.jobs, jobs2)
 
     def test_add_job(self):
-        '''
+        """
         Tests if add_job() method works as expected
-        '''
-        self.jobs.add_job('123')
-        self.assertIn(Job('123'), self.jobs.jobs)
+        """
+        self.jobs.add_job("123")
+        self.assertIn(Job("123"), self.jobs.jobs)
 
     def test_remove_job(self):
-        '''
+        """
         Tests if remove_job() method works as expected
-        '''
-        self.jobs.add_job('123')
-        self.jobs.remove_job('123')
-        self.assertNotIn(Job('123'), self.jobs.jobs)
+        """
+        self.jobs.add_job("123")
+        self.jobs.remove_job("123")
+        self.assertNotIn(Job("123"), self.jobs.jobs)
 
     def test_get_job_input(self):
-        '''
+        """
         Tests if get_job_input() method works as expected
-        '''
+        """
         job1 = Job(job_id="id1")
         job2 = Job(job_id="id2")
         self.assertNotEqual(job1, job2)
@@ -78,21 +76,21 @@ class TestJobs(unittest.TestCase):
         non_job_object = "some_string"
         self.assertNotEqual(job, non_job_object)
 
-        self.assertEqual(self.jobs.get_job('123'), None)
+        self.assertEqual(self.jobs.get_job("123"), None)
 
-        self.jobs.add_job('123', 'test_input')
-        self.assertEqual(self.jobs.get_job('123').input, 'test_input')
+        self.jobs.add_job("123", "test_input")
+        self.assertEqual(self.jobs.get_job("123").input, "test_input")
 
     def test_get_job_list(self):
-        '''
+        """
         Tests if get_job_list() method works as expected
-        '''
+        """
         self.assertTrue(self.jobs.get_job_list() is None)
 
-        self.jobs.add_job('123')
-        self.jobs.add_job('456')
+        self.jobs.add_job("123")
+        self.jobs.add_job("456")
         self.assertEqual(len(self.jobs.jobs), 2)
-        self.assertTrue(Job('123') in self.jobs.jobs)
-        self.assertTrue(Job('456') in self.jobs.jobs)
+        self.assertTrue(Job("123") in self.jobs.jobs)
+        self.assertTrue(Job("456") in self.jobs.jobs)
 
-        self.assertTrue(self.jobs.get_job_list() in ['123,456', '456,123'])
+        self.assertTrue(self.jobs.get_job_list() in ["123,456", "456,123"])

--- a/tests/test_serverless/test_modules/test_tips.py
+++ b/tests/test_serverless/test_modules/test_tips.py
@@ -1,28 +1,30 @@
-''' Tests for runpod.serverless.modules.rp_tips.py '''
+""" Tests for runpod.serverless.modules.rp_tips.py """
 
 import unittest
 from unittest.mock import patch
+
 from runpod.serverless.modules.rp_tips import check_return_size
 
-class TestTips(unittest.TestCase):
-    ''' Tests for the Tips module '''
 
-    @patch('runpod.serverless.modules.rp_tips.log.tip')
+class TestTips(unittest.TestCase):
+    """Tests for the Tips module"""
+
+    @patch("runpod.serverless.modules.rp_tips.log.tip")
     def test_check_return_size_small(self, mock_log):
-        '''
+        """
         Tests check_return_size function with a small return_body
-        '''
-        check_return_size('a' * 10)  # A small string
+        """
+        check_return_size("a" * 10)  # A small string
 
         # Ensure that the log.tip function was not called, as the return_body is small
         mock_log.assert_not_called()
 
-    @patch('runpod.serverless.modules.rp_tips.log.tip')
+    @patch("runpod.serverless.modules.rp_tips.log.tip")
     def test_check_return_size_large(self, mock_log):
-        '''
+        """
         Tests check_return_size function with a large return_body
-        '''
-        check_return_size('a' * 30_000_000)  # A large string (over 20 MB)
+        """
+        check_return_size("a" * 30_000_000)  # A large string (over 20 MB)
 
         # Ensure that the log.tip function was called, as the return_body is large
         mock_log.assert_called()

--- a/tests/test_serverless/test_utils/__init__.py
+++ b/tests/test_serverless/test_utils/__init__.py
@@ -1,1 +1,1 @@
-''' Import all test modules in this package. '''
+""" Import all test modules in this package. """

--- a/tests/test_serverless/test_utils/test_cleanup.py
+++ b/tests/test_serverless/test_utils/test_cleanup.py
@@ -1,17 +1,19 @@
-'''
+"""
 Test cleanup.py
-'''
+"""
 
 from unittest.mock import patch
 
 from runpod.serverless.utils import rp_cleanup
 
+
 def test_clean_no_folders():
-    '''
+    """
     Test clean() with no folders.
-    '''
-    with patch('shutil.rmtree') as mock_rmtree, patch('os.remove') as mock_remove, \
-        patch('os.path.exists', return_value=False):
+    """
+    with patch("shutil.rmtree") as mock_rmtree, patch(
+        "os.remove"
+    ) as mock_remove, patch("os.path.exists", return_value=False):
         rp_cleanup.clean()
         assert mock_rmtree.call_count == 3
         mock_rmtree.assert_any_call("input_objects", ignore_errors=True)
@@ -19,24 +21,28 @@ def test_clean_no_folders():
         mock_rmtree.assert_any_call("job_files", ignore_errors=True)
         mock_remove.assert_not_called()
 
+
 def test_clean_with_output_zip():
-    '''
+    """
     Test clean() with output.zip.
-    '''
-    with patch('shutil.rmtree') as mock_rmtree, patch('os.remove') as mock_remove, \
-        patch('os.path.exists', return_value=True):
+    """
+    with patch("shutil.rmtree") as mock_rmtree, patch(
+        "os.remove"
+    ) as mock_remove, patch("os.path.exists", return_value=True):
         rp_cleanup.clean()
         assert mock_rmtree.call_count == 3
-        mock_remove.assert_called_once_with('output.zip')
+        mock_remove.assert_called_once_with("output.zip")
+
 
 def test_clean_with_folders():
-    '''
+    """
     Test clean() with folders.
-    '''
-    with patch('shutil.rmtree') as mock_rmtree, patch('os.remove') as mock_remove, \
-        patch('os.path.exists', return_value=False):
-        rp_cleanup.clean(['test_folder1', 'test_folder2'])
+    """
+    with patch("shutil.rmtree") as mock_rmtree, patch(
+        "os.remove"
+    ) as mock_remove, patch("os.path.exists", return_value=False):
+        rp_cleanup.clean(["test_folder1", "test_folder2"])
         assert mock_rmtree.call_count == 5
-        mock_rmtree.assert_any_call('test_folder1', ignore_errors=True)
-        mock_rmtree.assert_any_call('test_folder2', ignore_errors=True)
+        mock_rmtree.assert_any_call("test_folder1", ignore_errors=True)
+        mock_rmtree.assert_any_call("test_folder2", ignore_errors=True)
         mock_remove.assert_not_called()

--- a/tests/test_serverless/test_utils/test_cuda.py
+++ b/tests/test_serverless/test_utils/test_cuda.py
@@ -1,30 +1,40 @@
-'''
+"""
 Unit tests for the rp_cuda module
-'''
+"""
 
 from unittest.mock import patch
+
 from runpod.serverless.utils import rp_cuda
 
+
 def test_is_available_true():
-    '''
+    """
     Test that is_available returns True when nvidia-smi is available
-    '''
-    with patch("subprocess.check_output", return_value=b"NVIDIA-SMI") as mock_check_output:
+    """
+    with patch(
+        "subprocess.check_output", return_value=b"NVIDIA-SMI"
+    ) as mock_check_output:
         assert rp_cuda.is_available() is True
     mock_check_output.assert_called_once_with("nvidia-smi", shell=True)
 
+
 def test_is_available_false():
-    '''
+    """
     Test that is_available returns False when nvidia-smi is not available
-    '''
-    with patch("subprocess.check_output", return_value=b"Not a GPU output") as mock_check_output:
+    """
+    with patch(
+        "subprocess.check_output", return_value=b"Not a GPU output"
+    ) as mock_check_output:
         assert rp_cuda.is_available() is False
     mock_check_output.assert_called_once_with("nvidia-smi", shell=True)
 
+
 def test_is_available_exception():
-    '''
+    """
     Test that is_available returns False when nvidia-smi raises an exception
-    '''
-    with patch("subprocess.check_output", side_effect=Exception("Bad Command")) as mock_check:
+    """
+    with patch(
+        "subprocess.check_output", side_effect=Exception("Bad Command")
+    ) as mock_check:
         assert rp_cuda.is_available() is False
     mock_check.assert_called_once_with("nvidia-smi", shell=True)

--- a/tests/test_serverless/test_utils/test_debugger.py
+++ b/tests/test_serverless/test_utils/test_debugger.py
@@ -1,115 +1,118 @@
-'''
+"""
 Unit tests for the debugger utility functions.
-'''
+"""
 
+import importlib
 import time
 import unittest
-import importlib
 from unittest.mock import patch
 
 from runpod.serverless.utils import rp_debugger
-from runpod.serverless.utils.rp_debugger import(
-    Checkpoints, LineTimer, FunctionTimer, get_debugger_output, clear_debugger_output
+from runpod.serverless.utils.rp_debugger import (
+    Checkpoints,
+    FunctionTimer,
+    LineTimer,
+    clear_debugger_output,
+    get_debugger_output,
 )
 
 
 class TestDebugger(unittest.TestCase):
-    ''' Unit tests for the debugger utility functions. '''
+    """Unit tests for the debugger utility functions."""
 
     def setUp(self):
         self.checkpoints = Checkpoints()
         self.checkpoints.clear()
 
-    @patch('runpod.serverless.utils.rp_debugger.cpuinfo.get_cpu_info')
+    @patch("runpod.serverless.utils.rp_debugger.cpuinfo.get_cpu_info")
     def test_key_error(self, mock_get_cpu_info):
-        '''
+        """
         Test that a KeyError is raised when an invalid key is used.
-        '''
-        mock_get_cpu_info.side_effect = KeyError('Test Error')
+        """
+        mock_get_cpu_info.side_effect = KeyError("Test Error")
 
         importlib.reload(rp_debugger)
 
         assert mock_get_cpu_info.called
-        self.assertEqual(rp_debugger.PROCESSOR, 'Unable to get processor info.')
+        self.assertEqual(rp_debugger.PROCESSOR, "Unable to get processor info.")
 
     def test_checkpoints(self):
-        '''
+        """
         Test that checkpoints are added and stopped correctly.
-        '''
-        self.checkpoints.add('checkpoint1')
-        self.checkpoints.start('checkpoint1')
+        """
+        self.checkpoints.add("checkpoint1")
+        self.checkpoints.start("checkpoint1")
         time.sleep(0.1)
-        self.checkpoints.stop('checkpoint1')
+        self.checkpoints.stop("checkpoint1")
 
-        output = get_debugger_output()['timestamps']
+        output = get_debugger_output()["timestamps"]
 
         self.assertEqual(len(output), 1)
-        self.assertEqual(output[0]['name'], 'checkpoint1')
-        self.assertGreater(output[0]['duration_ms'], 0)
+        self.assertEqual(output[0]["name"], "checkpoint1")
+        self.assertGreater(output[0]["duration_ms"], 0)
 
     def test_get_checkpoints(self):
-        '''
+        """
         Test that checkpoints are added and stopped correctly.
-        '''
-        self.checkpoints.add('checkpoint1')
+        """
+        self.checkpoints.add("checkpoint1")
         checkpoint_list = self.checkpoints.get_checkpoints()
 
         self.assertEqual(len(checkpoint_list), 0)
 
-
     def test_checkpoints_exception(self):
-        '''
+        """
         Test that a KeyError is raised when an invalid checkpoint is used.
-        '''
-        self.assertRaises(KeyError, self.checkpoints.start, 'nonexistent')
-        self.assertRaises(KeyError, self.checkpoints.stop, 'nonexistent')
+        """
+        self.assertRaises(KeyError, self.checkpoints.start, "nonexistent")
+        self.assertRaises(KeyError, self.checkpoints.stop, "nonexistent")
 
-        self.checkpoints.add('checkpoint2')
-        self.assertRaises(KeyError, self.checkpoints.add, 'checkpoint2')
-        self.assertRaises(KeyError, self.checkpoints.stop, 'checkpoint2')
+        self.checkpoints.add("checkpoint2")
+        self.assertRaises(KeyError, self.checkpoints.add, "checkpoint2")
+        self.assertRaises(KeyError, self.checkpoints.stop, "checkpoint2")
 
     def test_line_timer(self):
-        '''
+        """
         Test that the line timer works correctly.
-        '''
-        with LineTimer('line_timer'):
+        """
+        with LineTimer("line_timer"):
             time.sleep(0.1)
 
-        output = get_debugger_output()['timestamps']
+        output = get_debugger_output()["timestamps"]
 
         self.assertEqual(len(output), 1)
-        self.assertEqual(output[0]['name'], 'line_timer')
-        self.assertGreater(output[0]['duration_ms'], 0)
+        self.assertEqual(output[0]["name"], "line_timer")
+        self.assertGreater(output[0]["duration_ms"], 0)
 
     def test_function_timer(self):
-        '''
+        """
         Test that the function timer works correctly.
-        '''
+        """
+
         @FunctionTimer
         def func_to_time():
             time.sleep(0.1)
 
         func_to_time()
 
-        output = get_debugger_output()['timestamps']
+        output = get_debugger_output()["timestamps"]
 
         self.assertEqual(len(output), 1)
-        self.assertEqual(output[0]['name'], 'func_to_time')
-        self.assertGreater(output[0]['duration_ms'], 0)
-
+        self.assertEqual(output[0]["name"], "func_to_time")
+        self.assertGreater(output[0]["duration_ms"], 0)
 
     def test_clear_debugger_output(self):
-        '''
+        """
         Test that the debugger output is cleared correctly.
-        '''
-        self.checkpoints.add('checkpoint1')
-        self.checkpoints.start('checkpoint1')
+        """
+        self.checkpoints.add("checkpoint1")
+        self.checkpoints.start("checkpoint1")
 
         # Check that non-stopped checkpoints are not returned
         checkpoint_list = self.checkpoints.get_checkpoints()
         self.assertEqual(len(checkpoint_list), 0)
 
-        self.checkpoints.stop('checkpoint1')
+        self.checkpoints.stop("checkpoint1")
 
         checkpoint_list = self.checkpoints.get_checkpoints()
         self.assertEqual(len(checkpoint_list), 1)
@@ -118,6 +121,7 @@ class TestDebugger(unittest.TestCase):
 
         checkpoint_list = self.checkpoints.get_checkpoints()
         self.assertEqual(len(checkpoint_list), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_serverless/test_utils/test_download.py
+++ b/tests/test_serverless/test_utils/test_download.py
@@ -1,50 +1,57 @@
-''' Tests for runpod | serverless | modules | download.py '''
+""" Tests for runpod | serverless | modules | download.py """
+
 # pylint: disable=R0903,W0613
 
 import os
 import unittest
-from unittest.mock import patch, mock_open, MagicMock
+from unittest.mock import MagicMock, mock_open, patch
+
 from requests import RequestException
-from runpod.serverless.utils.rp_download import(
-    calculate_chunk_size, download_files_from_urls, file
+
+from runpod.serverless.utils.rp_download import (
+    calculate_chunk_size,
+    download_files_from_urls,
+    file,
 )
 
-URL_LIST = ['https://example.com/picture.jpg',
-            'https://example.com/picture.jpg?X-Amz-Signature=123']
+URL_LIST = [
+    "https://example.com/picture.jpg",
+    "https://example.com/picture.jpg?X-Amz-Signature=123",
+]
 
 JOB_ID = "job_123"
 
 
 def mock_requests_get(*args, **kwargs):
-    '''
+    """
     Mocks SyncClientSession.get
-    '''
+    """
     headers = {
-        'Content-Disposition': 'attachment; filename="picture.jpg"',
-        'Content-Length': '1000'
+        "Content-Disposition": 'attachment; filename="picture.jpg"',
+        "Content-Length": "1000",
     }
 
     class MockResponse:
-        ''' Mocks SyncClientSession.get response '''
+        """Mocks SyncClientSession.get response"""
 
         def __init__(self, content, status_code, headers=None):
-            '''
+            """
             Mocks SyncClientSession.get response
-            '''
+            """
             self.content = content
             self.status_code = status_code
             self.headers = headers or {}
 
         def raise_for_status(self):
-            ''' Mocks raise_for_status function '''
+            """Mocks raise_for_status function"""
             if 400 <= self.status_code < 600:
                 raise RequestException(f"Status code: {self.status_code}")
 
         def iter_content(self, chunk_size=1024):
-            ''' Mocks iter_content method '''
+            """Mocks iter_content method"""
             length = len(self.content)
             for i in range(0, length, chunk_size):
-                yield self.content[i:min(i + chunk_size, length)]
+                yield self.content[i : min(i + chunk_size, length)]
 
         def __enter__(self):
             return self
@@ -53,69 +60,81 @@ def mock_requests_get(*args, **kwargs):
             pass
 
     if args[0] in URL_LIST:
-        return MockResponse(b'nothing', 200, headers)
+        return MockResponse(b"nothing", 200, headers)
 
     return MockResponse(None, 404)
 
 
 class TestDownloadFilesFromUrls(unittest.TestCase):
-    ''' Tests for download_files_from_urls '''
+    """Tests for download_files_from_urls"""
 
     def test_calculate_chunk_size(self):
-        '''
+        """
         Tests calculate_chunk_size
-        '''
+        """
         self.assertEqual(calculate_chunk_size(1024), 1024)
-        self.assertEqual(calculate_chunk_size(1024*1024), 1024)
-        self.assertEqual(calculate_chunk_size(1024*1024*1024), 1024*1024)
-        self.assertEqual(calculate_chunk_size(1024*1024*1024*10), 1024*1024*10)
+        self.assertEqual(calculate_chunk_size(1024 * 1024), 1024)
+        self.assertEqual(calculate_chunk_size(1024 * 1024 * 1024), 1024 * 1024)
+        self.assertEqual(
+            calculate_chunk_size(1024 * 1024 * 1024 * 10), 1024 * 1024 * 10
+        )
 
-    @patch('os.makedirs', return_value=None)
-    @patch('runpod.http_client.SyncClientSession.get', side_effect=mock_requests_get)
-    @patch('builtins.open', new_callable=mock_open)
+    @patch("os.makedirs", return_value=None)
+    @patch("runpod.http_client.SyncClientSession.get", side_effect=mock_requests_get)
+    @patch("builtins.open", new_callable=mock_open)
     def test_download_files_from_urls(self, mock_open_file, mock_get, mock_makedirs):
-        '''
+        """
         Tests download_files_from_urls
-        '''
+        """
         downloaded_files = download_files_from_urls(
-            JOB_ID, ['https://example.com/picture.jpg', ]
+            JOB_ID,
+            [
+                "https://example.com/picture.jpg",
+            ],
         )
 
         self.assertEqual(len(downloaded_files), 1)
 
         # Check that the url was called with SyncClientSession.get
-        self.assertIn('https://example.com/picture.jpg', mock_get.call_args_list[0][0])
+        self.assertIn("https://example.com/picture.jpg", mock_get.call_args_list[0][0])
 
         # Check that the file has the correct extension
-        self.assertTrue(downloaded_files[0].endswith('.jpg'))
+        self.assertTrue(downloaded_files[0].endswith(".jpg"))
 
-        mock_open_file.assert_called_once_with(downloaded_files[0], 'wb')
-        mock_makedirs.assert_called_once_with(os.path.abspath(
-            f'jobs/{JOB_ID}/downloaded_files'), exist_ok=True)
+        mock_open_file.assert_called_once_with(downloaded_files[0], "wb")
+        mock_makedirs.assert_called_once_with(
+            os.path.abspath(f"jobs/{JOB_ID}/downloaded_files"), exist_ok=True
+        )
 
-
-        string_download_file = download_files_from_urls(JOB_ID, 'https://example.com/picture.jpg')
-        self.assertTrue(string_download_file[0].endswith('.jpg'))
+        string_download_file = download_files_from_urls(
+            JOB_ID, "https://example.com/picture.jpg"
+        )
+        self.assertTrue(string_download_file[0].endswith(".jpg"))
 
         # Check if None is returned when url is None
         self.assertEqual(download_files_from_urls(JOB_ID, [None]), [None])
 
         # Test requests exception
-        mock_get.side_effect = RequestException('Error')
+        mock_get.side_effect = RequestException("Error")
         self.assertEqual(
-            download_files_from_urls(JOB_ID, ['https://example.com/picture.jpg']),
-            [None]
+            download_files_from_urls(JOB_ID, ["https://example.com/picture.jpg"]),
+            [None],
         )
 
-    @patch('os.makedirs', return_value=None)
-    @patch('runpod.http_client.SyncClientSession.get', side_effect=mock_requests_get)
-    @patch('builtins.open', new_callable=mock_open)
-    def test_download_files_from_urls_signed(self, mock_open_file, mock_get, mock_makedirs):
-        '''
+    @patch("os.makedirs", return_value=None)
+    @patch("runpod.http_client.SyncClientSession.get", side_effect=mock_requests_get)
+    @patch("builtins.open", new_callable=mock_open)
+    def test_download_files_from_urls_signed(
+        self, mock_open_file, mock_get, mock_makedirs
+    ):
+        """
         Tests download_files_from_urls with signed urls
-        '''
+        """
         downloaded_files = download_files_from_urls(
-            JOB_ID, ['https://example.com/picture.jpg?X-Amz-Signature=123', ]
+            JOB_ID,
+            [
+                "https://example.com/picture.jpg?X-Amz-Signature=123",
+            ],
         )
 
         # Confirms that the same number of files were downloaded as urls provided
@@ -125,21 +144,23 @@ class TestDownloadFilesFromUrls(unittest.TestCase):
         self.assertIn(URL_LIST[1], mock_get.call_args_list[0][0])
 
         # Check that the file has the correct extension
-        self.assertTrue(downloaded_files[0].endswith('.jpg'))
+        self.assertTrue(downloaded_files[0].endswith(".jpg"))
 
-        mock_open_file.assert_called_once_with(downloaded_files[0], 'wb')
-        mock_makedirs.assert_called_once_with(os.path.abspath(
-            f'jobs/{JOB_ID}/downloaded_files'), exist_ok=True)
+        mock_open_file.assert_called_once_with(downloaded_files[0], "wb")
+        mock_makedirs.assert_called_once_with(
+            os.path.abspath(f"jobs/{JOB_ID}/downloaded_files"), exist_ok=True
+        )
+
 
 class FileDownloaderTestCase(unittest.TestCase):
-    ''' Tests for file_downloader '''
+    """Tests for file_downloader"""
 
-    @patch('runpod.serverless.utils.rp_download.SyncClientSession.get')
-    @patch('builtins.open', new_callable=mock_open)
+    @patch("runpod.serverless.utils.rp_download.SyncClientSession.get")
+    @patch("builtins.open", new_callable=mock_open)
     def test_download_file(self, mock_file, mock_get):
-        '''
+        """
         Tests download_file
-        '''
+        """
         # Mock the response from SyncClientSession.get
         mock_response = MagicMock()
         mock_response.content = b"file content"
@@ -158,13 +179,13 @@ class FileDownloaderTestCase(unittest.TestCase):
         # Check that the file was written correctly
         mock_file().write.assert_called_once_with(b"file content")
 
-    @patch('runpod.serverless.utils.rp_download.SyncClientSession.get')
-    @patch('builtins.open', new_callable=mock_open)
-    @patch('runpod.serverless.utils.rp_download.zipfile.ZipFile')
+    @patch("runpod.serverless.utils.rp_download.SyncClientSession.get")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("runpod.serverless.utils.rp_download.zipfile.ZipFile")
     def test_download_zip_file(self, mock_zip, mock_file, mock_get):
-        '''
+        """
         Tests download_file with a zip file
-        '''
+        """
         # Mock the response from SyncClientSession.get
         mock_response = MagicMock()
         mock_response.content = b"zip file content"

--- a/tests/test_serverless/test_utils/test_upload.py
+++ b/tests/test_serverless/test_utils/test_upload.py
@@ -1,25 +1,28 @@
-''' Tests for my_module | bucket utilities '''
+""" Tests for my_module | bucket utilities """
 
-import os
-import io
-import time
 import importlib
+import io
+import os
+import time
 import unittest
-from unittest.mock import MagicMock, patch, Mock
+from unittest.mock import MagicMock, Mock, patch
 
-from runpod.serverless.utils import rp_upload
+from runpod.serverless.utils import (
+    rp_upload,
+    upload_file_to_bucket,
+    upload_in_memory_object,
+)
 from runpod.serverless.utils.rp_upload import get_boto_client
-from runpod.serverless.utils import upload_file_to_bucket, upload_in_memory_object
 
 BUCKET_CREDENTIALS = {
-    'endpointUrl': 'https://your-bucket-endpoint-url.com',
-    'accessId': 'your_access_key_id',
-    'accessSecret': 'your_secret_access_key',
+    "endpointUrl": "https://your-bucket-endpoint-url.com",
+    "accessId": "your_access_key_id",
+    "accessSecret": "your_secret_access_key",
 }
 
 
 class TestBotoConfig(unittest.TestCase):
-    ''' Tests for boto config '''
+    """Tests for boto config"""
 
     def setUp(self) -> None:
         self.original_environ = os.environ.copy()
@@ -30,15 +33,16 @@ class TestBotoConfig(unittest.TestCase):
         os.environ = self.original_environ
 
     def test_get_boto_client(self):
-        '''
+        """
         Tests get_boto_client
-        '''
+        """
         # Define the bucket credentials
         bucket_creds = BUCKET_CREDENTIALS
 
         # Mock boto3.session.Session
-        with patch('boto3.session.Session') as mock_session, \
-                patch('runpod.serverless.utils.rp_upload.TransferConfig') as mock_transfer_config:
+        with patch("boto3.session.Session") as mock_session, patch(
+            "runpod.serverless.utils.rp_upload.TransferConfig"
+        ) as mock_transfer_config:
             mock_session.return_value.client.return_value = self.mock_boto_client
             mock_transfer_config.return_value = self.mock_transfer_config
 
@@ -54,56 +58,61 @@ class TestBotoConfig(unittest.TestCase):
 
             # Check if boto_client was called with the correct arguments
             mock_session.return_value.client.assert_called_once_with(
-                's3',
-                endpoint_url=bucket_creds['endpointUrl'],
-                aws_access_key_id=bucket_creds['accessId'],
-                aws_secret_access_key=bucket_creds['accessSecret'],
+                "s3",
+                endpoint_url=bucket_creds["endpointUrl"],
+                aws_access_key_id=bucket_creds["accessId"],
+                aws_secret_access_key=bucket_creds["accessSecret"],
                 config=unittest.mock.ANY,
-                region_name=None
+                region_name=None,
             )
 
             creds_s3 = bucket_creds.copy()
-            creds_s3['endpointUrl'] = "https://bucket-name.s3.region-code.amazonaws.com/key-name"
+            creds_s3["endpointUrl"] = (
+                "https://bucket-name.s3.region-code.amazonaws.com/key-name"
+            )
 
             boto_client, transfer_config = get_boto_client(creds_s3)
 
             mock_session.return_value.client.assert_called_with(
-                's3',
-                endpoint_url=creds_s3['endpointUrl'],
-                aws_access_key_id=bucket_creds['accessId'],
-                aws_secret_access_key=bucket_creds['accessSecret'],
+                "s3",
+                endpoint_url=creds_s3["endpointUrl"],
+                aws_access_key_id=bucket_creds["accessId"],
+                aws_secret_access_key=bucket_creds["accessSecret"],
                 config=unittest.mock.ANY,
-                region_name="region-code"
+                region_name="region-code",
             )
 
             creds_do = bucket_creds.copy()
-            creds_do['endpointUrl'] = "https://name.region-code.digitaloceanspaces.com/key-name"
+            creds_do["endpointUrl"] = (
+                "https://name.region-code.digitaloceanspaces.com/key-name"
+            )
 
             boto_client, transfer_config = get_boto_client(creds_do)
 
             mock_session.return_value.client.assert_called_with(
-                's3',
-                endpoint_url=creds_do['endpointUrl'],
-                aws_access_key_id=bucket_creds['accessId'],
-                aws_secret_access_key=bucket_creds['accessSecret'],
+                "s3",
+                endpoint_url=creds_do["endpointUrl"],
+                aws_access_key_id=bucket_creds["accessId"],
+                aws_secret_access_key=bucket_creds["accessSecret"],
                 config=unittest.mock.ANY,
-                region_name="region-code"
+                region_name="region-code",
             )
 
     def test_get_boto_client_environ(self):
-        '''
+        """
         Tests get_boto_client with environment variables
-        '''
+        """
         assert rp_upload.get_boto_client()[0] is None
 
-        os.environ['BUCKET_ENDPOINT_URL'] = 'https://your-bucket-endpoint-url.com'
-        os.environ['BUCKET_ACCESS_KEY_ID'] = 'your_access_key_id'
-        os.environ['BUCKET_SECRET_ACCESS_KEY'] = 'your_secret_access_key'
+        os.environ["BUCKET_ENDPOINT_URL"] = "https://your-bucket-endpoint-url.com"
+        os.environ["BUCKET_ACCESS_KEY_ID"] = "your_access_key_id"
+        os.environ["BUCKET_SECRET_ACCESS_KEY"] = "your_secret_access_key"
 
         importlib.reload(rp_upload)
 
-        with patch('boto3.session.Session') as mock_session, \
-                patch('runpod.serverless.utils.rp_upload.TransferConfig') as mock_transfer_config:
+        with patch("boto3.session.Session") as mock_session, patch(
+            "runpod.serverless.utils.rp_upload.TransferConfig"
+        ) as mock_transfer_config:
             mock_session.return_value.client.return_value = self.mock_boto_client
             mock_transfer_config.return_value = self.mock_transfer_config
 
@@ -112,21 +121,22 @@ class TestBotoConfig(unittest.TestCase):
             assert boto_client == self.mock_boto_client
             assert transfer_config == self.mock_transfer_config
 
+
 # ---------------------------------------------------------------------------- #
 #                                 Upload Image                                 #
 # ---------------------------------------------------------------------------- #
 
 
 class TestUploadImage(unittest.TestCase):
-    ''' Tests for upload_image '''
+    """Tests for upload_image"""
 
     @patch("runpod.serverless.utils.rp_upload.get_boto_client")
     @patch("builtins.open")
     @patch("runpod.serverless.utils.rp_upload.os.makedirs")
     def test_upload_image_local(self, mock_makedirs, mock_open, mock_get_boto_client):
-        '''
+        """
         Test upload_image function when there is no boto client
-        '''
+        """
         # Mocking get_boto_client to return None
         mock_get_boto_client.return_value = (None, None)
 
@@ -144,9 +154,9 @@ class TestUploadImage(unittest.TestCase):
     @patch("runpod.serverless.utils.rp_upload.get_boto_client")
     @patch("builtins.open")
     def test_upload_image_s3(self, mock_open, mock_get_boto_client):
-        '''
+        """
         Test upload_image function when there is a boto client
-        '''
+        """
         # Mocking boto_client
         mock_boto_client = Mock()
         mock_boto_client.put_object = Mock()
@@ -169,13 +179,13 @@ class TestUploadImage(unittest.TestCase):
 
 
 class TestUploadUtility(unittest.TestCase):
-    ''' Tests for upload utility '''
+    """Tests for upload utility"""
 
-    @patch('runpod.serverless.utils.rp_upload.get_boto_client')
+    @patch("runpod.serverless.utils.rp_upload.get_boto_client")
     def test_upload_file_to_bucket(self, mock_get_boto_client):
-        '''
+        """
         Tests upload_file_to_bucket
-        '''
+        """
         # Mock boto_client and transfer_config
         mock_boto_client = MagicMock()
         mock_transfer_config = MagicMock()
@@ -183,11 +193,11 @@ class TestUploadUtility(unittest.TestCase):
         mock_get_boto_client.return_value = (mock_boto_client, mock_transfer_config)
 
         # Define the file name and file location
-        file_name = 'example.txt'
-        file_location = '/path/to/your/local/file/example.txt'
+        file_name = "example.txt"
+        file_location = "/path/to/your/local/file/example.txt"
 
         # Mock os.path.getsize to return a file size
-        with patch('os.path.getsize', return_value=1024):
+        with patch("os.path.getsize", return_value=1024):
             upload_file_to_bucket(file_name, file_location, BUCKET_CREDENTIALS)
 
         # Check if get_boto_client was called with the correct arguments
@@ -195,28 +205,26 @@ class TestUploadUtility(unittest.TestCase):
 
         # Check if upload_file was called with the correct arguments
         upload_file_args = {
-            'Filename': file_location,
-            'Bucket': str(time.strftime('%m-%y')),
-            'Key': file_name,
-            'Config': mock_transfer_config,
-            'Callback': unittest.mock.ANY
+            "Filename": file_location,
+            "Bucket": str(time.strftime("%m-%y")),
+            "Key": file_name,
+            "Config": mock_transfer_config,
+            "Callback": unittest.mock.ANY,
         }
         mock_boto_client.upload_file.assert_called_once_with(**upload_file_args)
 
         # Check if generate_presigned_url was called with the correct arguments
         mock_boto_client.generate_presigned_url.assert_called_once_with(
-            'get_object',
-            Params={
-                'Bucket': str(time.strftime('%m-%y')),
-                'Key': file_name
-            }, ExpiresIn=604800
+            "get_object",
+            Params={"Bucket": str(time.strftime("%m-%y")), "Key": file_name},
+            ExpiresIn=604800,
         )
 
-    @patch('runpod.serverless.utils.rp_upload.get_boto_client')
+    @patch("runpod.serverless.utils.rp_upload.get_boto_client")
     def test_upload_in_memory_object(self, mock_get_boto_client):
-        '''
+        """
         Tests upload_in_memory_object
-        '''
+        """
         # Mock boto_client and transfer_config
         mock_boto_client = MagicMock()
         mock_transfer_config = MagicMock()
@@ -224,8 +232,8 @@ class TestUploadUtility(unittest.TestCase):
         mock_get_boto_client.return_value = (mock_boto_client, mock_transfer_config)
 
         # Define the file name and file data (bytes)
-        file_name = 'example.txt'
-        file_data = b'This is an example text.'
+        file_name = "example.txt"
+        file_data = b"This is an example text."
 
         upload_in_memory_object(file_name, file_data, BUCKET_CREDENTIALS)
 
@@ -235,10 +243,10 @@ class TestUploadUtility(unittest.TestCase):
         # Check if upload_fileobj was called with the correct arguments
         mock_boto_client.upload_fileobj.assert_called_once_with(
             unittest.mock.ANY,
-            str(time.strftime('%m-%y')),
+            str(time.strftime("%m-%y")),
             file_name,
             Config=mock_transfer_config,
-            Callback=unittest.mock.ANY
+            Callback=unittest.mock.ANY,
         )
 
         # Check if BytesIO was called with the correct arguments
@@ -247,9 +255,7 @@ class TestUploadUtility(unittest.TestCase):
 
         # Check if generate_presigned_url was called with the correct arguments
         mock_boto_client.generate_presigned_url.assert_called_once_with(
-            'get_object',
-            Params={
-                'Bucket': str(time.strftime('%m-%y')),
-                'Key': file_name
-            }, ExpiresIn=604800
+            "get_object",
+            Params={"Bucket": str(time.strftime("%m-%y")), "Key": file_name},
+            ExpiresIn=604800,
         )

--- a/tests/test_serverless/test_utils/test_validate.py
+++ b/tests/test_serverless/test_utils/test_validate.py
@@ -1,12 +1,13 @@
-''' Tests for runpod.serverless.utils.validate '''
+""" Tests for runpod.serverless.utils.validate """
 
 import unittest
 from unittest.mock import Mock
+
 from runpod.serverless.utils import rp_validator
 
 
 class TestValidator(unittest.TestCase):
-    ''' Tests for validator '''
+    """Tests for validator"""
 
     def setUp(self):
         self.raw_input = {"a": 1.1, "x": 10, "y": 20, "z": 30}
@@ -15,16 +16,18 @@ class TestValidator(unittest.TestCase):
             "x": {"type": int, "required": True},
             "y": {"type": int, "required": True, "default": 5},
             "z": {
-                "type": int, "required": False,
-                "default": 5, "constraints": Mock(return_value=True)
+                "type": int,
+                "required": False,
+                "default": 5,
+                "constraints": Mock(return_value=True),
             },
-            "w": {"type": int, "required": False, "default": 5}
+            "w": {"type": int, "required": False, "default": 5},
         }
 
     def test_validate_success(self):
-        '''
+        """
         Tests validate
-        '''
+        """
         result = rp_validator.validate(self.raw_input, self.schema)
 
         self.assertNotIn("errors", result)
@@ -33,9 +36,9 @@ class TestValidator(unittest.TestCase):
         self.assertEqual(result["validated_input"], expected_output)
 
     def test_validate_constraints_error(self):
-        '''
+        """
         Tests validate with constraints error
-        '''
+        """
         # Now add a constraint that the 'x' value must be less than 10
         self.schema["x"]["constraints"] = Mock(return_value=False)
 
@@ -45,9 +48,9 @@ class TestValidator(unittest.TestCase):
         self.assertIn("x does not meet the constraints.", result["errors"])
 
     def test_validate_missing_required_input(self):
-        '''
+        """
         Tests validate with missing required input
-        '''
+        """
         del self.raw_input["x"]
         result = rp_validator.validate(self.raw_input, self.schema)
 
@@ -55,19 +58,22 @@ class TestValidator(unittest.TestCase):
         self.assertIn("x is a required input.", result["errors"])
 
     def test_validate_unexpected_input(self):
-        '''
+        """
         Tests validate with unexpected input
-        '''
+        """
         self.raw_input["unexpected"] = "unexpected"
         result = rp_validator.validate(self.raw_input, self.schema)
 
         self.assertIn("errors", result)
-        self.assertIn("Unexpected input. unexpected is not a valid input option.", result["errors"])
+        self.assertIn(
+            "Unexpected input. unexpected is not a valid input option.",
+            result["errors"],
+        )
 
     def test_validate_missing_default(self):
-        '''
+        """
         Tests validate with missing default
-        '''
+        """
         del self.schema["w"]["default"]
         result = rp_validator.validate(self.raw_input, self.schema)
 
@@ -75,22 +81,24 @@ class TestValidator(unittest.TestCase):
         self.assertIn("Schema error, missing default value for w.", result["errors"])
 
     def test_validate_invalid_type(self):
-        '''
+        """
         Tests validate with invalid type
-        '''
+        """
         self.raw_input["x"] = "invalid"
         result = rp_validator.validate(self.raw_input, self.schema)
 
         self.assertIn("errors", result)
-        self.assertIn("x should be <class 'int'> type, not <class 'str'>.", result["errors"])
+        self.assertIn(
+            "x should be <class 'int'> type, not <class 'str'>.", result["errors"]
+        )
 
     def test_validate_rules_not_dict(self):
-        '''
+        """
         Tests validate with rules not dict
-        '''
+        """
         result = rp_validator.validate(self.raw_input, {"x": "not dict"})
         self.assertIn("errors", result)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_serverless/test_worker.py
+++ b/tests/test_serverless/test_worker.py
@@ -1,17 +1,17 @@
-''' Tests for runpod | serverless| worker '''
+""" Tests for runpod | serverless| worker """
+
 # pylint: disable=protected-access
 
-import os
 import argparse
-from unittest import mock
-from unittest.mock import patch, mock_open, Mock, MagicMock
+import os
+from unittest import IsolatedAsyncioTestCase, mock
+from unittest.mock import MagicMock, Mock, mock_open, patch
 
-from unittest import IsolatedAsyncioTestCase
 import nest_asyncio
 
 import runpod
-from runpod.serverless.modules.rp_logger import RunPodLogger
 from runpod.serverless import _signal_handler
+from runpod.serverless.modules.rp_logger import RunPodLogger
 
 nest_asyncio.apply()
 
@@ -27,47 +27,48 @@ class TestWorker(IsolatedAsyncioTestCase):
         }
 
     def test_is_local(self):
-        '''
+        """
         Test _is_local
-        '''
+        """
         with patch("runpod.serverless.worker.os") as mock_os:
             mock_os.environ.get.return_value = None
-            assert runpod.serverless.worker._is_local(
-                {"rp_args": {}}) is True
-            assert runpod.serverless.worker._is_local(
-                {"rp_args": {"test_input": "something"}}) is True
+            assert runpod.serverless.worker._is_local({"rp_args": {}}) is True
+            assert (
+                runpod.serverless.worker._is_local(
+                    {"rp_args": {"test_input": "something"}}
+                )
+                is True
+            )
 
             mock_os.environ.get.return_value = "something"
-            assert runpod.serverless.worker._is_local(
-                self.mock_config) is False
+            assert runpod.serverless.worker._is_local(self.mock_config) is False
 
     def test_start(self):
-        '''
+        """
         Test basic start call.
-        '''
-        with patch("builtins.open", mock_open(read_data='{"input":{"number":1}}')) as mock_file, \
-                self.assertRaises(SystemExit):
+        """
+        with patch(
+            "builtins.open", mock_open(read_data='{"input":{"number":1}}')
+        ) as mock_file, self.assertRaises(SystemExit):
 
             runpod.serverless.start({"handler": self.mock_handler})
 
             assert mock_file.called
 
     def test_is_local_testing(self):
-        '''
+        """
         Test _is_local_testing
-        '''
+        """
         with patch("runpod.serverless.worker.os") as mock_os:
             mock_os.environ.get.return_value = None
-            assert runpod.serverless.worker._is_local(
-                self.mock_config) is True
+            assert runpod.serverless.worker._is_local(self.mock_config) is True
             mock_os.environ.get.return_value = "something"
-            assert runpod.serverless.worker._is_local(
-                self.mock_config) is False
+            assert runpod.serverless.worker._is_local(self.mock_config) is False
 
     def test_local_api(self):
-        '''
+        """
         Test local FastAPI setup.
-        '''
+        """
         known_args = argparse.Namespace()
         known_args.rp_log_level = None
         known_args.rp_debugger = None
@@ -77,20 +78,23 @@ class TestWorker(IsolatedAsyncioTestCase):
         known_args.rp_api_host = "localhost"
         known_args.test_input = '{"test": "test"}'
 
-        with patch("argparse.ArgumentParser.parse_known_args") as mock_parse_known_args, \
-                patch("runpod.serverless.rp_fastapi") as mock_fastapi:
+        with patch(
+            "argparse.ArgumentParser.parse_known_args"
+        ) as mock_parse_known_args, patch(
+            "runpod.serverless.rp_fastapi"
+        ) as mock_fastapi:
 
             mock_parse_known_args.return_value = known_args, []
             runpod.serverless.start({"handler": self.mock_handler})
 
             assert mock_fastapi.WorkerAPI.called
 
-    @patch('runpod.serverless.log')
-    @patch('runpod.serverless.sys.exit')
+    @patch("runpod.serverless.log")
+    @patch("runpod.serverless.sys.exit")
     def test_signal_handler(self, mock_exit, mock_logger):
-        '''
+        """
         Test signal handler.
-        '''
+        """
 
         _signal_handler(None, None)
 
@@ -99,7 +103,7 @@ class TestWorker(IsolatedAsyncioTestCase):
 
 
 class TestWorkerTestInput(IsolatedAsyncioTestCase):
-    """ Tests for runpod | serverless| worker """
+    """Tests for runpod | serverless| worker"""
 
     def setUp(self):
         self.mock_handler = Mock()
@@ -108,9 +112,9 @@ class TestWorkerTestInput(IsolatedAsyncioTestCase):
         self.mock_handler.return_value = "test"
 
     def test_worker_bad_local(self):
-        '''
+        """
         Test sys args.
-        '''
+        """
         known_args = argparse.Namespace()
         known_args.rp_log_level = "WARN"
         known_args.rp_debugger = True
@@ -121,8 +125,9 @@ class TestWorkerTestInput(IsolatedAsyncioTestCase):
         known_args.test_input = '{"test": "test"}'
         known_args.test_output = '{"test": "test"}'
 
-        with patch("argparse.ArgumentParser.parse_known_args") as mock_parse_known_args, \
-                self.assertRaises(SystemExit):
+        with patch(
+            "argparse.ArgumentParser.parse_known_args"
+        ) as mock_parse_known_args, self.assertRaises(SystemExit):
 
             mock_parse_known_args.return_value = known_args, []
             runpod.serverless.start({"handler": self.mock_handler})
@@ -133,18 +138,18 @@ class TestWorkerTestInput(IsolatedAsyncioTestCase):
 
 
 def generator_handler(job):
-    '''
+    """
     Test generator_handler
-    '''
+    """
     print(job)
     yield "test1"
     yield "test2"
 
 
 def generator_handler_exception(job):
-    '''
+    """
     Test generator_handler
-    '''
+    """
     print(job)
     yield "test1"
     print("Raise exception")
@@ -152,7 +157,7 @@ def generator_handler_exception(job):
 
 
 def test_generator_handler_exception():
-    """ Test generator_handler_exception """
+    """Test generator_handler_exception"""
     job = {"id": "test_job"}
     gen = generator_handler_exception(job)
 
@@ -169,7 +174,7 @@ def test_generator_handler_exception():
 
 
 class TestRunWorker(IsolatedAsyncioTestCase):
-    """ Tests for runpod | serverless| worker """
+    """Tests for runpod | serverless| worker"""
 
     def setUp(self):
         os.environ["RUNPOD_WEBHOOK_GET_JOB"] = "https://test.com"
@@ -178,10 +183,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
         self.config = {
             "handler": MagicMock(),
             "refresh_worker": True,
-            "rp_args": {
-                "rp_debugger": True,
-                "rp_log_level": "DEBUG"
-            }
+            "rp_args": {"rp_debugger": True, "rp_log_level": "DEBUG"},
         }
 
     @patch("runpod.serverless.worker.AsyncClientSession")
@@ -191,8 +193,14 @@ class TestRunWorker(IsolatedAsyncioTestCase):
     @patch("runpod.serverless.worker.send_result")
     # pylint: disable=too-many-arguments
     async def test_run_worker(
-            self, mock_send_result, mock_stream_result, mock_run_job, mock_get_job, mock_session):
-        '''
+        self,
+        mock_send_result,
+        mock_stream_result,
+        mock_run_job,
+        mock_get_job,
+        mock_session,
+    ):
+        """
         Test run_worker with synchronous handler.
 
         Args:
@@ -201,7 +209,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
             mock_run_job (_type_): _description_
             mock_get_job (_type_): _description_
             mock_session (_type_): _description_
-        '''
+        """
         # Define the mock behaviors
         mock_get_job.return_value = {"id": "123", "input": {"number": 1}}
         mock_run_job.return_value = {"output": {"result": "odd"}}
@@ -222,9 +230,9 @@ class TestRunWorker(IsolatedAsyncioTestCase):
     @patch("runpod.serverless.worker.stream_result")
     @patch("runpod.serverless.worker.send_result")
     async def test_run_worker_generator_handler(
-            self, mock_send_result, mock_stream_result, mock_run_job,
-            mock_get_job):
-        '''
+        self, mock_send_result, mock_stream_result, mock_run_job, mock_get_job
+    ):
+        """
         Test run_worker with generator handler.
 
         Args:
@@ -232,14 +240,12 @@ class TestRunWorker(IsolatedAsyncioTestCase):
             mock_run_job_generator (_type_): _description_
             mock_run_job (_type_): _description_
             mock_get_job (_type_): _description_
-        '''
+        """
         # Define the mock behaviors
-        mock_get_job.return_value = {
-            "id": "generator-123", "input": {"number": 1}}
+        mock_get_job.return_value = {"id": "generator-123", "input": {"number": 1}}
 
         # Test generator handler
-        generator_config = {
-            "handler": generator_handler, "refresh_worker": True}
+        generator_config = {"handler": generator_handler, "refresh_worker": True}
         runpod.serverless.start(generator_config)
 
         assert mock_stream_result.called
@@ -247,48 +253,50 @@ class TestRunWorker(IsolatedAsyncioTestCase):
 
         # Since return_aggregate_stream is NOT activated, we should not submit any outputs.
         _, args, _ = mock_send_result.mock_calls[0]
-        assert args[1] == {'output': [], 'stopPod': True}
+        assert args[1] == {"output": [], "stopPod": True}
 
     @patch("runpod.serverless.modules.rp_scale.get_job")
     @patch("runpod.serverless.worker.run_job")
     @patch("runpod.serverless.worker.stream_result")
     @patch("runpod.serverless.worker.send_result")
     async def test_run_worker_generator_handler_exception(
-            self, mock_send_result, mock_stream_result, mock_run_job,
-            mock_get_job):
-        '''
+        self, mock_send_result, mock_stream_result, mock_run_job, mock_get_job
+    ):
+        """
         Test run_worker with generator handler.
 
         This test verifies that:
         - `stream_result` is called exactly once before an exception occurs.
         - `run_job` is never called since `handler` is a generator function.
         - An error is correctly reported back via `send_result`.
-        '''
+        """
         RunPodLogger().set_level("DEBUG")
 
         # Setup: Mock `get_job` to return a predefined job.
-        mock_get_job.return_value = {"id": "generator-123-exception", "input": {"number": 1}}
+        mock_get_job.return_value = {
+            "id": "generator-123-exception",
+            "input": {"number": 1},
+        }
 
-        runpod.serverless.start({
-            "handler": generator_handler_exception,
-            "refresh_worker": True
-        })
+        runpod.serverless.start(
+            {"handler": generator_handler_exception, "refresh_worker": True}
+        )
 
         assert mock_stream_result.call_count == 1
         assert not mock_run_job.called
 
         # Since return_aggregate_stream is NOT activated, we should not submit any outputs.
         _, args, _ = mock_send_result.mock_calls[0]
-        assert 'error' in args[1], "Expected the error to be reported in the results."
+        assert "error" in args[1], "Expected the error to be reported in the results."
 
     @patch("runpod.serverless.modules.rp_scale.get_job")
     @patch("runpod.serverless.worker.run_job")
     @patch("runpod.serverless.worker.stream_result")
     @patch("runpod.serverless.worker.send_result")
     async def test_run_worker_generator_aggregate_handler(
-            self, mock_send_result, mock_stream_result, mock_run_job,
-            mock_get_job):
-        '''
+        self, mock_send_result, mock_stream_result, mock_run_job, mock_get_job
+    ):
+        """
         Test run_worker with generator handler.
 
         Args:
@@ -297,14 +305,19 @@ class TestRunWorker(IsolatedAsyncioTestCase):
             mock_run_job (_type_): _description_
             mock_get_job (_type_): _description_
             mock_session (_type_): _description_
-        '''
+        """
         # Define the mock behaviors
         mock_get_job.return_value = {
-            "id": "generator-123-aggregate", "input": {"number": 1}}
+            "id": "generator-123-aggregate",
+            "input": {"number": 1},
+        }
 
         # Test generator handler
         generator_config = {
-            "handler": generator_handler, "return_aggregate_stream": True, "refresh_worker": True}
+            "handler": generator_handler,
+            "return_aggregate_stream": True,
+            "refresh_worker": True,
+        }
 
         runpod.serverless.start(generator_config)
 
@@ -314,7 +327,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
 
         # Since return_aggregate_stream is activated, we should submit a list of the outputs.
         _, args, _ = mock_send_result.mock_calls[0]
-        assert args[1] == {'output': ['test1', 'test2'], 'stopPod': True}
+        assert args[1] == {"output": ["test1", "test2"], "stopPod": True}
 
     @patch("runpod.serverless.worker.AsyncClientSession")
     @patch("runpod.serverless.modules.rp_scale.get_job")
@@ -323,8 +336,14 @@ class TestRunWorker(IsolatedAsyncioTestCase):
     @patch("runpod.serverless.worker.send_result")
     # pylint: disable=too-many-arguments
     async def test_run_worker_multi_processing(
-            self, mock_send_result, mock_stream_result, mock_run_job, mock_get_job, mock_session):
-        '''
+        self,
+        mock_send_result,
+        mock_stream_result,
+        mock_run_job,
+        mock_get_job,
+        mock_session,
+    ):
+        """
         Test run_worker with multi processing enabled, both async and generator handler.
 
         Args:
@@ -333,7 +352,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
             mock_run_job (_type_): _description_
             mock_get_job (_type_): _description_
             mock_session (_type_): _description_
-        '''
+        """
 
         # Define the mock behaviors
         mock_get_job.return_value = {"id": "123", "input": {"number": 1}}
@@ -351,10 +370,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
         assert mock_session.called
 
         # Test generator handler
-        generator_config = {
-            "handler": generator_handler,
-            "refresh_worker": True
-        }
+        generator_config = {"handler": generator_handler, "refresh_worker": True}
         runpod.serverless.start(generator_config)
         assert mock_stream_result.called
 
@@ -368,8 +384,8 @@ class TestRunWorker(IsolatedAsyncioTestCase):
                     "rp_serve_api": None,
                     "rp_api_port": 8000,
                     "rp_api_concurrency": 1,
-                    "rp_api_host": "localhost"
-                }
+                    "rp_api_host": "localhost",
+                },
             }
 
             mock_set_config_args.return_value = limited_config
@@ -382,8 +398,9 @@ class TestRunWorker(IsolatedAsyncioTestCase):
     @patch("runpod.serverless.modules.rp_scale.get_job")
     @patch("runpod.serverless.worker.run_job")
     async def test_run_worker_multi_processing_scaling_up(
-            self, mock_run_job, mock_get_job):
-        '''
+        self, mock_run_job, mock_get_job
+    ):
+        """
         Test run_worker with multi processing enabled, the scale-up and scale-down
         behavior with concurrency_controller.
 
@@ -393,7 +410,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
             mock_run_job (_type_): _description_
             mock_get_job (_type_): _description_
             mock_session (_type_): _description_
-        '''
+        """
         # Define the mock behaviors
         mock_get_job.return_value = {"id": "123", "input": {"number": 1}}
         mock_run_job.return_value = {"output": {"result": "odd"}}
@@ -402,35 +419,46 @@ class TestRunWorker(IsolatedAsyncioTestCase):
         # Should go from concurrency 1 -> 2 -> 4 -> 8 -> 16 -> 8 -> 4 -> 2 -> 1
         # 1+2+4+8+16+8+4+2+1 -> 46 calls to get_job.
         scale_behavior = {
-            'behavior': [False, False, False, False, False, False, True, True, True, True, True],
-            'counter': 0,
+            "behavior": [
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                True,
+                True,
+                True,
+                True,
+                True,
+            ],
+            "counter": 0,
         }
 
         # Let the test be a long running one so we can capture the scale-up and scale-down.
         config = {
             "handler": MagicMock(),
             "refresh_worker": False,
-            "rp_args": {
-                "rp_debugger": True,
-                "rp_log_level": "DEBUG"
-            }
+            "rp_args": {"rp_debugger": True, "rp_log_level": "DEBUG"},
         }
 
         # Let's mock job_scaler.is_alive so that it returns False
         # when scale_behavior's counter is now 5.
         def mock_is_alive():
-            res = scale_behavior['counter'] < 10
-            scale_behavior['counter'] += 1
+            res = scale_behavior["counter"] < 10
+            scale_behavior["counter"] += 1
             return res
 
-        with patch("runpod.serverless.modules.rp_scale.JobScaler.is_alive", wraps=mock_is_alive):
+        with patch(
+            "runpod.serverless.modules.rp_scale.JobScaler.is_alive", wraps=mock_is_alive
+        ):
             runpod.serverless.start(config)
 
     # Test with sls-core
     async def test_run_worker_with_sls_core(self):
-        '''
+        """
         Test run_worker with sls-core.
-        '''
+        """
         with patch("runpod.serverless.core.main") as mock_main:
             os.environ["RUNPOD_USE_CORE"] = "true"
             runpod.serverless.start(self.config)

--- a/tests/test_shared/__init__.py
+++ b/tests/test_shared/__init__.py
@@ -1,1 +1,1 @@
-''' Allows files to be imported from this directory. '''
+""" Allows files to be imported from this directory. """

--- a/tests/test_shared/test_auth.py
+++ b/tests/test_shared/test_auth.py
@@ -1,14 +1,14 @@
-'''
+"""
 Test shared functions related to authentication
-'''
+"""
 
-import unittest
 import importlib
+import unittest
+from unittest.mock import mock_open, patch
 
-from unittest.mock import patch, mock_open
 
 class TestAPIKey(unittest.TestCase):
-    ''' Test the API key '''
+    """Test the API key"""
 
     # The mocked TOML file
     CREDENTIALS = b"""
@@ -16,12 +16,13 @@ class TestAPIKey(unittest.TestCase):
     api_key = "RUNPOD_API_KEY"
     """
 
-    @patch('builtins.open', new_callable=mock_open, read_data=CREDENTIALS)
+    @patch("builtins.open", new_callable=mock_open, read_data=CREDENTIALS)
     def test_use_file_credentials(self, mock_file):
-        '''
+        """
         Test that the API key is read from the credentials file
-        '''
-        import runpod # pylint: disable=import-outside-toplevel
+        """
+        import runpod  # pylint: disable=import-outside-toplevel
+
         importlib.reload(runpod)
         self.assertEqual(runpod.api_key, "RUNPOD_API_KEY")
         assert mock_file.called

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -6,29 +6,31 @@ import json
 import unittest
 from time import time
 from types import SimpleNamespace
-from unittest.mock import patch, MagicMock
-from yarl import URL
+from unittest.mock import MagicMock, patch
+
 from aiohttp import (
     TraceConfig,
-    TraceRequestStartParams,
-    TraceConnectionCreateStartParams,
     TraceConnectionCreateEndParams,
+    TraceConnectionCreateStartParams,
     TraceConnectionReuseconnParams,
-    TraceRequestExceptionParams,
     TraceRequestChunkSentParams,
+    TraceRequestExceptionParams,
+    TraceRequestStartParams,
     TraceResponseChunkReceivedParams,
 )
+from yarl import URL
+
 from runpod.tracer import (
-    on_request_start,
-    on_connection_create_start,
+    create_aiohttp_tracer,
     on_connection_create_end,
+    on_connection_create_start,
     on_connection_reuseconn,
     on_request_chunk_sent,
-    on_response_chunk_received,
     on_request_end,
     on_request_exception,
+    on_request_start,
+    on_response_chunk_received,
     report_trace,
-    create_aiohttp_tracer,
     time_to_iso8601,
 )
 
@@ -48,11 +50,13 @@ class TestTracer(unittest.TestCase):
     def test_on_request_start(self):
         session = MagicMock()
         context = SimpleNamespace(trace_request_ctx={"current_attempt": 0})
-        params = TraceRequestStartParams("GET", URL("http://test.com/"), { "X-Request-ID": "myRequestId" })
+        params = TraceRequestStartParams(
+            "GET", URL("http://test.com/"), {"X-Request-ID": "myRequestId"}
+        )
 
         self.loop.run_until_complete(on_request_start(session, context, params))
-        assert hasattr(context, 'on_request_start')
-        assert hasattr(context, 'trace_id')
+        assert hasattr(context, "on_request_start")
+        assert hasattr(context, "trace_id")
         assert context.method == params.method
         assert context.url == params.url.human_repr()
 
@@ -61,7 +65,9 @@ class TestTracer(unittest.TestCase):
         context = SimpleNamespace(on_request_start=self.loop.time())
         params = TraceConnectionCreateStartParams()
 
-        self.loop.run_until_complete(on_connection_create_start(session, context, params))
+        self.loop.run_until_complete(
+            on_connection_create_start(session, context, params)
+        )
 
         assert context.connect
 
@@ -71,7 +77,7 @@ class TestTracer(unittest.TestCase):
         params = TraceConnectionCreateEndParams()
 
         self.loop.run_until_complete(on_connection_create_end(session, context, params))
-        
+
         assert context.connect
 
     def test_on_connection_reuseconn(self):
@@ -86,34 +92,42 @@ class TestTracer(unittest.TestCase):
     def test_on_request_chunk_sent(self):
         session = MagicMock()
         context = SimpleNamespace(on_request_start=self.loop.time())
-        params = TraceRequestChunkSentParams("GET", URL("http://test.com/"), chunk=b'test data')
+        params = TraceRequestChunkSentParams(
+            "GET", URL("http://test.com/"), chunk=b"test data"
+        )
 
         # Initial call to on_request_start to initialize context
         self.loop.run_until_complete(on_request_start(session, context, params))
 
         # Call on_request_chunk_sent multiple times to simulate multiple chunks being sent
         for _ in range(3):
-            self.loop.run_until_complete(on_request_chunk_sent(session, context, params))
-        
+            self.loop.run_until_complete(
+                on_request_chunk_sent(session, context, params)
+            )
+
         # Verify that payload_size_bytes has accumulated
         assert context.payload_size_bytes == len(params.chunk) * 3
 
     def test_on_response_chunk_received(self):
         session = MagicMock()
         context = SimpleNamespace(on_request_start=self.loop.time())
-        params = TraceResponseChunkReceivedParams("GET", URL("http://test.com/"), chunk=b'received data')
+        params = TraceResponseChunkReceivedParams(
+            "GET", URL("http://test.com/"), chunk=b"received data"
+        )
 
         # Initial call to on_request_start to initialize context
         self.loop.run_until_complete(on_request_start(session, context, params))
 
         # Call on_response_chunk_received multiple times to simulate multiple chunks being received
         for _ in range(3):
-            self.loop.run_until_complete(on_response_chunk_received(session, context, params))
+            self.loop.run_until_complete(
+                on_response_chunk_received(session, context, params)
+            )
 
         # Verify that payload_size_bytes has accumulated
         assert context.response_size_bytes == len(params.chunk) * 3
 
-    @patch('runpod.tracer.report_trace')
+    @patch("runpod.tracer.report_trace")
     def test_on_request_end(self, mock_report_trace):
         session = MagicMock()
         context = SimpleNamespace(on_request_start=self.loop.time(), connect=0.5)
@@ -122,17 +136,22 @@ class TestTracer(unittest.TestCase):
         self.loop.run_until_complete(on_request_end(session, context, params))
         mock_report_trace.assert_called_once()
 
-    @patch('runpod.tracer.report_trace')
+    @patch("runpod.tracer.report_trace")
     def test_on_request_exception(self, mock_report_trace):
         session = MagicMock()
         context = SimpleNamespace(on_request_start=self.loop.time(), connect=0.5)
-        params = TraceRequestExceptionParams("GET", URL("http://test.com/"), headers={}, exception=Exception("Test Exception"))
+        params = TraceRequestExceptionParams(
+            "GET",
+            URL("http://test.com/"),
+            headers={},
+            exception=Exception("Test Exception"),
+        )
 
         self.loop.run_until_complete(on_request_exception(session, context, params))
         mock_report_trace.assert_called_once()
         assert context.exception
 
-    @patch('runpod.tracer.log')
+    @patch("runpod.tracer.log")
     def test_report_trace(self, mock_log):
         context = SimpleNamespace()
         context.trace_id = "test-trace-id"
@@ -162,14 +181,14 @@ class TestTracer(unittest.TestCase):
             "end_time": time_to_iso8601(context.end_time),
             "total": 1500.0,  # 1.5 seconds to milliseconds
             "transfer": 1000.0,  # 1.5 - 0.5 seconds to milliseconds
-            "response_status": 200
+            "response_status": 200,
         }
 
         report_trace(context, params, elapsed, mock_log.trace)
 
         assert expected_report == json.loads(mock_log.trace.call_args[0][0])
 
-    @patch('runpod.tracer.log')
+    @patch("runpod.tracer.log")
     def test_report_trace_error_log(self, mock_log):
         context = SimpleNamespace()
         context.trace_id = "test-trace-id"
@@ -197,7 +216,7 @@ class TestTracer(unittest.TestCase):
             "end_time": time_to_iso8601(context.end_time),
             "total": 1500.0,  # 1.5 seconds to milliseconds
             "transfer": 1000.0,  # 1.5 - 0.5 seconds to milliseconds
-            "response_status": 502
+            "response_status": 502,
         }
 
         report_trace(context, params, elapsed, mock_log.error)

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -1,8 +1,8 @@
 """ Tests for the user_agent module. """
 
+import os
 import unittest
 from unittest.mock import patch
-import os
 
 from runpod import __version__ as runpod_version
 from runpod.user_agent import construct_user_agent
@@ -11,15 +11,16 @@ from runpod.user_agent import construct_user_agent
 class TestConstructUserAgent(unittest.TestCase):
     """Test the construct_user_agent function."""
 
-    @patch('runpod.user_agent.platform.system', return_value='Windows')
-    @patch('runpod.user_agent.platform.release', return_value='10')
-    @patch('runpod.user_agent.platform.machine', return_value='AMD64')
-    @patch('runpod.user_agent.platform.python_version', return_value='3.8.10')
+    @patch("runpod.user_agent.platform.system", return_value="Windows")
+    @patch("runpod.user_agent.platform.release", return_value="10")
+    @patch("runpod.user_agent.platform.machine", return_value="AMD64")
+    @patch("runpod.user_agent.platform.python_version", return_value="3.8.10")
     def test_user_agent_without_integration(
-            self, mock_python_version, mock_machine, mock_release, mock_system):
+        self, mock_python_version, mock_machine, mock_release, mock_system
+    ):
         """Test the User-Agent string without specifying an integration method."""
-        if 'RUNPOD_UA_INTEGRATION' in os.environ:
-            del os.environ['RUNPOD_UA_INTEGRATION']
+        if "RUNPOD_UA_INTEGRATION" in os.environ:
+            del os.environ["RUNPOD_UA_INTEGRATION"]
 
         expected_ua = f"RunPod-Python-SDK/{runpod_version} (Windows 10; AMD64) Language/Python 3.8.10"  # pylint: disable=line-too-long
         self.assertEqual(construct_user_agent(), expected_ua)
@@ -29,19 +30,20 @@ class TestConstructUserAgent(unittest.TestCase):
         assert mock_release.called
         assert mock_system.called
 
-    @patch('runpod.user_agent.platform.system', return_value='Linux')
-    @patch('runpod.user_agent.platform.release', return_value='5.4')
-    @patch('runpod.user_agent.platform.machine', return_value='x86_64')
-    @patch('runpod.user_agent.platform.python_version', return_value='3.9.5')
-    @patch.dict(os.environ, {'RUNPOD_UA_INTEGRATION': 'SkyPilot'})
+    @patch("runpod.user_agent.platform.system", return_value="Linux")
+    @patch("runpod.user_agent.platform.release", return_value="5.4")
+    @patch("runpod.user_agent.platform.machine", return_value="x86_64")
+    @patch("runpod.user_agent.platform.python_version", return_value="3.9.5")
+    @patch.dict(os.environ, {"RUNPOD_UA_INTEGRATION": "SkyPilot"})
     def test_user_agent_with_integration(
-            self, mock_python_version, mock_machine, mock_release, mock_system):
+        self, mock_python_version, mock_machine, mock_release, mock_system
+    ):
         """Test the User-Agent string with an integration method specified."""
         expected_ua = f"RunPod-Python-SDK/{runpod_version} (Linux 5.4; x86_64) Language/Python 3.9.5 Integration/SkyPilot"  # pylint: disable=line-too-long
 
-        os.environ['RUNPOD_UA_INTEGRATION'] = 'SkyPilot'
+        os.environ["RUNPOD_UA_INTEGRATION"] = "SkyPilot"
         self.assertEqual(construct_user_agent(), expected_ua)
-        os.environ.pop('RUNPOD_UA_INTEGRATION')
+        os.environ.pop("RUNPOD_UA_INTEGRATION")
 
         assert mock_python_version.called
         assert mock_machine.called
@@ -49,5 +51,5 @@ class TestConstructUserAgent(unittest.TestCase):
         assert mock_system.called
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,19 +1,22 @@
 """ Test the version module """
 
-from unittest.mock import patch
 from importlib.metadata import PackageNotFoundError
+from unittest.mock import patch
+
 from runpod.version import get_version
 
+
 def test_version_found():
-    """ Test that the version is found """
-    with patch('runpod.version.version') as mock_get_version:
-        mock_get_version.return_value = '1.0.0'
-        assert get_version() == '1.0.0'
+    """Test that the version is found"""
+    with patch("runpod.version.version") as mock_get_version:
+        mock_get_version.return_value = "1.0.0"
+        assert get_version() == "1.0.0"
         assert mock_get_version.called
 
+
 def test_version_not_found():
-    """ Test that the version is not found """
-    with patch('runpod.version.version') as mock_get_version:
+    """Test that the version is not found"""
+    with patch("runpod.version.version") as mock_get_version:
         mock_get_version.side_effect = PackageNotFoundError
-        assert get_version() == 'unknown'
+        assert get_version() == "unknown"
         assert mock_get_version.called

--- a/tests/test_whatever.py
+++ b/tests/test_whatever.py
@@ -3,6 +3,7 @@ This module contains unit tests for the 'whatever' module, specifically the is_e
 """
 
 import unittest
+
 from .whatever import is_even
 
 

--- a/tests/whatever.py
+++ b/tests/whatever.py
@@ -1,4 +1,4 @@
-'''
+"""
 This is the starting point for your serverless API.
 It can be named anything you want, but needs to have the following:
 
@@ -6,13 +6,13 @@ It can be named anything you want, but needs to have the following:
 - start function
 
 To return an error, return a dictionary with the key "error" and the value being the error message.
-'''
+"""
 
 import runpod  # Required
 
 
 def is_even(job):
-    '''
+    """
     Example function that returns True if the input is even, False otherwise.
 
     "job_input" will contain the input that was passed to the API along with some other metadata.
@@ -23,7 +23,7 @@ def is_even(job):
     }
 
     Whatever is returned from this function will be returned to the user as the output.
-    '''
+    """
 
     job_input = job["input"]
     the_number = job_input["number"]


### PR DESCRIPTION
`black` guarantees no abstract syntax tree changes.
`isort` is a little more persnickety - python import ordering can matter - but we _should_ be OK.


This kind of consistency makes codebases much easier to read.