### PR TITLE
minimum network speed parameters for create_pod

### DIFF
--- a/runpod/api/ctl_commands.py
+++ b/runpod/api/ctl_commands.py
@@ -107,6 +107,8 @@ def create_pod(
     template_id: Optional[str] = None,
     network_volume_id: Optional[str] = None,
     allowed_cuda_versions: Optional[list] = None,
+    min_download = None,
+    min_upload = None,
 ) -> dict:
     """
     Create a pod
@@ -125,7 +127,8 @@ def create_pod(
                 for example {EXAMPLE_VAR:"example_value", EXAMPLE_VAR2:"example_value 2"}, will
                 inject EXAMPLE_VAR and EXAMPLE_VAR2 into the pod with the mentioned values
     :param template_id: the id of the template to use for the pod
-
+    :param min_download: minimum download speed in Mbps
+    :param min_upload: minimum upload speed in Mbps
     :example:
 
     >>> pod_id = runpod.create_pod("test", "runpod/stack", "NVIDIA GeForce RTX 3070")
@@ -167,6 +170,8 @@ def create_pod(
             template_id,
             network_volume_id,
             allowed_cuda_versions,
+            min_download,
+            min_upload,
         )
     )
 

--- a/runpod/api/mutations/pods.py
+++ b/runpod/api/mutations/pods.py
@@ -28,6 +28,8 @@ def generate_pod_deployment_mutation(
     template_id=None,
     network_volume_id=None,
     allowed_cuda_versions: Optional[List[str]] = None,
+    min_download=None,
+    min_upload=None,
 ):
     """
     Generates a mutation to deploy a pod on demand.
@@ -89,9 +91,14 @@ def generate_pod_deployment_mutation(
         )
         input_fields.append(f"allowedCudaVersions: [{allowed_cuda_versions_string}]")
 
+    if min_download is not None:
+        input_fields.append(f'minDownload: {min_download}')
+
+    if min_upload is not None:
+        input_fields.append(f'minUpload: {min_upload}')
+
     # Format input fields
     input_string = ", ".join(input_fields)
-
     return f"""
     mutation {{
       podFindAndDeployOnDemand(


### PR DESCRIPTION
community pods can have slow network speeds

this PR adds support for the 2 graphQL parameters "minDownload" and "minUpload" to runpod.create_pod