### PR TITLE
Update async job streaming stop condition and test cases

### DIFF
--- a/runpod/endpoint/asyncio/asyncio_runner.py
+++ b/runpod/endpoint/asyncio/asyncio_runner.py
@@ -1,4 +1,4 @@
-""" Module for running endpoints asynchronously. """
+"""Module for running endpoints asynchronously."""
 
 # pylint: disable=too-few-public-methods,R0801
 
@@ -89,9 +89,14 @@ class Job:
         while True:
             await asyncio.sleep(1)
             stream_partial = await self._fetch_job(source="stream")
-            if stream_partial["status"] not in FINAL_STATES:
+            if (
+                stream_partial["status"] not in FINAL_STATES
+                or len(stream_partial["stream"]) > 0
+            ):
                 for chunk in stream_partial.get("stream", []):
                     yield chunk["output"]
+            elif stream_partial["status"] in FINAL_STATES:
+                break
 
     async def cancel(self) -> dict:
         """Cancels current job

--- a/runpod/endpoint/asyncio/asyncio_runner.py
+++ b/runpod/endpoint/asyncio/asyncio_runner.py
@@ -91,7 +91,7 @@ class Job:
             stream_partial = await self._fetch_job(source="stream")
             if (
                 stream_partial["status"] not in FINAL_STATES
-                or len(stream_partial["stream"]) > 0
+                or len(stream_partial.get("stream", [])) > 0
             ):
                 for chunk in stream_partial.get("stream", []):
                     yield chunk["output"]

--- a/tests/test_endpoint/test_asyncio_runner.py
+++ b/tests/test_endpoint/test_asyncio_runner.py
@@ -1,4 +1,4 @@
-""" Unit tests for the asyncio_runner module. """
+"""Unit tests for the asyncio_runner module."""
 
 # pylint: disable=too-few-public-methods
 
@@ -114,8 +114,6 @@ class TestJob(IsolatedAsyncioTestCase):
             outputs = []
             async for stream_output in job.stream():
                 outputs.append(stream_output)
-                if not responses:  # Break the loop when responses are exhausted
-                    break
 
             assert outputs == ["OUTPUT1", "OUTPUT2"]
 


### PR DESCRIPTION
The async job's streaming method runs indefinitely without specifically calling a break outside of the function. 
This change handles the break when the job is complete AND all the stream data has been consumed. (The stop condition should check for the `{status: "COMPLETED", stream: []}` job response.

This is in sync with the runner stream implementation. The test case has also been updated. 