### PR TITLE
Make core envvars backwards compatible

### DIFF
--- a/runpod/serverless/__init__.py
+++ b/runpod/serverless/__init__.py
@@ -172,16 +172,16 @@ def start(config: Dict[str, Any]):
         return
 
     # --------------------------------- SLS-Core --------------------------------- #
-    if os.getenv("RUNPOD_SLS_CORE", "false").lower() in (
-        "1",
-        "t",
-        "T",
-        "TRUE",
-        "true",
-        "True",
-    ):
-        core.main(config)
-        return
+
+    match os.getenv("RUNPOD_SLS_CORE"):
+        case None if os.getenv("RUNPOD_USE_CORE") is not None:
+            log.warn("RUNPOD_USE_CORE is deprecated. Please use RUNPOD_SLS_CORE instead.")
+            core.main(config)
+            return
+
+        case x if x.lower() in ["1", "t", "T", "TRUE", "true", "True"]:
+            core.main(config)
+            return
 
     # --------------------------------- Standard --------------------------------- #
     worker.main(config)


### PR DESCRIPTION
this way users won't be surprised if the old envvar stops working.


