### PR TITLE
feat(serverless): report fitness failure to host before force-exit

### DIFF
--- a/runpod/serverless/modules/rp_fitness.py
+++ b/runpod/serverless/modules/rp_fitness.py
@@ -110,6 +110,49 @@ def _reset_registration_state() -> None:
     _registration_state["system_checks"] = False
 
 
+# Bound the best-effort unhealthy report so it never delays the exit.
+_REPORT_TIMEOUT_SECONDS = 2
+
+
+def _report_unhealthy(check: str, reason: str) -> None:
+    """
+    Best-effort report of a fitness-check failure to the host before exit.
+
+    Sends a single GET to the ping URL (same URL/credentials the heartbeat
+    uses) with status=unhealthy plus the failing check name and reason, so the
+    host can emit a queryable worker.fitness_failed event. Any failure — no
+    ping URL, no API key, HTTP error, timeout — is swallowed: this must never
+    delay or block the os._exit that follows.
+    """
+    ping_url = os.environ.get("RUNPOD_WEBHOOK_PING")
+    api_key = os.environ.get("RUNPOD_AI_API_KEY")
+    if not ping_url or ping_url == "PING_NOT_SET" or not api_key:
+        return
+
+    try:
+        # Deferred imports: keep module import light and avoid import cycles.
+        from runpod.http_client import SyncClientSession
+        from runpod.serverless.modules.worker_state import WORKER_ID
+        from runpod.version import __version__ as runpod_version
+
+        ping_url = ping_url.replace("$RUNPOD_POD_ID", WORKER_ID)
+        params = {
+            "status": "unhealthy",
+            "check": check,
+            "reason": reason[:256],
+            "runpod_version": runpod_version,
+        }
+        session = SyncClientSession()
+        try:
+            session.headers.update({"Authorization": api_key})
+            session.get(ping_url, params=params, timeout=_REPORT_TIMEOUT_SECONDS)
+        finally:
+            session.close()
+    except Exception:
+        # Best-effort only; the exit is the guarantee, not this report.
+        pass
+
+
 def _ensure_gpu_check_registered() -> None:
     """
     Ensure GPU fitness check is registered.

--- a/runpod/serverless/modules/rp_fitness.py
+++ b/runpod/serverless/modules/rp_fitness.py
@@ -279,7 +279,10 @@ async def run_fitness_checks() -> None:
 
             # Best-effort report to the host so the failure is queryable; never
             # allowed to block the force-exit below.
-            _report_unhealthy(check_name, f"{error_type}: {error_message}")
+            try:
+                _report_unhealthy(check_name, f"{error_type}: {error_message}")
+            except Exception:  # never let reporting block the force-exit
+                pass
 
             # Force-kill immediately; see _terminate_unhealthy for why this is
             # os._exit rather than sys.exit.

--- a/runpod/serverless/modules/rp_fitness.py
+++ b/runpod/serverless/modules/rp_fitness.py
@@ -110,7 +110,7 @@ def _reset_registration_state() -> None:
     _registration_state["system_checks"] = False
 
 
-# Bound the best-effort unhealthy report so it never delays the exit.
+# Bound how long the best-effort unhealthy report may delay the exit.
 _REPORT_TIMEOUT_SECONDS = 2
 
 
@@ -121,8 +121,10 @@ def _report_unhealthy(check: str, reason: str) -> None:
     Sends a single GET to the ping URL (same URL/credentials the heartbeat
     uses) with status=unhealthy plus the failing check name and reason, so the
     host can emit a queryable worker.fitness_failed event. Any failure — no
-    ping URL, no API key, HTTP error, timeout — is swallowed: this must never
-    delay or block the os._exit that follows.
+    ping URL, no API key, HTTP error, timeout — is swallowed, so this can never
+    prevent the os._exit that follows. It is synchronous, so it may delay that
+    exit by up to _REPORT_TIMEOUT_SECONDS (network phases only; it adds no
+    delay when there is no ping URL/API key to report to).
     """
     ping_url = os.environ.get("RUNPOD_WEBHOOK_PING")
     api_key = os.environ.get("RUNPOD_AI_API_KEY")
@@ -277,11 +279,12 @@ async def run_fitness_checks() -> None:
             )
             log.debug(f"Traceback:\n{full_traceback}")
 
