### PR TITLE
chore: correct brand casing to Runpod in docs

### DIFF
--- a/docs/serverless/worker_fitness_checks.md
+++ b/docs/serverless/worker_fitness_checks.md
@@ -407,7 +407,7 @@ User-registered checks via `@register_fitness_check` still run regardless of the
 
 - Fitness checks run **only once at worker startup**
 - They run **before the first job is processed**
-- They run **only on the actual RunPod serverless platform**
+- They run **only on the actual Runpod serverless platform**
 - Local development and testing modes skip fitness checks
 
 ### Execution Order
@@ -653,7 +653,7 @@ if __name__ == "__main__":
 
 ### Checks Aren't Running
 
-Fitness checks only run on the actual RunPod serverless platform, not locally. To debug locally:
+Fitness checks only run on the actual Runpod serverless platform, not locally. To debug locally:
 
 ```python
 # Manually test your fitness checks


### PR DESCRIPTION
Corrects the brand casing of the company name in documentation: `RunPod` -> `Runpod`.

The company name is **Runpod** (capital R, lowercase p). `RunPod` was the official styling before the June 2025 rebrand, which is why it lingers across older docs.

### Scope
Markdown/MDX prose only. Deliberately **not** touched:
- Code identifiers (`RunPodClient`, `RunPodLogger`, `ChatRunPod`, `RunPodProvider`, ...)
- Anything inside fenced code blocks or inline `code` spans
- URLs (including `reddit.com/r/RunPod`, whose path cannot be renamed)
- Env vars (`RUNPOD_API_KEY`) and literal identifiers like `RunPod-Key-Go`

No code, behavior, or public API changes. Docs text only.

### Why it matters beyond tidiness
READMEs and docs are heavily crawled and are a large share of what LLMs and answer engines ingest about Runpod. Consistent casing at the source is how the correct spelling propagates into AI-generated answers over time.

Part of a company-wide brand-casing sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)