### PR TITLE
fix: match dev server webhook payload to cloud format

### DIFF
--- a/runpod/serverless/modules/rp_fastapi.py
+++ b/runpod/serverless/modules/rp_fastapi.py
@@ -2,6 +2,7 @@
 
 import os
 import threading
+import time
 import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
@@ -323,6 +324,8 @@ class WorkerAPI:
         assigned_job_id = f"test-{uuid.uuid4()}"
         job = TestJob(id=assigned_job_id, input=job_request.input)
 
+        job_start = time.time()
+
         if is_generator(self.config["handler"]):
             generator_output = run_job_generator(self.config["handler"], job.__dict__)
             job_output = {"output": []}
@@ -331,18 +334,36 @@ class WorkerAPI:
         else:
             job_output = await run_job(self.config["handler"], job.__dict__)
 
-        if job_output.get("error", None):
-            return jsonable_encoder(
-                {"id": job.id, "status": "FAILED", "error": job_output["error"]}
-            )
+        execution_time = int((time.time() - job_start) * 1000)
+
+        is_error = job_output.get("error", None)
+        status = "FAILED" if is_error else "COMPLETED"
 
         if job_request.webhook:
+            webhook_payload = {
+                "id": job.id,
+                "status": status,
+                "input": job_request.input,
+                "webhook": job_request.webhook,
+                "delayTime": 0,
+                "executionTime": execution_time,
+            }
+            if is_error:
+                webhook_payload["error"] = job_output["error"]
+            else:
+                webhook_payload["output"] = job_output["output"]
+
             thread = threading.Thread(
                 target=_send_webhook,
-                args=(job_request.webhook, job_output),
+                args=(job_request.webhook, webhook_payload),
                 daemon=True,
             )
             thread.start()
+
+        if is_error:
+            return jsonable_encoder(
+                {"id": job.id, "status": "FAILED", "error": job_output["error"]}
+            )
 
         return jsonable_encoder(
             {"id": job.id, "status": "COMPLETED", "output": job_output["output"]}
@@ -359,6 +380,8 @@ class WorkerAPI:
 
         job = TestJob(id=job_id, input=stashed_job.input)
 
+        job_start = time.time()
+
         if is_generator(self.config["handler"]):
             generator_output = run_job_generator(self.config["handler"], job.__dict__)
             stream_accumulator = []
@@ -373,12 +396,22 @@ class WorkerAPI:
                 }
             )
 
+        execution_time = int((time.time() - job_start) * 1000)
         job_list.remove(job.id)
 
         if stashed_job.webhook:
+            webhook_payload = {
+                "id": job_id,
+                "status": "COMPLETED",
+                "output": stream_accumulator,
+                "input": stashed_job.input,
+                "webhook": stashed_job.webhook,
+                "delayTime": 0,
+                "executionTime": execution_time,
+            }
             thread = threading.Thread(
                 target=_send_webhook,
-                args=(stashed_job.webhook, stream_accumulator),
+                args=(stashed_job.webhook, webhook_payload),
                 daemon=True,
             )
             thread.start()
@@ -398,6 +431,8 @@ class WorkerAPI:
 
         job = TestJob(id=stashed_job.id, input=stashed_job.input)
 
+        job_start = time.time()
+
         if is_generator(self.config["handler"]):
             generator_output = run_job_generator(self.config["handler"], job.__dict__)
             job_output = {"output": []}
@@ -406,20 +441,37 @@ class WorkerAPI:
         else:
             job_output = await run_job(self.config["handler"], job.__dict__)
 
+        execution_time = int((time.time() - job_start) * 1000)
         job_list.remove(job.id)
 
-        if job_output.get("error", None):
-            return jsonable_encoder(
-                {"id": job_id, "status": "FAILED", "error": job_output["error"]}
-            )
+        is_error = job_output.get("error", None)
+        status = "FAILED" if is_error else "COMPLETED"
 
         if stashed_job.webhook:
+            webhook_payload = {
+                "id": job_id,
+                "status": status,
+                "input": stashed_job.input,
+                "webhook": stashed_job.webhook,
+                "delayTime": 0,
+                "executionTime": execution_time,
+            }
+            if is_error:
+                webhook_payload["error"] = job_output["error"]
+            else:
+                webhook_payload["output"] = job_output["output"]
+
             thread = threading.Thread(
                 target=_send_webhook,
-                args=(stashed_job.webhook, job_output),
+                args=(stashed_job.webhook, webhook_payload),
                 daemon=True,
             )
             thread.start()