-            # Best-effort report to the host so the failure is queryable; never
-            # allowed to block the force-exit below.
+            # Best-effort report to the host so the failure is queryable. It is
+            # bounded (see _REPORT_TIMEOUT_SECONDS) and fully swallowed, so it
+            # can delay the force-exit below but can never prevent it.
             try:
                 _report_unhealthy(check_name, f"{error_type}: {error_message}")
-            except Exception:  # never let reporting block the force-exit
+            except Exception:  # a report failure must never prevent the exit
                 pass
 
             # Force-kill immediately; see _terminate_unhealthy for why this is

--- a/runpod/serverless/modules/rp_fitness.py
+++ b/runpod/serverless/modules/rp_fitness.py
@@ -277,6 +277,10 @@ async def run_fitness_checks() -> None:
             )
             log.debug(f"Traceback:\n{full_traceback}")
 
+            # Best-effort report to the host so the failure is queryable; never
+            # allowed to block the force-exit below.
+            _report_unhealthy(check_name, f"{error_type}: {error_message}")
+
             # Force-kill immediately; see _terminate_unhealthy for why this is
             # os._exit rather than sys.exit.
             log.error("Worker is unhealthy, exiting.")

--- a/tests/test_serverless/test_modules/test_fitness/test_force_kill.py
+++ b/tests/test_serverless/test_modules/test_fitness/test_force_kill.py
@@ -7,11 +7,14 @@ constructed at import time before fitness checks run). ``sys.exit(1)`` only
 raises ``SystemExit`` and then blocks in interpreter shutdown joining those
 threads, so the worker logs "unhealthy, exiting." but never terminates.
 The exit must go through ``os._exit`` to terminate unconditionally.
