### PR TITLE
ci: add automated Linear release tracking (SLS-171)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -103,7 +103,7 @@ jobs:
           verbose: true
 
   # ──────────────────────────────────────────────
-  # Linear release tracking (SLS-171)
+  # Linear release tracking
   # ──────────────────────────────────────────────
 
   linear-sync:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -102,6 +102,42 @@ jobs:
         with:
           verbose: true
 
+  # ──────────────────────────────────────────────
+  # Linear release tracking (SLS-171)
+  # ──────────────────────────────────────────────
+
+  linear-sync:
+    name: Linear Release Sync
+    needs: release-please
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}
+          command: sync
+          version: ${{ needs.release-please.outputs.tag_name }}
+          name: ${{ needs.release-please.outputs.tag_name && format('runpod-python {0}', needs.release-please.outputs.tag_name) || '' }}
+
+  linear-complete:
+    name: Linear Release Complete
+    if: ${{ needs.release-please.outputs.release_created }}
+    needs: [release-please, linear-sync]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}
+          command: complete
+          version: ${{ needs.release-please.outputs.tag_name }}
+
   # TODO: Re-enable after optimizing (17 parallel jobs each sleeping 5min is wasteful).
   #        Consider a single job that sleeps once then dispatches sequentially.
   # notify-workers:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -110,6 +110,8 @@ jobs:
     name: Linear Release Sync
     needs: release-please
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
         with:
@@ -127,6 +129,8 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     needs: [release-please, linear-sync]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Adds `linear-sync` + `linear-complete` jobs to `.github/workflows/cd.yml`, keyed off the existing `release-please` job (mirrors the `main-ui` reference). Sync runs after every release-please run on `main`; complete runs only when a release is actually created.
## Requirements
- Repo/org secret **`LINEAR_RELEASE_ACCESS_KEY`** must be set (same secret already used by `main-ui`).

Implements SLS-171 (part of SLS-160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)