### PR TITLE
Fix: handle uncaught exception only for Serverless workers

### DIFF
--- a/runpod/serverless/__init__.py
+++ b/runpod/serverless/__init__.py
@@ -10,7 +10,6 @@ import os
 import signal
 import sys
 import time
-import typing
 from typing import Any, Dict
 
 from runpod.serverless import core
@@ -22,12 +21,6 @@ from .modules.rp_logger import RunPodLogger
 from .modules.rp_progress import progress_update
 
 log = RunPodLogger()
-
-
-def handle_uncaught_exception(exc_type, exc_value, exc_traceback):
-    log.error(f"Uncaught exception | {exc_type}; {exc_value}; {exc_traceback};")
-
-sys.excepthook = handle_uncaught_exception
 
 
 # ---------------------------------------------------------------------------- #

--- a/runpod/serverless/modules/rp_scale.py
+++ b/runpod/serverless/modules/rp_scale.py
@@ -5,6 +5,8 @@ Provides the functionality for scaling the runpod serverless worker.
 
 import asyncio
 import signal
+import sys
+import traceback
 from typing import Any, Dict
 
 from ...http_client import AsyncClientSession, ClientSession, TooManyRequests
@@ -14,6 +16,11 @@ from .worker_state import JobsProgress, IS_LOCAL_TEST
 
 log = RunPodLogger()
 job_progress = JobsProgress()
+
+
+def _handle_uncaught_exception(exc_type, exc_value, exc_traceback):
+    exc = traceback.format_exception(exc_type, exc_value, exc_traceback)
+    log.error(f"Uncaught exception | {exc}")
 
 
 def _default_concurrency_modifier(current_concurrency: int) -> int:

--- a/runpod/serverless/modules/rp_scale.py
+++ b/runpod/serverless/modules/rp_scale.py
@@ -44,8 +44,6 @@ class JobScaler:
     """
 
     def __init__(self, config: Dict[str, Any]):
-        sys.excepthook = _handle_uncaught_exception
- 
         self._shutdown_event = asyncio.Event()
         self.current_concurrency = 1
         self.config = config
@@ -96,6 +94,8 @@ class JobScaler:
         when the user sends a SIGTERM or SIGINT signal. This is typically
         the case when the worker is running in a container.
         """
+        sys.excepthook = _handle_uncaught_exception
+
         try:
             # Register signal handlers for graceful shutdown
             signal.signal(signal.SIGTERM, self.handle_shutdown)

--- a/runpod/serverless/modules/rp_scale.py
+++ b/runpod/serverless/modules/rp_scale.py
@@ -44,6 +44,8 @@ class JobScaler:
     """
 
     def __init__(self, config: Dict[str, Any]):
+        sys.excepthook = _handle_uncaught_exception
+ 
         self._shutdown_event = asyncio.Event()
         self.current_concurrency = 1
         self.config = config

--- a/tests/test_serverless/test_modules/test_scale.py
+++ b/tests/test_serverless/test_modules/test_scale.py
@@ -1,0 +1,53 @@
+import sys
+import traceback
+from unittest import TestCase
+from unittest.mock import patch
+
+from runpod.serverless.modules.rp_scale import _handle_uncaught_exception
+
+
+class TestHandleUncaughtException(TestCase):
+    @patch("runpod.serverless.modules.rp_scale.log")
+    def test__handle_uncaught_exception(self, mock_logger):
+        exc_type = ValueError
+        exc_value = ValueError("This is a test error")
+        exc_traceback = None  # No traceback for simplicity
+
+        _handle_uncaught_exception(exc_type, exc_value, exc_traceback)
+
+        formatted_exception = traceback.format_exception(exc_type, exc_value, exc_traceback)
+
+        mock_logger.error.assert_called_once()
+        log_message = mock_logger.error.call_args[0][0]
+        assert "Uncaught exception | " in log_message
+        assert str(formatted_exception) in log_message
+
+
+    @patch("runpod.serverless.modules.rp_scale.log")
+    def test_handle_uncaught_exception_with_traceback(self, mock_logger):
+        try:
+            raise RuntimeError("This is a runtime error")
+        except RuntimeError:
+            exc_type, exc_value, exc_traceback = traceback.sys.exc_info()
+
+            _handle_uncaught_exception(exc_type, exc_value, exc_traceback)
+
+            formatted_exception = traceback.format_exception(exc_type, exc_value, exc_traceback)
+
+            mock_logger.error.assert_called_once()
+            log_message = mock_logger.error.call_args[0][0]
+            assert "Uncaught exception | " in log_message
+            assert str(formatted_exception) in log_message
+
+
+    @patch("runpod.serverless.modules.rp_scale.log")
+    def test_handle_uncaught_exception_with_no_exception(self, mock_logger):
+        _handle_uncaught_exception(None, None, None)
+
+        mock_logger.error.assert_called_once()
+        log_message = mock_logger.error.call_args[0][0]
+        assert "Uncaught exception | " in log_message
+
+    def test_excepthook_not_set_when_start_not_invoked(self):
+        assert sys.excepthook == sys.__excepthook__
+        assert sys.excepthook != _handle_uncaught_exception

--- a/tests/test_serverless/test_modules/test_scale.py
+++ b/tests/test_serverless/test_modules/test_scale.py
@@ -7,8 +7,11 @@ from runpod.serverless.modules.rp_scale import _handle_uncaught_exception
 
 
 class TestHandleUncaughtException(TestCase):
+    def setUp(self):
+        sys.excepthook = sys.__excepthook__
+
     @patch("runpod.serverless.modules.rp_scale.log")
-    def test__handle_uncaught_exception(self, mock_logger):
+    def test_handle_uncaught_exception(self, mock_logger):
         exc_type = ValueError
         exc_value = ValueError("This is a test error")
         exc_traceback = None  # No traceback for simplicity
@@ -22,13 +25,12 @@ class TestHandleUncaughtException(TestCase):
         assert "Uncaught exception | " in log_message
         assert str(formatted_exception) in log_message
 
-
     @patch("runpod.serverless.modules.rp_scale.log")
     def test_handle_uncaught_exception_with_traceback(self, mock_logger):
         try:
             raise RuntimeError("This is a runtime error")
         except RuntimeError:
-            exc_type, exc_value, exc_traceback = traceback.sys.exc_info()
+            exc_type, exc_value, exc_traceback = sys.exc_info()
 
             _handle_uncaught_exception(exc_type, exc_value, exc_traceback)
 
@@ -38,7 +40,6 @@ class TestHandleUncaughtException(TestCase):
             log_message = mock_logger.error.call_args[0][0]
             assert "Uncaught exception | " in log_message
             assert str(formatted_exception) in log_message
-
 
     @patch("runpod.serverless.modules.rp_scale.log")
     def test_handle_uncaught_exception_with_no_exception(self, mock_logger):

--- a/tests/test_serverless/test_worker.py
+++ b/tests/test_serverless/test_worker.py
@@ -550,7 +550,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
             assert mock_main.called
 
     @patch("runpod.serverless.signal.signal")
-    @patch("runpod.serverless.worker.rp_scale.JobScaler.start")
+    @patch("runpod.serverless.worker.rp_scale.JobScaler.run")
     def test_start_sets_excepthook(self, _, __):
         runpod.serverless.start({})
         assert sys.excepthook == _handle_uncaught_exception


### PR DESCRIPTION
All other SDK functions should not be affected