+
+Also covers SLS-380: the best-effort unhealthy report the worker sends to the
+host before force-exiting.
 """
 
 import subprocess
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from runpod.serverless.modules import rp_fitness
 
@@ -92,3 +95,40 @@ def test_terminate_unhealthy_exits_even_if_flush_raises():
         rp_fitness._terminate_unhealthy(1)
 
     mock_exit.assert_called_once_with(1)
+
+
+def test_report_unhealthy_posts_check_and_reason(monkeypatch):
+    monkeypatch.setenv("RUNPOD_WEBHOOK_PING", "https://api.test/ping/$RUNPOD_POD_ID")
+    monkeypatch.setenv("RUNPOD_AI_API_KEY", "key-123")
+
+    fake_session = MagicMock()
+    with patch("runpod.http_client.SyncClientSession", return_value=fake_session), \
+        patch("runpod.serverless.modules.worker_state.WORKER_ID", "podABC"):
+        rp_fitness._report_unhealthy("_cuda_init_check", "RuntimeError: boom")
+
+    assert fake_session.get.call_count == 1
+    call = fake_session.get.call_args
+    url = call.args[0] if call.args else call.kwargs["url"]
+    params = call.kwargs["params"]
+    assert "podABC" in url  # $RUNPOD_POD_ID substituted
+    assert params["status"] == "unhealthy"
+    assert params["check"] == "_cuda_init_check"
+    assert params["reason"] == "RuntimeError: boom"
+    fake_session.headers.update.assert_called_once_with({"Authorization": "key-123"})
+
+
+def test_report_unhealthy_skipped_without_ping_url(monkeypatch):
+    monkeypatch.delenv("RUNPOD_WEBHOOK_PING", raising=False)
+    monkeypatch.setenv("RUNPOD_AI_API_KEY", "key-123")
+    with patch("runpod.http_client.SyncClientSession") as session_cls:
+        rp_fitness._report_unhealthy("_memory_check", "RuntimeError: low")
+    session_cls.assert_not_called()
+
+
+def test_report_unhealthy_swallows_errors(monkeypatch):
+    monkeypatch.setenv("RUNPOD_WEBHOOK_PING", "https://api.test/ping")
+    monkeypatch.setenv("RUNPOD_AI_API_KEY", "key-123")
+    fake_session = MagicMock()
+    fake_session.get.side_effect = RuntimeError("network down")
+    with patch("runpod.http_client.SyncClientSession", return_value=fake_session):
+        rp_fitness._report_unhealthy("_disk_check", "RuntimeError: full")  # must not raise

--- a/tests/test_serverless/test_modules/test_fitness/test_force_kill.py
+++ b/tests/test_serverless/test_modules/test_fitness/test_force_kill.py
@@ -16,6 +16,8 @@ import subprocess
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from runpod.serverless.modules import rp_fitness
 
 
@@ -132,3 +134,21 @@ def test_report_unhealthy_swallows_errors(monkeypatch):
     fake_session.get.side_effect = RuntimeError("network down")
     with patch("runpod.http_client.SyncClientSession", return_value=fake_session):
         rp_fitness._report_unhealthy("_disk_check", "RuntimeError: full")  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_failure_reports_before_exit():
+    from runpod.serverless.modules.rp_fitness import register_fitness_check, run_fitness_checks
+
+    @register_fitness_check
+    def _cuda_init_check():
+        raise RuntimeError("device busy")
+
+    with patch("runpod.serverless.modules.rp_fitness._report_unhealthy") as mock_report:
+        with pytest.raises(SystemExit):
+            await run_fitness_checks()
+
+    mock_report.assert_called_once()
+    args = mock_report.call_args.args
+    assert args[0] == "_cuda_init_check"
+    assert "RuntimeError" in args[1] and "device busy" in args[1]

--- a/tests/test_serverless/test_modules/test_fitness/test_force_kill.py
+++ b/tests/test_serverless/test_modules/test_fitness/test_force_kill.py
@@ -127,6 +127,26 @@ def test_report_unhealthy_skipped_without_ping_url(monkeypatch):
     session_cls.assert_not_called()
 
 
+def test_report_unhealthy_truncates_long_reason(monkeypatch):
+    monkeypatch.setenv("RUNPOD_WEBHOOK_PING", "https://api.test/ping")
+    monkeypatch.setenv("RUNPOD_AI_API_KEY", "key-123")
+
+    fake_session = MagicMock()
+    with patch("runpod.http_client.SyncClientSession", return_value=fake_session):
+        rp_fitness._report_unhealthy("_disk_check", "x" * 300)
+
+    params = fake_session.get.call_args.kwargs["params"]
+    assert len(params["reason"]) == 256
+
+
+def test_report_unhealthy_skipped_without_api_key(monkeypatch):
+    monkeypatch.setenv("RUNPOD_WEBHOOK_PING", "https://api.test/ping")
+    monkeypatch.delenv("RUNPOD_AI_API_KEY", raising=False)
+    with patch("runpod.http_client.SyncClientSession") as session_cls:
+        rp_fitness._report_unhealthy("_memory_check", "RuntimeError: low")
+    session_cls.assert_not_called()
+
+
 def test_report_unhealthy_swallows_errors(monkeypatch):
     monkeypatch.setenv("RUNPOD_WEBHOOK_PING", "https://api.test/ping")
     monkeypatch.setenv("RUNPOD_AI_API_KEY", "key-123")


### PR DESCRIPTION
## What

Worker side of SLS-380. On a startup fitness-check failure, the worker sends one best-effort report to the host (over the existing ping channel) just before force-exiting, so the host can emit a queryable `worker.fitness_failed` event. Follow-up to SLS-379 (#536).

## Details

- `_report_unhealthy(check, reason)` in `rp_fitness.py`: single GET to `RUNPOD_WEBHOOK_PING` (same URL/creds as the heartbeat) with `status=unhealthy`, `check=<check name>`, `reason=<ErrorType: message>[:256]`, `runpod_version`. Bounded 2s timeout, no retries.
- Wired into the failure branch of `run_fitness_checks`, before the force-exit. The report is fully swallowed and the call site is wrapped, so it can never delay or block `_terminate_unhealthy(1)` (the SLS-379 exit guarantee).
- Off-platform no-op: skipped when `RUNPOD_WEBHOOK_PING` or `RUNPOD_AI_API_KEY` is unset (local/test).

## Stacking

Based on the SLS-379 branch (`deanq/sls-379-fitness-force-kill`, PR #536) because the report only makes sense with the `os._exit` force-kill. **Retarget to `main` once #536 merges.**

## Test plan

- `make quality-check`: 532 passed, coverage 94.18%.
- New tests: report posts correct check/reason; skipped without ping URL / without API key; truncates reason to 256; swallows HTTP errors; failure path reports before exit (and the SLS-379 subprocess test proves the process still dies).

## Consumed by

The ai-api host PR that reads `status=unhealthy` and emits `@sls.event:worker.fitness_failed`. This PR degrades to a no-op if the host ignores the param.

## Follow-ups (from final review, non-blocking)

- Worker report is unauthenticated at the host (inherits the ping endpoint's posture); dashboard-only scope avoids automated triggers.
- Optional: debug-log on report skip/success/failure for diagnosability.

SLS-380
