### PR TITLE
test: fix two flaky serverless tests

### DIFF
--- a/tests/test_serverless/test_utils/test_download.py
+++ b/tests/test_serverless/test_utils/test_download.py
@@ -95,10 +95,14 @@ class TestDownloadFilesFromUrls(unittest.TestCase):
 
         self.assertEqual(len(downloaded_files), len(urls))
 
-        for index, url in enumerate(urls):
-            # Check that the url was called with SyncClientSession.get
-            self.assertIn(url, mock_get.call_args_list[index][0])
+        # Downloads run in parallel threads, so the order of get() calls is
+        # non-deterministic; assert the set of requested URLs instead of order.
+        requested_urls = {call.args[0] for call in mock_get.call_args_list}
+        self.assertEqual(requested_urls, set(urls))
 
+        # executor.map preserves input order in results, so downloaded_files
+        # still aligns positionally with urls.
+        for index in range(len(urls)):
             # Check that the file has the correct extension
             self.assertTrue(downloaded_files[index].endswith(".jpg"))
 

--- a/tests/test_serverless/test_worker.py
+++ b/tests/test_serverless/test_worker.py
@@ -6,7 +6,7 @@ import argparse
 import os
 import sys
 from unittest import mock
-from unittest.mock import patch, mock_open, Mock, MagicMock
+from unittest.mock import patch, mock_open, Mock, MagicMock, AsyncMock
 
 from unittest import IsolatedAsyncioTestCase
 import nest_asyncio
@@ -181,6 +181,16 @@ class TestRunWorker(IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self):
         os.environ["RUNPOD_WEBHOOK_GET_JOB"] = "https://test.com"
+
+        # Fitness checks probe real host resources (e.g. available memory) and
+        # exit the process when unmet; they have dedicated coverage in
+        # tests/test_serverless/test_modules/test_fitness/. Stub them here so
+        # run_worker tests are deterministic regardless of host state.
+        fitness_patcher = patch(
+            "runpod.serverless.worker.run_fitness_checks", new=AsyncMock()
+        )
+        fitness_patcher.start()
+        self.addCleanup(fitness_patcher.stop)
 
         # Set up the config
         self.config = {


### PR DESCRIPTION
## Summary

Two tests fail intermittently regardless of source changes, blocking `make quality-check` and CI.

### 1. `TestRunWorker` (test_worker.py) — real memory probe
`run_worker()` calls `asyncio.run(run_fitness_checks())` (`runpod/serverless/worker.py:40`). The `_memory_check` probe reads **real** host memory and `sys.exit(1)`s when <4GB. No `TestRunWorker` test mocked it, so the class failed whenever the host was under memory pressure (`RuntimeError: Insufficient memory: 3.66GB available, 4.0GB required`).

Fix: stub `run_fitness_checks` in `asyncSetUp`. Fitness checks keep dedicated coverage in `tests/test_serverless/test_modules/test_fitness/`.

### 2. `test_download_files_from_urls` — parallel call ordering
`download_files_from_urls` downloads via `ThreadPoolExecutor.map`. The test asserted `mock_get.call_args_list[index]` matched `urls[index]` positionally, but call order across threads is non-deterministic (`executor.map` preserves *result* order, not *call* order).

Fix: assert the set of requested URLs equals the input set. Result-order checks (extension, `open()` call) are unchanged since `executor.map` preserves result order.

## Test plan

Verified deterministic across repeated runs before fixing intent:
- `test_download_files_from_urls`: 10/10 passed (was ~4/5)
- `TestRunWorker`: 9/9 passed across 10 runs
- `make quality-check`: 478 passed, coverage 94.08% (gate 90%)