### PR TITLE
fix: pings were missing requestIds since the last big refactor

### DIFF
--- a/runpod/serverless/modules/rp_job.py
+++ b/runpod/serverless/modules/rp_job.py
@@ -14,12 +14,12 @@ from runpod.serverless.modules.rp_logger import RunPodLogger
 
 from ...version import __version__ as runpod_version
 from .rp_tips import check_return_size
-from .worker_state import WORKER_ID, JobsQueue
+from .worker_state import WORKER_ID, REF_COUNT_ZERO, JobsProgress
 
 JOB_GET_URL = str(os.environ.get("RUNPOD_WEBHOOK_GET_JOB")).replace("$ID", WORKER_ID)
 
 log = RunPodLogger()
-job_list = JobsQueue()
+job_progress = JobsProgress()
 
 
 def _job_get_url(batch_size: int = 1):
@@ -32,7 +32,7 @@ def _job_get_url(batch_size: int = 1):
     Returns:
         str: The prepared URL for the 'get' request to the serverless API.
     """
-    job_in_progress = "1" if job_list.get_job_count() else "0"
+    job_in_progress = "1" if job_progress.get_job_count() else "0"
 
     if batch_size > 1:
         job_take_url = JOB_GET_URL.replace("/job-take/", "/job-take-batch/")

--- a/runpod/serverless/modules/rp_ping.py
+++ b/runpod/serverless/modules/rp_ping.py
@@ -22,16 +22,16 @@ jobs = JobsProgress()  # Contains the list of jobs that are currently running.
 class Heartbeat:
     """Sends heartbeats to the Runpod server."""
 
-    PING_URL = os.environ.get("RUNPOD_WEBHOOK_PING", "PING_NOT_SET")
-    PING_URL = PING_URL.replace("$RUNPOD_POD_ID", WORKER_ID)
-    PING_INTERVAL = int(os.environ.get("RUNPOD_PING_INTERVAL", 10000)) // 1000
-
     _thread_started = False
 
     def __init__(self, pool_connections=10, retries=3) -> None:
         """
         Initializes the Heartbeat class.
         """
+        self.PING_URL = os.environ.get("RUNPOD_WEBHOOK_PING", "PING_NOT_SET")
+        self.PING_URL = self.PING_URL.replace("$RUNPOD_POD_ID", WORKER_ID)
+        self.PING_INTERVAL = int(os.environ.get("RUNPOD_PING_INTERVAL", 10000)) // 1000
+
         self._session = SyncClientSession()
         self._session.headers.update(
             {"Authorization": f"{os.environ.get('RUNPOD_AI_API_KEY')}"}
@@ -56,15 +56,15 @@ class Heartbeat:
         """
         Sends heartbeat pings to the Runpod server.
         """
-        if os.environ.get("RUNPOD_AI_API_KEY") is None:
+        if not os.environ.get("RUNPOD_AI_API_KEY"):
             log.debug("Not deployed on RunPod serverless, pings will not be sent.")
             return
 
-        if os.environ.get("RUNPOD_POD_ID") is None:
+        if not os.environ.get("RUNPOD_POD_ID"):
             log.info("Not running on RunPod, pings will not be sent.")
             return
 
-        if self.PING_URL in ["PING_NOT_SET", None]:
+        if (not self.PING_URL) or self.PING_URL == "PING_NOT_SET":
             log.error("Ping URL not set, cannot start ping.")
             return
 

--- a/runpod/serverless/modules/rp_ping.py
+++ b/runpod/serverless/modules/rp_ping.py
@@ -12,11 +12,11 @@ from urllib3.util.retry import Retry
 
 from runpod.http_client import SyncClientSession
 from runpod.serverless.modules.rp_logger import RunPodLogger
-from runpod.serverless.modules.worker_state import WORKER_ID, JobsQueue
+from runpod.serverless.modules.worker_state import WORKER_ID, JobsProgress
 from runpod.version import __version__ as runpod_version
 
 log = RunPodLogger()
-jobs = JobsQueue()  # Contains the list of jobs that are currently running.
+jobs = JobsProgress()  # Contains the list of jobs that are currently running.
 
 
 class Heartbeat:

--- a/runpod/serverless/modules/rp_scale.py
+++ b/runpod/serverless/modules/rp_scale.py
@@ -143,6 +143,11 @@ class JobScaler:
 
             if config.get("refresh_worker", False):
                 self.kill_worker()
+        
+        except Exception as err:
+            log.error(f"Error handling job: {err}", job["id"])
+            raise err
+
         finally:
             # Inform JobsQueue of a task completion
             job_list.task_done()

--- a/runpod/serverless/modules/worker_state.py
+++ b/runpod/serverless/modules/worker_state.py
@@ -33,10 +33,14 @@ class Job:
         id: str,
         input: Optional[Dict[str, Any]] = None,
         webhook: Optional[str] = None,
+        **kwargs
     ) -> None:
         self.id = id
         self.input = input
         self.webhook = webhook
+
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Job):

--- a/runpod/serverless/modules/worker_state.py
+++ b/runpod/serverless/modules/worker_state.py
@@ -5,7 +5,7 @@ Handles getting stuff from environment variables and updating the global state l
 import os
 import time
 import uuid
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 from asyncio import Queue
 
 REF_COUNT_ZERO = time.perf_counter()  # Used for benchmarking with the debugger.
@@ -30,12 +30,12 @@ class Job:
 
     def __init__(
         self,
-        job_id: str,
-        job_input: Optional[Dict[str, Any]] = None,
+        id: str,
+        input: Optional[Dict[str, Any]] = None,
         webhook: Optional[str] = None,
     ) -> None:
-        self.id = job_id
-        self.input = job_input
+        self.id = id
+        self.input = input
         self.webhook = webhook
 
     def __eq__(self, other: object) -> bool:
@@ -53,52 +53,82 @@ class Job:
 # ---------------------------------------------------------------------------- #
 #                                    Tracker                                   #
 # ---------------------------------------------------------------------------- #
-class Jobs:
-    """Track the state of current jobs."""
+class JobsProgress(set):
+    """Track the state of current jobs in progress."""
 
     _instance = None
-    jobs = set()
 
     def __new__(cls):
-        if Jobs._instance is None:
-            Jobs._instance = object.__new__(cls)
-            Jobs._instance.jobs = set()
-        return Jobs._instance
+        if JobsProgress._instance is None:
+            JobsProgress._instance = set.__new__(cls)
+        return JobsProgress._instance
 
-    def add_job(self, job_id, job_input=None, webhook=None):
-        """
-        Adds a job to the list of jobs.
-        """
-        self.jobs.add(Job(job_id, job_input, webhook))
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}>: {self.get_job_list()}"
 
-    def remove_job(self, job_id):
+    def add(self, element: Any):
         """
