### PR TITLE
Fix support for API concurrency > 1 by updating Uvicorn launch logic

### DIFF
--- a/runpod/serverless/modules/rp_fastapi.py
+++ b/runpod/serverless/modules/rp_fastapi.py
@@ -271,14 +271,28 @@ class WorkerAPI:
         """
         Starts the Uvicorn server.
         """
-        uvicorn.run(
-            self.rp_app,
-            host=api_host,
-            port=int(api_port),
-            workers=int(api_concurrency),
-            log_level=os.environ.get("UVICORN_LOG_LEVEL", "info"),
-            access_log=False,
-        )
+        if api_concurrency > 1:
+            # For multiple workers, we need to use the module:app format
+            import uvicorn.workers
+            uvicorn.run(
+                "runpod.serverless.modules.rp_fastapi:app",
+                host=api_host,
+                port=int(api_port),
+                workers=int(api_concurrency),
+                log_level=os.environ.get("UVICORN_LOG_LEVEL", "info"),
+                access_log=False,
+                factory=True
+            )
+        else:
+            # For single worker, we can use the app instance directly
+            uvicorn.run(
+                self.rp_app,
+                host=api_host,
+                port=int(api_port),
+                workers=1,
+                log_level=os.environ.get("UVICORN_LOG_LEVEL", "info"),
+                access_log=False
+            )
 
     # ----------------------------- Realtime Endpoint ---------------------------- #
     async def _realtime(self, job: Job):


### PR DESCRIPTION
Fix for the bug when launching the serverless worker locally with api concurrency > 1

I got the following error:
WARNING:  You must pass the application as an import string to enable 'reload' or 'workers'.

As per my issue I created here
https://github.com/runpod/runpod-python/issues/407