### PR TITLE
fix: change log to debug

### DIFF
--- a/runpod/serverless/modules/rp_scale.py
+++ b/runpod/serverless/modules/rp_scale.py
@@ -135,7 +135,7 @@ class JobScaler:
         """
         Whether to kill the worker.
         """
-        log.info("Kill worker.")
+        log.debug("Kill worker.")
         self._shutdown_event.set()
 
     def current_occupancy(self) -> int:


### PR DESCRIPTION
Users are concerned by the ‘kill worker’ log message. Move it under `debug` instead of `info`, as it’s just the system signaling the container to terminate.