-        Removes a job from the list of jobs.
-        """
-        self.jobs.remove(Job(job_id))
+        Adds a Job object to the set.
 
-    def get_job(self, job_id) -> Optional[Union[dict, list, str, int, float, bool]]:
+        If the added element is a string, then `Job(id=element)` is added
+        
+        If the added element is a dict, that `Job(**element)` is added
         """
-        Returns the job with the given id.
-        Used within rp_fastapi.py for local testing.
+        if isinstance(element, str):
+            element = Job(id=element)
+
+        if isinstance(element, dict):
+            element = Job(**element)
+
+        if not isinstance(element, Job):
+            raise TypeError("Only Job objects can be added to JobsProgress.")
+
+        return super().add(element)
+
+    def remove(self, element: Any):
         """
-        for job in self.jobs:
-            if job.id == job_id:
+        Adds a Job object to the set.
+
+        If the added element is a string, then `Job(id=element)` is added
+        
+        If the added element is a dict, that `Job(**element)` is added
+        """
+        if isinstance(element, str):
+            element = Job(id=element)
+
+        if isinstance(element, dict):
+            element = Job(**element)
+
+        if not isinstance(element, Job):
+            raise TypeError("Only Job objects can be removed from JobsProgress.")
+
+        return super().remove(element)
+
+    def get(self, element: Any) -> Job:
+        if isinstance(element, str):
+            element = Job(id=element)
+
+        if not isinstance(element, Job):
+            raise TypeError("Only Job objects can be retrieved from JobsProgress.")
+
+        for job in self:
+            if job == element:
                 return job
 
-        return None
-
-    def get_job_list(self):
+    def get_job_list(self) -> str:
         """
-        Returns the list of jobs as a string.
+        Returns the list of job IDs as comma-separated string.
         """
