### PR TITLE
fix: stream errors to client before breaking generator loop

### DIFF
--- a/runpod/serverless/modules/rp_job.py
+++ b/runpod/serverless/modules/rp_job.py
@@ -204,9 +204,18 @@ async def handle_job(session: ClientSession, config: Dict[str, Any], job) -> dic
 
             if isinstance(stream_output.get("output"), dict):
                 if stream_output["output"].get("error"):
-                    stream_output = {"error": str(stream_output["output"]["error"])}
+                    error_fields = {
+                        k: v
+                        for k, v in stream_output["output"].items()
+                        if k != "error"
+                    }
+                    stream_output = {
+                        "error": str(stream_output["output"]["error"]),
+                        **error_fields,
+                    }
 
             if stream_output.get("error"):
+                await stream_result(session, stream_output, job)
                 job_result = stream_output
                 break
 

--- a/tests/test_serverless/test_modules/test_job.py
+++ b/tests/test_serverless/test_modules/test_job.py
@@ -440,3 +440,71 @@ class TestRunJobGenerator(IsolatedAsyncioTestCase):
         assert mock_log.info.call_count == 1
         mock_log.info.assert_called_with("Finished running generator.", "123")
 
+
+class TestHandleJobStreamError(IsolatedAsyncioTestCase):
+    """Tests that generator errors are streamed to the client. (Fixes #397)"""
+
+    @staticmethod
+    async def _noop(*args, **kwargs):
+        pass
+
+    async def test_error_is_streamed_before_break(self):
+        """When a generator yields an error, stream_result must be called with it."""
+
+        def error_gen(job):
+            yield "chunk_1"
+            yield {"error": "GPU OOM"}
+
+        config = {"handler": error_gen}
+        job = {"id": "test-123"}
+        session = Mock()
+
+        stream_calls = []
+
+        async def capture_stream(*args, **kwargs):
+            stream_calls.append(args)
+
+        with patch(
+            "runpod.serverless.modules.rp_job.stream_result", side_effect=capture_stream,
+        ), patch(
+            "runpod.serverless.modules.rp_job.send_result", side_effect=self._noop,
+        ), patch(
+            "runpod.serverless.modules.rp_job.log", new_callable=Mock
+        ):
+            await rp_job.handle_job(session, config, job)
+
+        # stream_result should be called twice: once for "chunk_1", once for the error
+        assert len(stream_calls) == 2
+        streamed_payload = stream_calls[1][1]  # second call, second positional arg
+        assert "error" in streamed_payload
+
+    async def test_nested_error_preserves_extra_fields(self):
+        """Extra fields like refresh_worker should survive error extraction."""
+
+        def error_gen(job):
+            yield {"error": "bad things", "context": "step 47", "refresh_worker": True}
+
+        config = {"handler": error_gen}
+        job = {"id": "test-456"}
+        session = Mock()
+
+        stream_calls = []
+
+        async def capture_stream(*args, **kwargs):
+            stream_calls.append(args)
+
+        with patch(
+            "runpod.serverless.modules.rp_job.stream_result", side_effect=capture_stream,
+        ), patch(
+            "runpod.serverless.modules.rp_job.send_result", side_effect=self._noop,
+        ), patch(
+            "runpod.serverless.modules.rp_job.log", new_callable=Mock
+        ):
+            await rp_job.handle_job(session, config, job)
+
+        assert len(stream_calls) == 1
+        streamed_payload = stream_calls[0][1]
+        assert streamed_payload["error"] == "bad things"
+        assert streamed_payload["context"] == "step 47"
+        assert streamed_payload["refresh_worker"] is True
+


### PR DESCRIPTION
## Summary

- **Stream errors are now delivered to clients** — `stream_result()` is called with the error before breaking out of the generator loop
- **Extra fields are preserved** — fields like `context` and `refresh_worker` survive error extraction instead of being stripped

Fixes #397

## What was wrong

Since v1.7.7 (PR #384), when a generator handler yields an error, the code in `handle_job()` breaks out of the streaming loop *before* calling `stream_result()`:

```python
if stream_output.get("error"):
    job_result = stream_output
    break                          # ← exits loop

await stream_result(...)           # ← never reached for errors
```

Clients listening on `/stream` receive normal chunks fine, but when an error occurs the stream goes silent. The error is saved internally (visible via `/status`), but never delivered through the stream.

Additionally, the error extraction replaced the entire dict:
```python
stream_output = {"error": str(stream_output["output"]["error"])}
```
This discarded all other fields (`context`, `refresh_worker`, etc.).

PR #384's intent (marking errored jobs as FAILED instead of COMPLETED) is preserved — `send_result()` still receives `job_result` with the error and sets the correct status.

## What changed

**`rp_job.py` — `handle_job()` generator loop:**
- Call `await stream_result(session, stream_output, job)` before `break` so errors reach the stream
- Preserve extra fields from the error dict using dict unpacking instead of replacing the whole dict

**`test_job.py` — 2 new tests:**
- Error is streamed before break (stream_result called with error payload)
- Nested error preserves extra fields (context, refresh_worker survive extraction)

## Test plan

- [x] All 31 tests in `test_job.py` pass (29 existing + 2 new)
- [x] New test verifies `stream_result` is called twice (once for normal chunk, once for error)
- [x] New test verifies extra fields (`context`, `refresh_worker`) are present in streamed error