+
+        if is_error:
+            return jsonable_encoder(
+                {"id": job_id, "status": "FAILED", "error": job_output["error"]}
+            )
 
         return jsonable_encoder(
             {"id": job_id, "status": "COMPLETED", "output": job_output["output"]}

--- a/tests/test_serverless/test_modules/test_fastapi.py
+++ b/tests/test_serverless/test_modules/test_fastapi.py
@@ -220,9 +220,34 @@ class TestFastAPI(unittest.TestCase):
             )
             assert "error" in error_runsync_return
 
-            # Test webhook caller sent
+            # Test webhook caller sent with full cloud-parity payload
             asyncio.run(worker_api._sim_runsync(input_object_with_webhook))
             assert mock_threading.Thread.called
+            webhook_kwargs = mock_threading.Thread.call_args
+            webhook_payload = webhook_kwargs[1]["args"][1] if "args" in webhook_kwargs[1] else webhook_kwargs[0][0][1] if webhook_kwargs[0] else webhook_kwargs[1]["args"][1]
+            # Extract payload from the positional args passed to Thread(target=..., args=(...))
+            call_args = mock_threading.Thread.call_args
+            payload = call_args.kwargs.get("args", call_args[1].get("args", (None, None)))[1]
+            assert "id" in payload
+            assert payload["status"] == "COMPLETED"
+            assert "input" in payload
+            assert "webhook" in payload
+            assert "delayTime" in payload
+            assert "executionTime" in payload
+            assert "output" in payload
+
+            # Test webhook fires on error too (fixes #410)
+            mock_threading.reset_mock()
+            error_input_with_webhook = rp_fastapi.DefaultRequest(
+                input={"test_input": "test_input"}, webhook="test_webhook"
+            )
+            error_worker_api_wh = rp_fastapi.WorkerAPI({"handler": self.error_handler})
+            asyncio.run(error_worker_api_wh._sim_runsync(error_input_with_webhook))
+            assert mock_threading.Thread.called, "Webhook must fire on failed jobs"
+            call_args = mock_threading.Thread.call_args
+            payload = call_args.kwargs.get("args", call_args[1].get("args", (None, None)))[1]
+            assert payload["status"] == "FAILED"
+            assert "error" in payload
 
 
     @pytest.mark.asyncio
@@ -330,10 +355,18 @@ class TestFastAPI(unittest.TestCase):
                 "output": {"result": "success"},
             }
 
-            # Test webhook caller sent
+            # Test webhook caller sent with full cloud-parity payload
             asyncio.run(worker_api._sim_run(input_object_with_webhook))
             asyncio.run(worker_api._sim_status("test-123"))
             assert mock_threading.Thread.called
+            call_args = mock_threading.Thread.call_args
+            payload = call_args.kwargs.get("args", call_args[1].get("args", (None, None)))[1]
+            assert "id" in payload
+            assert payload["status"] == "COMPLETED"
+            assert "input" in payload
+            assert "webhook" in payload
+            assert "delayTime" in payload
+            assert "executionTime" in payload
 
             # Test with generator handler
             def generator_handler(job):


### PR DESCRIPTION
## Summary

- **Dev server webhook payloads now match the cloud format** — includes `id`, `status`, `input`, `webhook`, `delayTime`, and `executionTime` fields alongside `output`/`error`
- **Webhooks now fire on failed jobs** — previously the error path returned before reaching the webhook dispatch code
- **Execution timing tracked** via `time.time()` so `executionTime` reports real milliseconds (`delayTime` is always `0` in local dev since there's no queue)

Fixes #409  
Fixes #410

## What was wrong

The three simulation endpoints (`_sim_runsync`, `_sim_stream`, `_sim_status`) in `rp_fastapi.py` had two issues:

1. **Incomplete webhook payload** — only the raw handler output (`{"output": ...}`) was sent to the webhook URL, while the cloud API sends a full envelope with job metadata. Developers building webhook handlers against the local dev server would see breakage on deploy.

2. **No webhook on failure** — in `_sim_runsync` and `_sim_status`, the error check returned early *before* the webhook code, so failed jobs never triggered a webhook callback. In production, RunPod sends a webhook with `"status": "FAILED"`.

## What changed

- Added `import time` and `job_start`/`execution_time` tracking in each method
- Construct full cloud-parity payload before dispatching the webhook
- Moved webhook dispatch *above* the early error return so it fires on both success and failure
- Updated tests to assert webhook payload structure (all 7 fields) and added a test for error-path webhook delivery

## Test plan

- [x] All existing tests pass (`pytest tests/test_serverless/test_modules/test_fastapi.py` — 8/8)
- [x] New assertions verify webhook payload contains `id`, `status`, `input`, `webhook`, `delayTime`, `executionTime`, `output`
- [x] New test verifies webhook fires with `"status": "FAILED"` when handler raises an exception