-        return ",".join(str(job) for job in self.jobs) if self.jobs else None
+        if not self.get_job_count():
+            return None
 
-    def get_job_count(self):
+        return ",".join(str(job) for job in self)
+
+    def get_job_count(self) -> int:
         """
         Returns the number of jobs.
         """
-        return len(self.jobs)
+        return len(self)
 
 
 class JobsQueue(Queue):

--- a/tests/test_serverless/test_modules/test_ping.py
+++ b/tests/test_serverless/test_modules/test_ping.py
@@ -3,11 +3,13 @@
 import importlib
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import requests
 
 from runpod.serverless.modules import rp_ping
+from runpod.serverless.modules.rp_ping import Heartbeat
+from runpod.serverless.modules.worker_state import JobsProgress
 
 
 class MockResponse:  # pylint: disable=too-few-public-methods
@@ -91,3 +93,61 @@ class TestPing(unittest.TestCase):
         with patch("runpod.serverless.modules.rp_ping.log.error") as mock_log_error:
             rp_ping.Heartbeat().ping_loop(test=True)
             assert mock_log_error.call_count == 1
+
+
+class TestHeartbeat(unittest.TestCase):
+
+    @patch("runpod.serverless.modules.rp_ping.SyncClientSession")
+    @patch("runpod.serverless.modules.rp_ping.log")
+    @patch("runpod.serverless.modules.rp_ping.Retry")
+    def setUp(self, mock_retry, mock_logger, mock_session):
+        # Mock environment variables
+        os.environ["RUNPOD_AI_API_KEY"] = "test_api_key"
+        os.environ["RUNPOD_POD_ID"] = "test_pod_id"
+        os.environ["RUNPOD_WEBHOOK_PING"] = "http://localhost/ping/$RUNPOD_POD_ID"
+        os.environ["RUNPOD_PING_INTERVAL"] = "10000"
+
+        # Mock instances
+        self.mock_logger = mock_logger
+        self.mock_session = mock_session.return_value
+
+    @patch.dict(os.environ, {"RUNPOD_AI_API_KEY": ""})
+    @patch("runpod.serverless.modules.rp_ping.log")
+    def test_start_ping_no_api_key(self, mock_logger):
+        """Test start_ping method when RUNPOD_AI_API_KEY is missing."""
+        heartbeat = Heartbeat()
+        heartbeat.start_ping()
+        mock_logger.debug.assert_called_once_with(
+            "Not deployed on RunPod serverless, pings will not be sent."
+        )
+
+    @patch("runpod.serverless.modules.rp_ping.log")
+    @patch.dict(os.environ, {"RUNPOD_POD_ID": ""})
+    def test_start_ping_no_pod_id(self, mock_logger):
+        """Test start_ping method when RUNPOD_POD_ID is missing."""
+        heartbeat = Heartbeat()
+        heartbeat.start_ping()
+        mock_logger.info.assert_called_once_with(
+            "Not running on RunPod, pings will not be sent."
+        )
+
+    @patch("runpod.serverless.modules.rp_ping.threading.Thread")
+    def test_start_ping_thread_started(self, mock_thread):
+        """Test that the ping thread is started only once."""
+        heartbeat = Heartbeat()
+        heartbeat._thread_started = False  # Reset thread flag for testing
+        assert not Heartbeat._thread_started
+
+        heartbeat.start_ping()
+        assert Heartbeat._thread_started
+
+        mock_thread.assert_called_once()
+
+    @patch("runpod.serverless.modules.rp_ping.Heartbeat._send_ping")
+    @patch.dict(os.environ, {"RUNPOD_PING_INTERVAL": "0"})
+    def test_ping_loop(self, mock_send_ping):
+        """Test ping_loop runs and exits correctly in test mode."""
+        heartbeat = Heartbeat()
+        heartbeat.ping_loop(test=True)
+        mock_send_ping.assert_called_once()
+

