### PR TITLE
fix(test): update flashBootType assertion to match enum value

### DIFF
--- a/tests/test_api/test_mutation_endpoints.py
+++ b/tests/test_api/test_mutation_endpoints.py
@@ -42,4 +42,4 @@ class TestGenerateEndpointMutation(unittest.TestCase):
         self.assertIn("scalerValue: 5", result)
         self.assertIn("workersMin: 2", result)
         self.assertIn("workersMax: 4", result)
-        self.assertIn('flashBootType: "FLASHBOOT"', result)
+        self.assertIn("flashBootType: FLASHBOOT", result)


### PR DESCRIPTION
## Summary
- PR #488 changed `flashBootType` from a quoted string to a proper GraphQL enum value but didn't update the test assertion
- Fixes the failing `test_all_fields` test in CI

## Test plan
- [ ] CI unit tests pass (specifically `tests/test_api/test_mutation_endpoints.py::TestGenerateEndpointMutation::test_all_fields`)