### PR TITLE
fix: streamed errors were previously swallowed

### DIFF
--- a/runpod/serverless/modules/rp_job.py
+++ b/runpod/serverless/modules/rp_job.py
@@ -126,9 +126,15 @@ async def handle_job(session: ClientSession, config: Dict[str, Any], job) -> dic
         job_result = {"output": []}
         async for stream_output in generator_output:
             log.debug(f"Stream output: {stream_output}", job["id"])
-            if "error" in stream_output:
+
+            if type(stream_output.get("output")) == dict:
+                if stream_output["output"].get("error"):
+                    stream_output = {"error": str(stream_output["output"]["error"])}
+
+            if stream_output.get("error"):
                 job_result = stream_output
                 break
+
             if config.get("return_aggregate_stream", False):
                 job_result["output"].append(stream_output["output"])
 


### PR DESCRIPTION
This created false-positive completed tasks