### PR TITLE
feat: support template README content

### DIFF
--- a/runpod/api/ctl_commands.py
+++ b/runpod/api/ctl_commands.py
@@ -282,6 +282,7 @@ def create_template(
     env: dict = None,
     is_serverless: bool = False,
     registry_auth_id: str = None,
+    readme: str = None,
 ):
     """
     Create a template
@@ -298,6 +299,7 @@ def create_template(
                 inject EXAMPLE_VAR and EXAMPLE_VAR2 into the pod with the mentioned values
     :param is_serverless: is the template serverless?
     :param registry_auth_id: the id of the registry auth
+    :param readme: the README content to associate with the template
 
     :example:
 
@@ -315,6 +317,7 @@ def create_template(
             env=env,
             is_serverless=is_serverless,
             registry_auth_id=registry_auth_id,
+            readme=readme,
         )
     )
 

--- a/runpod/api/mutations/templates.py
+++ b/runpod/api/mutations/templates.py
@@ -14,6 +14,7 @@ def generate_pod_template(
     env: dict = None,
     is_serverless: bool = False,
     registry_auth_id: str = None,
+    readme: str = None,
 ):
     """Generate a string for a GraphQL mutation to create a new pod template."""
     input_fields = [f'name: "{name}"', f'imageName: "{image_name}"']
@@ -59,7 +60,18 @@ def generate_pod_template(
     else:
         input_fields.append('containerRegistryAuthId : ""')
 
-    input_fields.extend(("startSsh: true", "isPublic: false", 'readme: ""'))
+    if readme is not None:
+        readme = (
+            readme.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+        )
+        input_fields.append(f'readme: "{readme}"')
+    else:
+        input_fields.append('readme: ""')
+
+    input_fields.extend(("startSsh: true", "isPublic: false"))
     # Format the input fields into a string
     input_fields_string = ", ".join(input_fields)
 

--- a/tests/test_api/test_mutations_templates.py
+++ b/tests/test_api/test_mutations_templates.py
@@ -19,6 +19,7 @@ class TestGeneratePodTemplate(unittest.TestCase):
         self.assertIn('ports: ""', result)  # Defaults
         self.assertIn("env: []", result)  # Defaults
         self.assertIn("isServerless: false", result)  # Defaults
+        self.assertIn('readme: ""', result)  # Defaults
 
     def test_optional_fields(self):
         """Test the optional fields are present in the generated template"""
@@ -43,3 +44,13 @@ class TestGeneratePodTemplate(unittest.TestCase):
         )
         self.assertIn("isServerless: true", result)
         self.assertIn('containerRegistryAuthId : "test_auth"', result)
+
+    def test_readme_is_escaped_and_included(self):
+        """Test that README content is included as a GraphQL string."""
+        result = generate_pod_template(
+            "test_name",
+            "test_image_name",
+            readme='line one "quoted"\nline two',
+        )
+
+        self.assertIn('readme: "line one \\"quoted\\"\\nline two"', result)


### PR DESCRIPTION
## Summary

- add an optional `readme` argument to `runpod.create_template()`
- include and escape the README content in the `saveTemplate` GraphQL mutation
- add coverage for defaults and multiline/quoted README values

Closes #461.

## Validation

- `uv run --group test pytest -q --no-cov tests/test_api/test_mutations_templates.py` — 3 passed
- `uv run --group test pytest -q --no-cov tests/test_api/test_ctl_commands.py` — 16 passed
- `python3 -m py_compile runpod/api/mutations/templates.py runpod/api/ctl_commands.py`
- `git diff --check`

The repository's default coverage threshold is not meaningful for a targeted test invocation, so the focused runs use `--no-cov`; the tests themselves pass.