--- a/tests/test_serverless/test_modules/test_state.py
+++ b/tests/test_serverless/test_modules/test_state.py
@@ -4,6 +4,7 @@ import os
 import unittest
 
 from runpod.serverless.modules.worker_state import (
+    Job,
     JobsProgress,
     JobsQueue,
     IS_LOCAL_TEST,
@@ -35,46 +36,6 @@ class TestEnvVars(unittest.TestCase):
         os.environ["RUNPOD_POD_ID"] = WORKER_ID
 
         self.assertEqual(WORKER_ID, os.environ.get("RUNPOD_POD_ID"))
-
-
-import unittest
-from typing import Dict, Any, Optional
-
-# Assuming the Job class is defined as follows:
-class Job:
-    """
-    Represents a job object.
-
-    Args:
-        job_id: The id of the job, a unique string.
-        job_input: The input to the job.
-        webhook: The webhook to send the job output to.
-    """
-
-    def __init__(
-        self,
-        id: str,
-        input: Optional[Dict[str, Any]] = None,
-        webhook: Optional[str] = None,
-        **kwargs
-    ) -> None:
-        self.id = id
-        self.input = input
-        self.webhook = webhook
-
-        for key, value in kwargs.items():
-            setattr(self, key, value)
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, Job):
-            return self.id == other.id
-        return False
-
-    def __hash__(self) -> int:
-        return hash(self.id)
-
-    def __str__(self) -> str:
-        return self.id
 
 
 class TestJob(unittest.TestCase):

