### PR TITLE
feat: SLS-389: add batch ID to log messages

### DIFF
--- a/runpod/serverless/modules/rp_logger.py
+++ b/runpod/serverless/modules/rp_logger.py
@@ -10,12 +10,24 @@ WARN - 3 - An indication that something unexpected happened.
 ERROR - 4 - Serious problem, the software has not been able to perform some function.
 """
 
+from contextvars import ContextVar, Token
 import json
 import os
 from typing import Optional
 
 MAX_MESSAGE_LENGTH = 4096
 LOG_LEVELS = ["NOTSET", "TRACE", "DEBUG", "INFO", "WARN", "ERROR"]
+_batch_id: ContextVar[Optional[str]] = ContextVar("runpod_batch_id", default=None)
+
+
+def _set_batch_id(batch_id: Optional[str]) -> Token:
+    """Set the batch ID associated with the current job task."""
+    return _batch_id.set(batch_id)
+
+
+def _reset_batch_id(token: Token):
+    """Restore the previous batch ID for the current job task."""
+    _batch_id.reset(token)
 
 
 def _validate_log_level(log_level):
@@ -74,6 +86,9 @@ class RunPodLogger:
             return
 
         message = str(message)
+        if batch_id := _batch_id.get():
+            message = f"[batchId={batch_id}] {message}"
+
         # Truncate message over 10MB, remove chunk from the middle
         if len(message) > MAX_MESSAGE_LENGTH:
             half_max_length = MAX_MESSAGE_LENGTH // 2

--- a/runpod/serverless/modules/rp_scale.py
+++ b/runpod/serverless/modules/rp_scale.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Set
 
 from ...http_client import AsyncClientSession, ClientSession, TooManyRequests
 from .rp_job import _job_stop_url, get_job, get_stop_signals, handle_job
-from .rp_logger import RunPodLogger
+from .rp_logger import RunPodLogger, _reset_batch_id, _set_batch_id
 from .worker_state import JobsProgress, IS_LOCAL_TEST
 
 log = RunPodLogger()
@@ -342,6 +342,7 @@ class JobScaler:
         """
         Process an individual job. This function is run concurrently for multiple jobs.
         """
+        batch_id_token = _set_batch_id(job.get("batchId"))
         try:
             log.debug("Handling Job", job["id"])
 
@@ -359,11 +360,14 @@ class JobScaler:
             raise
 
         finally:
-            # Inform Queue of a task completion
-            self.jobs_queue.task_done()
+            try:
+                # Inform Queue of a task completion
+                self.jobs_queue.task_done()
 
-            # Job is no longer in progress
-            self.job_progress.remove(job)
-            self.jobs_tasks.pop(job["id"], None)
+                # Job is no longer in progress
+                self.job_progress.remove(job)
+                self.jobs_tasks.pop(job["id"], None)
 
-            log.debug("Finished Job", job["id"])
+                log.debug("Finished Job", job["id"])
+            finally:
+                _reset_batch_id(batch_id_token)

--- a/runpod/serverless/modules/rp_scale.py
+++ b/runpod/serverless/modules/rp_scale.py
@@ -360,14 +360,12 @@ class JobScaler:
             raise
 
         finally:
-            try:
-                # Inform Queue of a task completion
-                self.jobs_queue.task_done()
+            # Inform Queue of a task completion
+            self.jobs_queue.task_done()
 
-                # Job is no longer in progress
-                self.job_progress.remove(job)
-                self.jobs_tasks.pop(job["id"], None)
+            # Job is no longer in progress
+            self.job_progress.remove(job)
+            self.jobs_tasks.pop(job["id"], None)
 
-                log.debug("Finished Job", job["id"])
-            finally:
-                _reset_batch_id(batch_id_token)
+            log.debug("Finished Job", job["id"])
+            _reset_batch_id(batch_id_token)


### PR DESCRIPTION
## Summary

When batchId is set on a particular job, this threads batch id through and sets it via a context var for workers so that jobs associated with a particular batch include the batch id in log statements.

- scope batch IDs to each concurrently executing job with ContextVar
- prefix RunPodLogger messages with [batchId=...]
- reset batch context after the existing job cleanup flow

## Motivation
The existing Tinybird log pipeline preserves message text but drops additional structured fields. Adding the batch token to the message enables filtering without a Tinybird schema migration.

## Verification
- Python module compilation
- git diff --check
- independent code review passed with no blocking findings

## Related
- Linear: https://linear.app/runpod/issue/SLS-389/per-batch-log-filtering-filter-logs-by-batch-id
- ai-api: https://github.com/runpod/ai-api/pull/984
- main-ui: https://github.com/runpod/main-ui/pull/4606