### PR TITLE
[fix]: prevent CI job run failures on fork

### DIFF
--- a/.github/workflows/CI-e2e.yml
+++ b/.github/workflows/CI-e2e.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   e2e-build:
     name: Build and push mock-worker Docker image
+    if: github.repository == 'runpod/runpod-python'
     runs-on: ubuntu-latest
     outputs:
       docker_tag: ${{ steps.output_docker_tag.outputs.docker_tag }}


### PR DESCRIPTION
Hi,

This job currently fails on fork due to missing access to secrets.

Adding the ìf`condition with repo prevent the job from running (hence the failure) on forks.

Best,

Didier