--- a/tests/test_serverless/test_modules/test_state.py
+++ b/tests/test_serverless/test_modules/test_state.py
@@ -4,7 +4,7 @@ import os
 import unittest
 
 from runpod.serverless.modules.worker_state import (
-    Job,
+    JobsProgress,
     JobsQueue,
     IS_LOCAL_TEST,
     WORKER_ID,
@@ -38,7 +38,7 @@ class TestEnvVars(unittest.TestCase):
 
 
 class TestJobsQueue(unittest.IsolatedAsyncioTestCase):
-    """Tests for Jobs class"""
+    """Tests for JobsQueue class"""
 
     def setUp(self):
         """
@@ -109,4 +109,67 @@ class TestJobsQueue(unittest.IsolatedAsyncioTestCase):
         assert self.jobs.get_job_count() == 2
         assert job1 in self.jobs
         assert job2 in self.jobs
+        assert self.jobs.get_job_list() in ["123,456", "456,123"]
+
+
+class TestJobsProgress(unittest.TestCase):
+    """Tests for JobsProgress class"""
+
+    def setUp(self):
+        """
+        Set up test variables
+        """
+        self.jobs = JobsProgress()
+
+    def asyncTearDown(self):
+        self.jobs.clear()  # clear jobs before each test
+
+    def test_singleton(self):
+        jobs2 = JobsProgress()
+        self.assertEqual(self.jobs, jobs2)
+
+    def test_add_job(self):
+        assert not self.jobs.get_job_count()
+
+        id = "123"
+        self.jobs.add({"id": id})
+        assert self.jobs.get_job_count() == 1
+
+        job1 = self.jobs.get(id)
+        assert job1 in self.jobs
+
+        id = "234"
+        self.jobs.add(id)
+        assert self.jobs.get_job_count() == 2
+
+        job2 = self.jobs.get(id)
+        assert job2 in self.jobs
+
+    def test_remove_job(self):
+        assert not self.jobs.get_job_count()
+
+        job = {"id": "123"}
+        self.jobs.add(job)
+        assert self.jobs.get_job_count()
+
+        self.jobs.remove("123")
+        assert not self.jobs.get_job_count()
+
+    def test_get_job(self):
+        for id in ["123", "234", "345"]:
+            self.jobs.add({"id": id})
+
+        job1 = self.jobs.get(id)
+        assert job1 in self.jobs
+
+    def test_get_job_list(self):
+        self.assertTrue(self.jobs.get_job_list() is None)
+
+        job1 = {"id": "123"}
+        self.jobs.add(job1)
+
+        job2 = {"id": "456"}
+        self.jobs.add(job2)
+
+        assert self.jobs.get_job_count() == 2
         assert self.jobs.get_job_list() in ["123,456", "456,123"]

--- a/tests/test_serverless/test_modules/test_state.py
+++ b/tests/test_serverless/test_modules/test_state.py
@@ -37,6 +37,105 @@ class TestEnvVars(unittest.TestCase):
         self.assertEqual(WORKER_ID, os.environ.get("RUNPOD_POD_ID"))
 
 
+import unittest
+from typing import Dict, Any, Optional
+
+# Assuming the Job class is defined as follows:
+class Job:
+    """
+    Represents a job object.
+
+    Args:
+        job_id: The id of the job, a unique string.
+        job_input: The input to the job.
+        webhook: The webhook to send the job output to.
+    """
+
+    def __init__(
+        self,
+        id: str,
+        input: Optional[Dict[str, Any]] = None,
+        webhook: Optional[str] = None,
+        **kwargs
+    ) -> None:
+        self.id = id
+        self.input = input
+        self.webhook = webhook
+
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Job):
+            return self.id == other.id
+        return False
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+    def __str__(self) -> str:
+        return self.id
+
+
+class TestJob(unittest.TestCase):
+
+    def test_initialization_with_basic_attributes(self):
+        """Test basic initialization of Job object."""
+        job = Job(id="job_123", input={"task": "data_process"}, webhook="http://example.com/webhook")
+        self.assertEqual(job.id, "job_123")
+        self.assertEqual(job.input, {"task": "data_process"})
+        self.assertEqual(job.webhook, "http://example.com/webhook")
+
+    def test_initialization_with_additional_kwargs(self):
+        """Test initialization with extra kwargs dynamically creating attributes."""
+        job = Job(id="job_456", status="pending", priority=5)
+        self.assertEqual(job.id, "job_456")
+        self.assertEqual(job.status, "pending")
+        self.assertEqual(job.priority, 5)
+
+    def test_equality(self):
+        """Test equality between two Job objects based on the job ID."""
+        job1 = Job(id="job_123")
+        job2 = Job(id="job_123")
+        job3 = Job(id="job_456")
+        
+        self.assertEqual(job1, job2)
+        self.assertNotEqual(job1, job3)
+
+    def test_hashing(self):
+        """Test hashing of Job object based on the job ID."""
+        job1 = Job(id="job_123")
+        job2 = Job(id="job_123")
+        job3 = Job(id="job_456")
+        
+        self.assertEqual(hash(job1), hash(job2))
+        self.assertNotEqual(hash(job1), hash(job3))
+
+    def test_string_representation(self):
+        """Test the string representation of the Job object."""
+        job = Job(id="job_123")
+        self.assertEqual(str(job), "job_123")
+
+    def test_none_input(self):
+        """Test initialization with None values."""
+        job = Job(id="job_123", input=None, webhook=None)
+        self.assertEqual(job.id, "job_123")
+        self.assertIsNone(job.input)
+        self.assertIsNone(job.webhook)
+
+    def test_dynamic_kwargs_assignment(self):
+        """Test if kwargs are dynamically assigned as attributes."""
+        job = Job(id="job_789", foo="bar", custom_attr=42)
+        self.assertEqual(job.foo, "bar")
+        self.assertEqual(job.custom_attr, 42)
+
+    def test_missing_attributes(self):
+        """Test that accessing non-existent attributes raises AttributeError."""
+        job = Job(id="job_123")
+        with self.assertRaises(AttributeError):
+            _ = job.non_existent_attr
+
+
 class TestJobsQueue(unittest.IsolatedAsyncioTestCase):
     """Tests for JobsQueue class"""
 

--- a/tests/test_serverless/test_worker.py
+++ b/tests/test_serverless/test_worker.py
@@ -189,9 +189,9 @@ class TestRunWorker(IsolatedAsyncioTestCase):
 
     @patch("runpod.serverless.worker.AsyncClientSession")
     @patch("runpod.serverless.modules.rp_scale.get_job")
-    @patch("runpod.serverless.modules.rp_scale.run_job")
-    @patch("runpod.serverless.modules.rp_scale.stream_result")
-    @patch("runpod.serverless.modules.rp_scale.send_result")
+    @patch("runpod.serverless.modules.rp_job.run_job")
+    @patch("runpod.serverless.modules.rp_job.stream_result")
+    @patch("runpod.serverless.modules.rp_job.send_result")
     # pylint: disable=too-many-arguments
     async def test_run_worker(
         self,
@@ -227,9 +227,9 @@ class TestRunWorker(IsolatedAsyncioTestCase):
         assert mock_session.called
 
     @patch("runpod.serverless.modules.rp_scale.get_job")
-    @patch("runpod.serverless.modules.rp_scale.run_job")
-    @patch("runpod.serverless.modules.rp_scale.stream_result")
-    @patch("runpod.serverless.modules.rp_scale.send_result")
+    @patch("runpod.serverless.modules.rp_job.run_job")
+    @patch("runpod.serverless.modules.rp_job.stream_result")
+    @patch("runpod.serverless.modules.rp_job.send_result")
     async def test_run_worker_generator_handler(
         self, mock_send_result, mock_stream_result, mock_run_job, mock_get_job
     ):
@@ -257,9 +257,9 @@ class TestRunWorker(IsolatedAsyncioTestCase):
         assert args[1] == {"output": [], "stopPod": True}
 
     @patch("runpod.serverless.modules.rp_scale.get_job")
-    @patch("runpod.serverless.modules.rp_scale.run_job")
-    @patch("runpod.serverless.modules.rp_scale.stream_result")
-    @patch("runpod.serverless.modules.rp_scale.send_result")
+    @patch("runpod.serverless.modules.rp_job.run_job")
+    @patch("runpod.serverless.modules.rp_job.stream_result")
+    @patch("runpod.serverless.modules.rp_job.send_result")
     async def test_run_worker_generator_handler_exception(
         self, mock_send_result, mock_stream_result, mock_run_job, mock_get_job
     ):
@@ -290,9 +290,9 @@ class TestRunWorker(IsolatedAsyncioTestCase):
         assert "error" in args[1], "Expected the error to be reported in the results."
 
     @patch("runpod.serverless.modules.rp_scale.get_job")
-    @patch("runpod.serverless.modules.rp_scale.run_job")
-    @patch("runpod.serverless.modules.rp_scale.stream_result")
-    @patch("runpod.serverless.modules.rp_scale.send_result")
+    @patch("runpod.serverless.modules.rp_job.run_job")
+    @patch("runpod.serverless.modules.rp_job.stream_result")
+    @patch("runpod.serverless.modules.rp_job.send_result")
     async def test_run_worker_generator_aggregate_handler(
         self, mock_send_result, mock_stream_result, mock_run_job, mock_get_job
     ):
@@ -330,9 +330,9 @@ class TestRunWorker(IsolatedAsyncioTestCase):
 
     @patch("runpod.serverless.worker.AsyncClientSession")
     @patch("runpod.serverless.modules.rp_scale.get_job")
-    @patch("runpod.serverless.modules.rp_scale.run_job")
-    @patch("runpod.serverless.modules.rp_scale.stream_result")
-    @patch("runpod.serverless.modules.rp_scale.send_result")
+    @patch("runpod.serverless.modules.rp_job.run_job")
+    @patch("runpod.serverless.modules.rp_job.stream_result")
+    @patch("runpod.serverless.modules.rp_job.send_result")
     # pylint: disable=too-many-arguments
     async def test_run_worker_concurrency(
         self,
@@ -374,9 +374,9 @@ class TestRunWorker(IsolatedAsyncioTestCase):
 
     @patch("runpod.serverless.worker.AsyncClientSession")
     @patch("runpod.serverless.modules.rp_scale.get_job")
-    @patch("runpod.serverless.modules.rp_scale.run_job")
-    @patch("runpod.serverless.modules.rp_scale.stream_result")
-    @patch("runpod.serverless.modules.rp_scale.send_result")
+    @patch("runpod.serverless.modules.rp_job.run_job")
+    @patch("runpod.serverless.modules.rp_job.stream_result")
+    @patch("runpod.serverless.modules.rp_job.send_result")
     # pylint: disable=too-many-arguments
     async def test_run_worker_multi_processing(
         self,
@@ -439,7 +439,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
             assert mock_set_config_args.called
 
     @patch("runpod.serverless.modules.rp_scale.get_job")
-    @patch("runpod.serverless.modules.rp_scale.run_job")
+    @patch("runpod.serverless.modules.rp_job.run_job")
     async def test_run_worker_multi_processing_scaling_up(
         self, mock_run_job, mock_get_job
     ):


### PR DESCRIPTION
- Distinguish JobsQueue(asyncio.Queue) and JobsProgress(set) and reference them appropriately
- Cleaned up JobScaler.process_job --> rp_job.handle_job
- Graceful cleanup when worker is killed
- More tests