### PR TITLE
fix: preserve empty dict handler output

### DIFF
--- a/runpod/serverless/modules/rp_job.py
+++ b/runpod/serverless/modules/rp_job.py
@@ -279,9 +279,6 @@ async def run_job(handler: Callable, job: Dict[str, Any]) -> Dict[str, Any]:
         else:
             run_result = {"output": job_output}
 
-        if run_result.get("output") == {}:
-            run_result.pop("output")
-
         check_return_size(run_result)  # Checks the size of the return body.
 
     except Exception as err:

--- a/tests/test_serverless/test_modules/test_fastapi.py
+++ b/tests/test_serverless/test_modules/test_fastapi.py
@@ -198,6 +198,19 @@ class TestFastAPI(unittest.TestCase):
                 "output": {"result": "success"},
             }
 
+            # Empty dict outputs should be returned as valid results rather
+            # than raising KeyError while building the runsync response.
+            empty_handler = Mock(return_value={})
+            empty_worker_api = rp_fastapi.WorkerAPI({"handler": empty_handler})
+            empty_runsync_return = asyncio.run(
+                empty_worker_api._sim_runsync(default_input_object)
+            )
+            assert empty_runsync_return == {
+                "id": "test-123",
+                "status": "COMPLETED",
+                "output": {},
+            }
+
             # Test with generator handler
             def generator_handler(job):
                 del job

--- a/tests/test_serverless/test_modules/test_job.py
+++ b/tests/test_serverless/test_modules/test_job.py
@@ -15,6 +15,17 @@ from runpod.serverless.modules import rp_job
 class TestJob(IsolatedAsyncioTestCase):
     """Tests for the get_job function."""
 
+    async def test_run_job_preserves_empty_dict_output(self):
+        """Empty dict handler results are valid outputs."""
+
+        def handler(job):
+            del job
+            return {}
+
+        result = await rp_job.run_job(handler, {"id": "test-job", "input": {}})
+
+        self.assertEqual(result, {"output": {}})
+
     async def test_get_job_200(self):
         """Tests the get_job function with a valid 200 response."""
         # Mock the 200 response


### PR DESCRIPTION
## Summary
- Preserve `{}` returned by serverless handlers as a valid `output` payload.
- Add regression coverage for `run_job()` and the local `runsync` simulation path.

## Why this helps
- Fixes #459, where a handler returning an empty dict caused `_sim_runsync()` to raise `KeyError: 'output'` while building the completed response.

## Test Plan
- `pytest tests/test_serverless/test_modules/test_job.py::TestJob::test_run_job_preserves_empty_dict_output tests/test_serverless/test_modules/test_fastapi.py::TestFastAPI::test_runsync -q --no-cov`
- `git diff --check`

Note: the same targeted pytest command without `--no-cov` ran both tests successfully, but the repository-wide coverage gate failed because only two focused tests were selected.
