### PR TITLE
add wrappers for UpdateRegistryAuth and UpdateRegistryAuth.

### DIFF
--- a/runpod/__init__.py
+++ b/runpod/__init__.py
@@ -9,6 +9,7 @@ from .api.ctl_commands import (
     create_endpoint,
     create_pod,
     create_template,
+    delete_container_registry_auth,
     get_endpoints,
     get_gpu,
     get_gpus,
@@ -18,6 +19,7 @@ from .api.ctl_commands import (
     resume_pod,
     stop_pod,
     terminate_pod,
+    update_container_registry_auth,
     update_endpoint_template,
     update_user_settings,
 )

--- a/runpod/api/ctl_commands.py
+++ b/runpod/api/ctl_commands.py
@@ -371,3 +371,38 @@ def create_container_registry_auth(name: str, username: str, password: str):
         )
     )
     return raw_response["data"]["saveRegistryAuth"]
+
+
+def update_container_registry_auth(registry_auth_id: str, username: str, password: str):
+    """
+    Update a container registry authentication.
+
+    Args:
+        registry_auth_id (str): The id of the container registry authentication
+        username (str): The username for authentication.
+        password (str): The password for authentication.
+
+    Returns:
+        dict: The response data containing the updated container registry authentication.
+    """
+    raw_response = run_graphql_query(
+        container_register_auth_mutations.update_container_registry_auth(
+            registry_auth_id, username, password
+        )
+    )
+    return raw_response["data"]["updateRegistryAuth"]
+
+
+def delete_container_registry_auth(registry_auth_id: str):
+    """
+    Delete a container registry authentication.
+
+    Args:
+        registry_auth_id (str): The id of the container registry authentication
+    """
+    raw_response = run_graphql_query(
+        container_register_auth_mutations.delete_container_registry_auth(
+            registry_auth_id
+        )
+    )
+    return raw_response["data"]["deleteRegistryAuth"]

--- a/runpod/api/mutations/container_register_auth.py
+++ b/runpod/api/mutations/container_register_auth.py
@@ -27,3 +27,49 @@ def generate_container_registry_auth(name: str, username: str, password: str):
         }}
     }}
     """
+
+
+def update_container_registry_auth(registry_auth_id: str, username: str, password: str):
+    """
+    Generate a GraphQL mutation string to update registry authentication details.
+
+    Args:
+        registry_auth_id (str): The id of the container registry authentication
+        username (str): The username for authentication.
+        password (str): The password for authentication.
+
+    Returns:
+        str: The GraphQL mutation string.
+    """
+    # Prepare the input dictionary
+    input_dict = {"id": registry_auth_id, "username": username, "password": password}
+
+    # Convert the input dictionary to a string, properly formatted for GraphQL
+    input_str = ", ".join(f'{key}: "{value}"' for key, value in input_dict.items())
+
+    return f"""
+    mutation UpdateRegistryAuth {{
+        updateRegistryAuth(input: {{{input_str}}}) {{
+            id
+            name
+        }}
+    }}
+    """
+
+
+def delete_container_registry_auth(registry_auth_id: str):
+    """
+    Generate a GraphQL mutation string to delete registry authentication details.
+
+    Args:
+        registry_auth_id (str): The id of the container registry authentication
+
+    Returns:
+        str: The GraphQL mutation string.
+    """
+
+    return f"""
+    mutation DeleteRegistryAuth {{
+        deleteRegistryAuth(registryAuthId: "{registry_auth_id}")
+    }}
+    """

--- a/tests/test_api/test_mutation_container_registry_auth.py
+++ b/tests/test_api/test_mutation_container_registry_auth.py
@@ -3,7 +3,9 @@
 import unittest
 
 from runpod.api.mutations.container_register_auth import (
+    delete_container_registry_auth,
     generate_container_registry_auth,
+    update_container_registry_auth
 )
 
 
@@ -33,3 +35,47 @@ class TestGenerateContainerRegistryAuth(unittest.TestCase):
         )
         self.assertIn("id", actual_mutation)
         self.assertIn("name", actual_mutation)
+
+    def test_update_container_registry_auth(self):
+        """
+        Test that the update_container_registry_auth function produces the correct
+        GraphQL mutation string with the provided registry_auth_id, username and password.
+        """
+        # Define test inputs
+        registry_auth_id = "testAuthId"
+        username = "testUser"
+        password = "testPass"
+
+        # Generate the actual mutation string
+        actual_mutation = update_container_registry_auth(
+            registry_auth_id, username, password
+        ).strip()
+
+        # Verify key components of the mutation string
+        self.assertIn("mutation UpdateRegistryAuth", actual_mutation)
+        self.assertIn(
+            'updateRegistryAuth(input: {id: "testAuthId", username: "testUser", password: "testPass"})',  # pylint: disable=line-too-long
+            actual_mutation,
+        )
+        self.assertIn("id", actual_mutation)
+        self.assertIn("name", actual_mutation)
+
+    def test_delete_container_registry_auth(self):
+        """
+        Test that the delete_container_registry_auth function produces the correct
+        GraphQL mutation string with the provided registry_auth_id
+        """
+        # Define test inputs
+        registry_auth_id = "testAuthId"
+
+        # Generate the actual mutation string
+        actual_mutation = delete_container_registry_auth(
+            registry_auth_id
+        ).strip()
+
+        # Verify key components of the mutation string
+        self.assertIn("mutation DeleteRegistryAuth", actual_mutation)
+        self.assertIn(
+            'deleteRegistryAuth(registryAuthId: "testAuthId")',  # pylint: disable=line-too-long
+            actual_mutation,
+        )


### PR DESCRIPTION
adds wrappers for:
* UpdateRegistryAuth (runpod.update_container_registry_auth)
* DeleteRegistryAuth (runpod.delete_container_registry_auth)

and tests similar to what exists for generate_container_registry_auth

should address #317 

tried it on my account, seems to work

