### PR TITLE
fix(deps): bump cryptography floor to >=48.0.1 for OpenSSL fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ backoff >= 2.2.1
 boto3 >= 1.26.165
 click >= 8.1.7
 colorama >= 0.4.6, < 0.4.7
-cryptography < 47.0.0
+cryptography >= 48.0.1
 fastapi[all] >= 0.94.0
 filelock >= 3.19.1
 paramiko >= 3.3.1


### PR DESCRIPTION
## Problem

`requirements.txt` pins `cryptography < 47.0.0`. With no lower bound, pip resolves to the newest release below 47 → **46.0.7**, which bundles a vulnerable statically-linked OpenSSL (**GHSA-537c-gmf6-5ccf**, per the OpenSSL advisory of 2026-06-09). The fix landed in cryptography **48.0.1**, which the cap excludes — so every install is held back on a vulnerable wheel.

The cap is dependabot-managed and only bumps one major at a time (last bump: #460, `<46` → `<47`). The OpenSSL fix is in a later major, so dependabot hasn't caught up.

## Fix

```diff
-cryptography < 47.0.0
+cryptography >= 48.0.1
```

Sets a floor at the patched version. runpod-python requires Python `>=3.10`; cryptography 48+ requires `>=3.9`, so there is no Python-floor conflict.

## Verification

- Resolves to cryptography 49.0.0, bundling OpenSSL 4.0.1 (9 Jun 2026) — the patched build.
- `make quality-check`: 478 passed, 94.11% coverage.

Fixes #511