### PR TITLE
fix: preserve empty dict handler output

### DIFF
--- a/runpod/serverless/modules/rp_job.py
+++ b/runpod/serverless/modules/rp_job.py
@@ -279,9 +279,6 @@ async def run_job(handler: Callable, job: Dict[str, Any]) -> Dict[str, Any]:
         else:
             run_result = {"output": job_output}
 
-        if run_result.get("output") == {}:
-            run_result.pop("output")
-
         check_return_size(run_result)  # Checks the size of the return body.
 
     except Exception as err:

--- a/tests/test_serverless/test_modules/test_fastapi.py
+++ b/tests/test_serverless/test_modules/test_fastapi.py
@@ -198,6 +198,17 @@ class TestFastAPI(unittest.TestCase):
                 "output": {"result": "success"},
             }
 
+            empty_handler = Mock(return_value={})
+            empty_worker_api = rp_fastapi.WorkerAPI({"handler": empty_handler})
+            empty_runsync_return = asyncio.run(
+                empty_worker_api._sim_runsync(default_input_object)
+            )
+            assert empty_runsync_return == {
+                "id": "test-123",
+                "status": "COMPLETED",
+                "output": {},
+            }
+
             # Test with generator handler
             def generator_handler(job):
                 del job
@@ -328,6 +339,16 @@ class TestFastAPI(unittest.TestCase):
                 "id": "test-123",
                 "status": "COMPLETED",
                 "output": {"result": "success"},
+            }
+
+            empty_handler = Mock(return_value={})
+            empty_worker_api = rp_fastapi.WorkerAPI({"handler": empty_handler})
+            asyncio.run(empty_worker_api._sim_run(default_input_object))
+            empty_status_return = asyncio.run(empty_worker_api._sim_status("test-123"))
+            assert empty_status_return == {
+                "id": "test-123",
+                "status": "COMPLETED",
+                "output": {},
             }
 
             # Test webhook caller sent


### PR DESCRIPTION
## Summary
- Stop dropping an empty dict returned by a serverless handler from the normalized job result.
- Add regression coverage for local /runsync and /status simulation paths returning `output: {}`.

## Why this helps
- Fixes #459: handlers that intentionally return `{}` should complete successfully instead of causing local FastAPI simulation to raise `KeyError: 'output'`.

## Test Plan
- [x] `pytest tests/test_serverless/test_modules/test_fastapi.py -q --no-cov` (8 passed)

Note: a targeted run without `--no-cov` also had all 8 tests pass, but failed the repository-wide coverage threshold because only one test file was selected.