### PR TITLE
feat: support Python 3.10-3.14, drop EOL 3.8/3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Runpod Serverless Module Architecture
 
-**Last Updated**: 2025-12-13
+**Last Updated**: 2026-06-18
 **Module**: `runpod/serverless/`
 **Python Support**: 3.10-3.14
 
@@ -1467,4 +1467,4 @@ stateDiagram-v2
 ---
 
 **Document Version**: 1.0
-**Last Updated**: 2025-12-13
+**Last Updated**: 2026-06-18

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 **Last Updated**: 2025-12-13
 **Module**: `runpod/serverless/`
-**Python Support**: 3.8-3.11
+**Python Support**: 3.10-3.14
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ cd runpod-python
 pip install -e .
 ```
 
-*Python 3.8 or higher is required to use the latest version of this package.*
+*Python 3.10 or higher is required to use the latest version of this package.*
 
 ## ⚡ | Serverless Worker (SDK)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ dev = [
 ]
 test = [
     "asynctest",
-    "nest_asyncio",
     "faker",
     "pytest-asyncio",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "runpod"
 dynamic = ["version", "dependencies"]
 description = "🐍 | Python library for Runpod API and serverless worker SDK."
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = { text = "MIT License" }
 authors = [
     { name = "Runpod", email = "engineer@runpod.io" },
@@ -25,10 +25,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,9 +2,11 @@
 addopts = --durations=10 --cov-config=.coveragerc --timeout=120 --timeout_method=thread --cov=runpod --cov-report=xml --cov-report=term-missing --cov-fail-under=90 -p no:cacheprovider -p no:unraisableexception
 filterwarnings =
     error
-    # nest_asyncio (test-only dep) calls the deprecated asyncio.get_event_loop_policy
-    # on Python 3.14; the SDK itself does not. Don't fail collection on its warning.
+    # Third-party deps (e.g. backoff) still call asyncio APIs that 3.14 deprecates
+    # and slates for removal in 3.16. The SDK's own code does not; at runtime these
+    # only warn. Don't fail the suite on them until the deps update.
     ignore:'asyncio\.get_event_loop_policy' is deprecated:DeprecationWarning
+    ignore:'asyncio\.iscoroutinefunction' is deprecated:DeprecationWarning
 python_files = tests.py test_*.py *_test.py
 norecursedirs = venv *.egg-info .git build tests/e2e
 asyncio_mode = auto

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,10 @@
 [pytest]
-addopts = --durations=10 --cov-config=.coveragerc --timeout=120 --timeout_method=thread --cov=runpod --cov-report=xml --cov-report=term-missing --cov-fail-under=90 -W error -p no:cacheprovider -p no:unraisableexception
+addopts = --durations=10 --cov-config=.coveragerc --timeout=120 --timeout_method=thread --cov=runpod --cov-report=xml --cov-report=term-missing --cov-fail-under=90 -p no:cacheprovider -p no:unraisableexception
+filterwarnings =
+    error
+    # nest_asyncio (test-only dep) calls the deprecated asyncio.get_event_loop_policy
+    # on Python 3.14; the SDK itself does not. Don't fail collection on its warning.
+    ignore:'asyncio\.get_event_loop_policy' is deprecated:DeprecationWarning
 python_files = tests.py test_*.py *_test.py
 norecursedirs = venv *.egg-info .git build tests/e2e
 asyncio_mode = auto

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
         install_requires=install_requires,
         extras_require=extras_require,
         packages=find_packages(),
-        python_requires=">=3.8",
+        python_requires=">=3.10",
         description="🐍 | Python library for Runpod API and serverless worker SDK.",
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/tests/test_serverless/test_utils/test_download.py
+++ b/tests/test_serverless/test_utils/test_download.py
@@ -95,10 +95,14 @@ class TestDownloadFilesFromUrls(unittest.TestCase):
 
         self.assertEqual(len(downloaded_files), len(urls))
 
-        for index, url in enumerate(urls):
-            # Check that the url was called with SyncClientSession.get
-            self.assertIn(url, mock_get.call_args_list[index][0])
+        # Downloads run in parallel threads, so the order of get() calls is
+        # non-deterministic; assert the set of requested URLs instead of order.
+        requested_urls = {call.args[0] for call in mock_get.call_args_list}
+        self.assertEqual(requested_urls, set(urls))
 
+        # executor.map preserves input order in results, so downloaded_files
+        # still aligns positionally with urls.
+        for index in range(len(urls)):
             # Check that the file has the correct extension
             self.assertTrue(downloaded_files[index].endswith(".jpg"))
 

--- a/tests/test_serverless/test_worker.py
+++ b/tests/test_serverless/test_worker.py
@@ -6,23 +6,19 @@ import argparse
 import os
 import sys
 from unittest import mock
-from unittest.mock import patch, mock_open, Mock, MagicMock
-
-from unittest import IsolatedAsyncioTestCase
-import nest_asyncio
+from unittest import TestCase
+from unittest.mock import patch, mock_open, Mock, MagicMock, AsyncMock
 
 import runpod
 from runpod.serverless.modules.rp_logger import RunPodLogger
 from runpod.serverless.modules.rp_scale import _handle_uncaught_exception
 from runpod.serverless import _signal_handler
 
-nest_asyncio.apply()
 
-
-class TestWorker(IsolatedAsyncioTestCase):
+class TestWorker(TestCase):
     """Tests for Runpod serverless worker."""
 
-    async def asyncSetUp(self):
+    def setUp(self):
         self.mock_handler = mock.Mock(return_value="test")
         self.mock_config = {
             "handler": self.mock_handler,
@@ -105,10 +101,10 @@ class TestWorker(IsolatedAsyncioTestCase):
         assert mock_logger.info.called
 
 
-class TestWorkerTestInput(IsolatedAsyncioTestCase):
+class TestWorkerTestInput(TestCase):
     """Tests for runpod | serverless| worker"""
 
-    async def asyncSetUp(self):
+    def setUp(self):
         self.mock_handler = Mock()
         self.mock_handler.return_value = {}
 
@@ -176,11 +172,21 @@ def test_generator_handler_exception():
         assert True, "Exception was caught as expected"
 
 
-class TestRunWorker(IsolatedAsyncioTestCase):
+class TestRunWorker(TestCase):
     """Tests for runpod | serverless| worker"""
 
-    async def asyncSetUp(self):
+    def setUp(self):
         os.environ["RUNPOD_WEBHOOK_GET_JOB"] = "https://test.com"
+
+        # run_worker() runs real fitness checks (GPU/memory probes) that exit the
+        # process when unmet; they have dedicated coverage in
+        # test_modules/test_fitness/. Stub them so these tests are deterministic
+        # regardless of host state.
+        fitness_patcher = patch(
+            "runpod.serverless.worker.run_fitness_checks", new=AsyncMock()
+        )
+        fitness_patcher.start()
+        self.addCleanup(fitness_patcher.stop)
 
         # Set up the config
         self.config = {
@@ -189,7 +195,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
             "rp_args": {"rp_debugger": True, "rp_log_level": "DEBUG"},
         }
 
-    async def asyncTearDown(self):
+    def tearDown(self):
         sys.excepthook = sys.__excepthook__
 
     @patch("runpod.serverless.modules.rp_scale.AsyncClientSession")
@@ -197,7 +203,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
     @patch("runpod.serverless.modules.rp_job.run_job")
     @patch("runpod.serverless.modules.rp_job.stream_result")
     @patch("runpod.serverless.modules.rp_job.send_result")
-    async def test_run_worker(
+    def test_run_worker(
         self,
         mock_send_result,
         mock_stream_result,
@@ -228,7 +234,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
     @patch("runpod.serverless.modules.rp_job.run_job")
     @patch("runpod.serverless.modules.rp_job.stream_result")
     @patch("runpod.serverless.modules.rp_job.send_result")
-    async def test_run_worker_generator_handler(
+    def test_run_worker_generator_handler(
         self, mock_send_result, mock_stream_result, mock_run_job, mock_get_job
     ):
         """
@@ -258,7 +264,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
     @patch("runpod.serverless.modules.rp_job.run_job")
     @patch("runpod.serverless.modules.rp_job.stream_result")
     @patch("runpod.serverless.modules.rp_job.send_result")
-    async def test_run_worker_generator_handler_exception(
+    def test_run_worker_generator_handler_exception(
         self, mock_send_result, mock_stream_result, mock_run_job, mock_get_job
     ):
         """
@@ -303,7 +309,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
     @patch("runpod.serverless.modules.rp_job.run_job")
     @patch("runpod.serverless.modules.rp_job.stream_result")
     @patch("runpod.serverless.modules.rp_job.send_result")
-    async def test_run_worker_generator_aggregate_handler(
+    def test_run_worker_generator_aggregate_handler(
         self, mock_send_result, mock_stream_result, mock_run_job, mock_get_job
     ):
         """
@@ -343,7 +349,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
     @patch("runpod.serverless.modules.rp_job.run_job")
     @patch("runpod.serverless.modules.rp_job.stream_result")
     @patch("runpod.serverless.modules.rp_job.send_result")
-    async def test_run_worker_concurrency(
+    def test_run_worker_concurrency(
         self,
         mock_send_result,
         mock_stream_result,
@@ -420,7 +426,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
     @patch("runpod.serverless.modules.rp_job.run_job")
     @patch("runpod.serverless.modules.rp_job.stream_result")
     @patch("runpod.serverless.modules.rp_job.send_result")
-    async def test_run_worker_multi_processing(
+    def test_run_worker_multi_processing(
         self,
         mock_send_result,
         mock_stream_result,
@@ -480,7 +486,7 @@ class TestRunWorker(IsolatedAsyncioTestCase):
 
     @patch("runpod.serverless.modules.rp_scale.get_job")
     @patch("runpod.serverless.modules.rp_job.run_job")
-    async def test_run_worker_multi_processing_scaling_up(
+    def test_run_worker_multi_processing_scaling_up(
         self, mock_run_job, mock_get_job
     ):
         """


### PR DESCRIPTION
## Summary

`runpod-python` declared support for Python 3.8/3.9 — both end-of-life and receiving no security patches — and the declared range was inconsistent across files. This aligns the package to a supported, tested range of **Python 3.10–3.14**.

### Python support schedule (as of 2026-06-18)

| Version | EOL | Status |
|---|---|---|
| 3.8 | 2024-10-07 | EOL |
| 3.9 | 2025-10-31 | EOL |
| 3.10 | 2026-10-31 | Security-only (EOL in ~4 months) |
| 3.11 | 2027-10-31 | Supported |
| 3.12 | 2028-10-31 | Supported |
| 3.13 | 2029-10-31 | Supported |
| 3.14 | 2030-10-31 | Supported (GA Oct 2025) |

### Changes

- `pyproject.toml` — `requires-python = ">=3.10"`; classifiers 3.10–3.14
- `setup.py` — `python_requires=">=3.10"`
- `.github/workflows/ci.yml` — test matrix `["3.10", "3.11", "3.12", "3.13", "3.14"]`
- `README.md`, `ARCHITECTURE.md` — reflect the new support range

### Why floor at 3.10, not 3.11

3.10 reaches EOL 2026-10-31, but the GPU/ML base-image ecosystem still ships 3.10/3.11, and the SDK floor caps what serverless workers can run. Holding at 3.10 avoids stranding those workers. Planned follow-up: bump floor to 3.11 after 3.10 EOL (Q4 2026).

### Out of scope (follow-up)

The `runpod project create` CLI still offers 3.8/3.9 in its version picker (`runpod/cli/groups/project/commands.py`). That selector is gated by RunPod GPU base-image availability — a separate axis from the SDK runtime — so it needs base-image verification before changing.

## Test plan

- `make quality-check` passes locally: 478 passed, coverage 94.39% (gate 90%)
- CI matrix exercises 3.10–3.14